### PR TITLE
Fates ensemble jupyter notebook

### DIFF
--- a/jupyter_ppe_scripts/generic_ensemble_script.ipynb
+++ b/jupyter_ppe_scripts/generic_ensemble_script.ipynb
@@ -1,0 +1,1159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h1> Ensemble generation submission and analysis notebook </h1>\n",
+    "\n",
+    "This script will:\n",
+    "\n",
+    "<ol>\n",
+    "<li>Clone github repo \n",
+    "<li>Make and build a default 4x5 CLM-FATES case\n",
+    "<li>Make an ensemble of CLM-FATES cases \n",
+    "<li>Generate an ensemble of parameter files with one at a time or latin hypercube  modification\n",
+    "<li>Point each ensemble member at a different parameter file\n",
+    "<li>Submit all these jobs\n",
+    "<li>Analyse output\n",
+    "</ol>\n",
+    "\n",
+    "<h4>n.b. This notebook is also set up to work with Cheyenne specific paths, but can be modified. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Control variables for the analysis script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "setup, submit, analysis: 1 1 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# This mega script does \n",
+    "# ensemble setup (including parameter file generation.  \n",
+    "# job submission and \n",
+    "# analysis. \n",
+    "\n",
+    "# You can turn these off and on according to where you are tin the process. \n",
+    "\n",
+    "dosetup = 1 #do we want to create parameters files and so on?\n",
+    "dosubmit = 1 #do we do the submission stage, or just the analysis?\n",
+    "forcenewcase = 0 #do we scurb all the old cases and start again?\n",
+    "doanalysis = 1 #do we want to plot the outputs? \n",
+    "print(\"setup, submit, analysis:\", dosetup,dosubmit,doanalysis)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#import things. Not sure if all of these are still strictly necessary. \n",
+    "from multiprocessing.pool import ThreadPool\n",
+    "import dask\n",
+    "dask.config.set(scheduler='single-threaded')\n",
+    "import os\n",
+    "import netCDF4 as nc4\n",
+    "import sys\n",
+    "import shutil\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h3>Set global variables and paths for ensemble analysis </h3>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FATES mode settings for the ensemble\n",
+    "sp=1 #are we using SP mode?\n",
+    "calib=1 # this script can be run in one at a time and latin hypercube mode.\n",
+    "calibvars=2 #which set of variables are we peturbing?\n",
+    "n=1 #the number of the ensemble. For when you need to do it all again ;) \n",
+    "dim3=0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set pathnames for parameter directories and casenames."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# what is your clone of the ctsm repo called? (or you want it to be called?) \n",
+    "ctsmrepo='ctsmsep22'\n",
+    "\n",
+    "#what do you want the directory with the ensemble cases in to be called?\n",
+    "ens_directory='RTM_ens'+str(n)\n",
+    "\n",
+    "#what do you want the case names to begin with?\n",
+    "caseroot=ens_directory+'_case_'\n",
+    "\n",
+    "#path to scratch (or where the model is built.)\n",
+    "defbuildroot='/glade/scratch/'\n",
+    "\n",
+    "#how many members are in the ensemble?\n",
+    "ncases=12 \n",
+    "\n",
+    "#where are we now?\n",
+    "notebookdr=os.getcwd()  \n",
+    "\n",
+    "USER='rfisher'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### SP/NOCOMP specific paths to default case/param files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RTM_ens1_case_\n"
+     ]
+    }
+   ],
+   "source": [
+    "if(sp == 1): #Settings for the SP ensemble.\n",
+    "    resub=0 #how many times to resubmit the model. \n",
+    "\n",
+    "    #what is the name of your 'basecase'?\n",
+    "    defcase='fates_crops_smo_minlai_opt_vcmax50'\n",
+    "    \n",
+    "    #what is the base parameter file called?\n",
+    "    paramfiledefault='fates_params_default.nc'    \n",
+    "\n",
+    "else: #Settings for the NOCOMP ensemble. \n",
+    "    resub=2 #how many times do we want to resubmit the job?\n",
+    "    \n",
+    "    #what is the name of your 'basecase'?\n",
+    "    defcase='SPdefault_sept'\n",
+    "    \n",
+    "    #what is the base parameter file called?\n",
+    "    paramfiledefault='param_files_nocomp_'+str(n)   \n",
+    "    paramfiledefault='/glade/u/home/rfisher/fates_sp_ensembles/param_files_sp_n6_noc4/calib_paramfiledefault.nc'\n",
+    "    \n",
+    "print(caseroot)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Clone CTSM repo (if necessary)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### (This box and others like it go into BASH script 'mode', and hence isn't in python) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Already have ctsm repo\n",
+      "Currently in /glade/work/rfisher/git/ctsmsep22\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash -s \"$ctsmrepo\" \"$dosetup\"\n",
+    "ctsmrepo=$1\n",
+    "dosetup=$2\n",
+    "\n",
+    "if [ $dosetup -eq 1 ]\n",
+    "then\n",
+    "cd /glade/work/$USER/\n",
+    "#go to git directory\n",
+    "if [[ -d \"git\" ]]\n",
+    "then\n",
+    "cd git\n",
+    "else\n",
+    "mkdir git\n",
+    "cd git\n",
+    "fi\n",
+    "\n",
+    "#go to git repo, or checkout code\n",
+    "if [[ -d \"$ctsmrepo\" ]]\n",
+    "then\n",
+    "cd $ctsmrepo\n",
+    "echo \"Already have ctsm repo\"\n",
+    "else\n",
+    "echo \"Cloning ctsm\"\n",
+    "#clone CTSM code if you didn't to this already. \n",
+    "#git clone https://github.com/escomp/ctsm $ctsmrepo\n",
+    "cd $ctsmrepo\n",
+    "#./manage_externals/checkout_externals\n",
+    "cd src\n",
+    "fi\n",
+    "fi\n",
+    "echo \"Currently in\" $(pwd)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h4> Make a default FATES 4x5 case (this will take a while if it has to build) </h4>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "defcase is fates_crops_smo_minlai_opt_vcmax50\n",
+      "setup= 1\n",
+      "1\n",
+      "fates_crops_smo_minlai_opt_vcmax50 exists on your filesystem. .fates_crops_smo_minlai_opt_vcmax50\n",
+      "Currently in /glade/work/rfisher/git/ctsmsep22/cime/scripts\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash -s \"$ctsmrepo\" \"$dosetup\" \"$defcase\" \n",
+    "ctsmrepo=$1\n",
+    "dosetup=$2\n",
+    "defcase=$3\n",
+    "echo \"defcase is\" $defcase\n",
+    "echo \"setup=\" $dosetup\n",
+    "echo $dosetup\n",
+    "compset=2000_DATM%GSWP3v1_CLM50%FATES_SICE_SOCN_MOSART_SGLC_SWAV_SESP\n",
+    "if [[ $dosetup -eq 1 ]]\n",
+    "then\n",
+    "cd /glade/work/$USER/git/$ctsmrepo/cime/scripts\n",
+    "if [[ -d \"$defcase\" ]]\n",
+    "then\n",
+    "    echo \"$defcase exists on your filesystem.\" .$defcase\n",
+    "else\n",
+    "    echo \"making defcase.\",$defcase\n",
+    "./create_newcase --case $defcase --compset 2000_DATM%GSWP3v1_CLM50%FATES_SICE_SOCN_MOSART_SGLC_SWAV_SESP --res f45_f45_mg37  --run-unsupported\n",
+    "cd $defcase\n",
+    "./case.setup\n",
+    "./case.build\n",
+    "fi\n",
+    "fi\n",
+    "echo \"Currently in\" $(pwd)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Adjust settings of default case. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "updating settings\n",
+      "Currently in /glade/work/rfisher/git/ctsmsep22/cime/scripts/fates_crops_smo_minlai_opt_vcmax50\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash -s \"$ctsmrepo\" \"$defcase\" \"$dosetup\" \"$defbuildroot\" \n",
+    "\n",
+    "ctsmrepo=$1\n",
+    "defcase=$2\n",
+    "dosetup=$3\n",
+    "defbuildroot=$4\n",
+    "\n",
+    "if [[ $dosetup -eq 1 ]]\n",
+    "then\n",
+    "defbld=$defbuildroot$USER/$defcase/bld\n",
+    "cd /glade/work/$USER/git/$ctsmrepo/cime/scripts/$defcase\n",
+    "\n",
+    "echo 'updating settings'\n",
+    "./xmlchange CONTINUE_RUN=FALSE;  \n",
+    "./xmlchange --id STOP_N --val 5;  #number of years of simulation\n",
+    "./xmlchange --id STOP_OPTION --val nyears;\n",
+    "./xmlchange --id CLM_FORCE_COLDSTART --val on;\n",
+    "echo \"Currently in\" $(pwd)\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Make a default user_nl_clm file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Currently in /glade/work/rfisher/git/ctsmsep22/cime/scripts/fates_crops_smo_minlai_opt_vcmax50\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash -s \"$ctsmrepo\" \"$defcase\" \"$dosetup\" \"$ens_directory\" \"$sp\"\n",
+    "\n",
+    "ctsmrepo=$1\n",
+    "defcase=$2\n",
+    "dosetup=$3\n",
+    "ens_directory=$4\n",
+    "usesp=$5\n",
+    "\n",
+    "if [[ $dosetup -eq 1 ]]\n",
+    "then\n",
+    "cd /glade/work/$USER/git/$ctsmrepo/cime/scripts\n",
+    "cd $defcase\n",
+    "\n",
+    "if [ -f \"user_nl_clm_store\" ] #did we do this already?\n",
+    "then\n",
+    "#move the stored version to the default version\n",
+    "cp user_nl_clm_store  user_nl_clm_default\n",
+    "else\n",
+    "#store the 'vanilla' user_nl_clm file\n",
+    "cp user_nl_clm  user_nl_clm_store\n",
+    "# and then make a copy of that to act as the default for the ensemble. \n",
+    "cp user_nl_clm_store  user_nl_clm_default\n",
+    "fi \n",
+    "\n",
+    "if [[ $usesp -eq 1 ]] #change to SP mode. \n",
+    "then\n",
+    "echo use_fates_sp=.true. >> user_nl_clm_default\n",
+    "fi\n",
+    " \n",
+    "echo \"Currently in\" $(pwd)\n",
+    "cp user_nl_clm_default ../$ens_directory/user_nl_clm_default\n",
+    "fi\n",
+    "\n",
+    "#n.b. i overwrote this with a file in the ensemble directory last time i did it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h3> Make ensemble of cases.</h3>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "%%bash -s \"$ctsmrepo\" \"$defcase\" c \"$ens_directory\" \"$caseroot\" \"$ncases\" \"$forcenewcase\"\n",
+    "\n",
+    "ctsmrepo=$1\n",
+    "defcase=$2\n",
+    "dosetup=$3\n",
+    "ens_directory=$4\n",
+    "caseroot=$5\n",
+    "ncases=$6\n",
+    "forcenewcase=$7\n",
+    "\n",
+    "echo \"ncases=\" $ncases\n",
+    "echo \"caseroot=\" $caseroot\n",
+    "echo \"dosetup=\" $dosetup\n",
+    "echo \"forcenewcase=\" $forcenewcase\n",
+    "echo \"ens_directory=\" $ens_directory\n",
+    "\n",
+    "if [[ $dosetup -eq 1 ]]\n",
+    "then\n",
+    "echo \"setup\"\n",
+    "\n",
+    "cd /glade/work/$USER/git/$ctsmrepo/cime/scripts\n",
+    "\n",
+    "if [[ -d \"$ens_directory\" ]]\n",
+    "then\n",
+    "echo \"already have ensemble directory\"\n",
+    "else\n",
+    "mkdir $ens_directory\n",
+    "fi \n",
+    "\n",
+    "#make directory for parameter files. \n",
+    "cd $ens_directory\n",
+    "if [[ -d \"parameter_files\" ]]\n",
+    "then\n",
+    "echo \"already have parameter_files directory\"\n",
+    "else\n",
+    "mkdir parameter_files\n",
+    "fi \n",
+    "cd ..\n",
+    "\n",
+    "counter1=0 #include a default zero case. \n",
+    "while [ $counter1 -le $ncases ]\n",
+    "do\n",
+    "  newcase=$caseroot$counter1 #name of ensemble membr case.    \n",
+    "  if [ -d $ens_directory/$newcase ]\n",
+    "  then\n",
+    "    echo ' new case already exists',$ens_directory/$newcase\n",
+    "    if [ $forcenewcase -eq 1 ]\n",
+    "    then\n",
+    "    echo 'force making case', $ens_directory/$newcase\n",
+    "    rm -rf $ens_directory/$newcase\n",
+    "    ./create_clone --clone $defcase --case $ens_directory/$newcase ;\n",
+    "    fi    \n",
+    "  else\n",
+    "   echo 'making new case', $ens_directory/$newcase\n",
+    "    ./create_clone --clone $defcase --case $ens_directory/$newcase ;\n",
+    "  fi\n",
+    "((counter1++))\n",
+    "done\n",
+    "\n",
+    "counter1=0 #include a default zero case. \n",
+    "while [ $counter1 -le $ncases ]\n",
+    "do\n",
+    "  newcase=$caseroot$counter1 #name of ensemble membr case.   \n",
+    "   cd $ens_directory/$newcase\n",
+    "   echo 'case setup', $ens_directory/$newcase\n",
+    "   ./case.setup;\n",
+    "    cd ../../ \n",
+    "((counter1++))\n",
+    "done\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h3> Create .nc version of current defualt file. I FAILED ATT THIS. NEEDS INPUT..</h3>\n",
+    "You currently have to do this step manually, by doing this in the terminal:\n",
+    "\n",
+    "<i> cd /glade/work/$USER/git/$ctsmrepo/src/fates/parameter_files/</i><br>\n",
+    "<i>ncgen -o fates_params_default.nc fates_params_default.cdl </i>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Copy default .nc template parameter file to ensemble parameter directory . "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_default.nc\n"
+     ]
+    }
+   ],
+   "source": [
+    "if(dosetup == 1): \n",
+    "    paramsdir='/glade/work/'+USER+'/git/'+ctsmrepo+'/cime/scripts/'+ens_directory+'/parameter_files'\n",
+    "    defparamfile='/glade/work/'+USER+'/git/'+ctsmrepo+'/src/fates/parameter_files/'+paramfiledefault\n",
+    "    !cp $defparamfile $paramsdir\n",
+    "    filename_template = paramsdir+'/'+paramfiledefault\n",
+    "    print(filename_template)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Make function for copying fates parameter files. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def copy_clobber(filename1, filename2):\n",
+    "    try:\n",
+    "        os.remove(filename2) #replacing file\n",
+    "    except: #'file does not yet exist\n",
+    "        shutil.copyfile(filename1, filename2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Make function to modify FATES parameter files. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def def_pftfile( fileroot,i,variable,delta):   \n",
+    "    pfilename = fileroot+str(i)+'.nc' \n",
+    "    print('modifying parameter file',i,variable,'x',delta);\n",
+    "    fin = nc4.Dataset(pfilename, 'r+')\n",
+    "    var = fin.variables[variable]\n",
+    "    var[:] = var[:]*delta\n",
+    "    fin.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create ensemble of parameter files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_0.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_1.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_2.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_3.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_4.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_5.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_6.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_7.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_8.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_9.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_10.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_11.nc\n",
+      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_12.nc\n"
+     ]
+    }
+   ],
+   "source": [
+    "if(dosetup == 1): \n",
+    "    fatesparamfile= 'fates_params_'+ens_directory+'_'\n",
+    "    vs=range(0,ncases+1) \n",
+    "    print(paramsdir)\n",
+    "    for i in vs:\n",
+    "        filename_out = paramsdir+'/'+fatesparamfile+str(i)+'.nc' \n",
+    "        #print('making parameter file',i,fatesparamfile+str(i)+'.nc');\n",
+    "        print('making:'+filename_out)\n",
+    "        copy_clobber(filename_template,filename_out) ; \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Modify parameters for senstivity analysis. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['fates_rad_leaf_clumping_index', 'fates_rad_leaf_xl', 'fates_rad_leaf_rhovis', 'fates_leaf_vcmax25top', 'fates_rad_stem_tauvis', 'fates_rad_leaf_rhonir']\n"
+     ]
+    }
+   ],
+   "source": [
+    "parameter_list=['fates_rad_leaf_clumping_index','fates_rad_leaf_xl',\n",
+    "                'fates_rad_leaf_rhovis','fates_leaf_vcmax25top',\n",
+    "                'fates_rad_stem_tauvis','fates_rad_leaf_rhonir']\n",
+    "\n",
+    "min_delta=[0.9,0.1,0.8,0.8,0.8,0.8]\n",
+    "max_delta=[1.1,10 ,1.2,1.2,1.2,1.2]\n",
+    "print(parameter_list)  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_\n",
+      "0 -1\n",
+      "modifying parameter file 1 fates_rad_leaf_clumping_index x 0.9\n",
+      "modifying parameter file 2 fates_rad_leaf_clumping_index x 1.1\n",
+      "1 1\n",
+      "modifying parameter file 3 fates_rad_leaf_xl x 0.1\n",
+      "modifying parameter file 4 fates_rad_leaf_xl x 10\n",
+      "2 3\n",
+      "modifying parameter file 5 fates_rad_leaf_rhovis x 0.8\n",
+      "modifying parameter file 6 fates_rad_leaf_rhovis x 1.2\n",
+      "3 5\n",
+      "modifying parameter file 7 fates_leaf_vcmax25top x 0.8\n",
+      "modifying parameter file 8 fates_leaf_vcmax25top x 1.2\n",
+      "4 7\n",
+      "modifying parameter file 9 fates_rad_stem_tauvis x 0.8\n",
+      "modifying parameter file 10 fates_rad_stem_tauvis x 1.2\n",
+      "5 9\n",
+      "modifying parameter file 11 fates_rad_leaf_rhonir x 0.8\n",
+      "modifying parameter file 12 fates_rad_leaf_rhonir x 1.2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/ncar/usr/jupyterhub/envs/pangeo-2019.09.12/lib/python3.7/site-packages/ipykernel_launcher.py:6: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.\n",
+      "Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations\n",
+      "  \n"
+     ]
+    }
+   ],
+   "source": [
+    "#n.b. I (RAF) have other scripts that do LHC sampling or n dimensional arrays. \n",
+    "#just inclusing this one at a time example here for simplicity. \n",
+    "if(dosetup == 1): \n",
+    "    fileroot =  paramsdir+'/'+fatesparamfile \n",
+    "    print(fileroot)\n",
+    "    if(sp == 1):\n",
+    "        for p in range(0,6):\n",
+    "            print(p,p*2-1)\n",
+    "            def_pftfile(fileroot,p*2+1,parameter_list[p],min_delta[p])\n",
+    "            def_pftfile(fileroot,p*2+2,parameter_list[p],max_delta[p])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Point each ensemble script at different parameter file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing parameter file names into user_nl_clm files\n",
+      "pftfilename =  fates_params_RTM_ens1_0\n",
+      "pftfilename =  fates_params_RTM_ens1_1\n",
+      "pftfilename =  fates_params_RTM_ens1_2\n",
+      "pftfilename =  fates_params_RTM_ens1_3\n",
+      "pftfilename =  fates_params_RTM_ens1_4\n",
+      "pftfilename =  fates_params_RTM_ens1_5\n",
+      "pftfilename =  fates_params_RTM_ens1_6\n",
+      "pftfilename =  fates_params_RTM_ens1_7\n",
+      "pftfilename =  fates_params_RTM_ens1_8\n",
+      "pftfilename =  fates_params_RTM_ens1_9\n",
+      "pftfilename =  fates_params_RTM_ens1_10\n",
+      "pftfilename =  fates_params_RTM_ens1_11\n",
+      "pftfilename =  fates_params_RTM_ens1_12\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash -s \"$ctsmrepo\" \"$fatesparamfile\" \"$ens_directory\" \"$caseroot\" \"$dosetup\" \"$ncases\" \"$paramsdir\"\n",
+    "\n",
+    "\n",
+    "ctsmrepo=$1\n",
+    "fatesparamfile=$2\n",
+    "ens_directory=$3\n",
+    "caseroot=$4\n",
+    "dosetup=$5\n",
+    "ncases=$6\n",
+    "paramsdir=$7\n",
+    "\n",
+    "if [ $dosetup -eq 1 ]\n",
+    "then\n",
+    "echo \"Writing parameter file names into user_nl_clm files\"\n",
+    "unl=user_nl_clm\n",
+    "cd /glade/work/$USER/git/$ctsmrepo/cime/scripts\n",
+    "counter1=0\n",
+    "cd $ens_directory\n",
+    "\n",
+    "while [[ $counter1 -le $ncases ]]\n",
+    "do\n",
+    "  #echo $counter1\n",
+    "  newcase=$caseroot$counter1 \n",
+    "  pftfilename=$fatesparamfile$counter1\n",
+    "  echo \"pftfilename = \"  $pftfilename\n",
+    "  if [ -d $newcase ]\n",
+    "  then\n",
+    "   cd $newcase\n",
+    "   #get default parameter file\n",
+    "    cp ../user_nl_clm_default user_nl_clm\n",
+    "    sed -i \"s|fates_params_default|$pftfilename|g\" user_nl_clm\n",
+    "    cd ../\n",
+    "  else\n",
+    "   echo 'no case', $newcase\n",
+    "  fi\n",
+    "\n",
+    "  ((counter1++))\n",
+    "  done\n",
+    "#cat $newcase/user_nl_clm\n",
+    "\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h3>Submit ensemble of cases</h3>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "%%bash -s \"$ctsmrepo\" \"$defcase\" \"$ens_directory\" \"$caseroot\" \"$ncases\" \"$dosubmit\" \n",
+    "\n",
+    "ctsmrepo=$1\n",
+    "defcase=$2\n",
+    "ens_directory=$3\n",
+    "caseroot=$4\n",
+    "ncases=$5\n",
+    "dosubmit=$6\n",
+    "\n",
+    "if [ $dosubmit -eq 1 ]\n",
+    "then\n",
+    "cd /glade/work/$USER/git/$ctsmrepo/cime/scripts\n",
+    "echo 'submitting'\n",
+    "startcase=0\n",
+    "counter1=$startcase\n",
+    "cd $ens_directory\n",
+    "pwd\n",
+    "\n",
+    "while [ $counter1 -le $ncases ]\n",
+    "do\n",
+    "  echo $counter1\n",
+    "  newcase=$caseroot$counter1\n",
+    "  echo $newcase\n",
+    "\n",
+    "  if [ -d $newcase ]\n",
+    "  then\n",
+    "    cd $newcase\n",
+    "    echo 'submitting job',$newcase\n",
+    "    ./xmlchange BUILD_COMPLETE=TRUE\n",
+    "    #./xmlchange RESUBMIT=1\n",
+    "   # ./xmlchange PROJECT=P93300041\n",
+    "    ./case.submit\n",
+    "    cd ../\n",
+    "  else\n",
+    "   echo 'no case', $newcase\n",
+    "  fi\n",
+    "\n",
+    "  ((counter1++))\n",
+    "  done\n",
+    "else\n",
+    "echo \"not submitting jobs\"\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h2>Analyse output</h2>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import libraries for analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "if doanalysis ==1:\n",
+    "    import numpy as np\n",
+    "    import warnings\n",
+    "    warnings.filterwarnings('ignore')\n",
+    "    import xarray as xr\n",
+    "    from matplotlib import pyplot as plt\n",
+    "    import datetime\n",
+    "    import cartopy\n",
+    "    import cartopy.crs as ccrs\n",
+    "    import os.path\n",
+    "    import xesmf as xe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if doanalysis ==1: \n",
+    "    output='/glade/scratch/rfisher/'\n",
+    "    conv = 3600*24*365\n",
+    "    yr='.clm2.h0.'   \n",
+    "    ychoose=2000\n",
+    "    delta=1\n",
+    "    pftnames=['BlEvTrTr','NlEvTr','NlCdDecTt','BlEvTmTr','BlDrDecTt','BlCdDecTr','BlEvSh','BlDrDecSh','BlCdDecSh','C3AG','C3G']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h3>Make output figure directory</h3>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "figs_RTM_ens1\n"
+     ]
+    }
+   ],
+   "source": [
+    "#fig dir\n",
+    "figdirname='figs_'+ens_directory\n",
+    "print(figdirname)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "made fig firectory, figs_RTM_ens1\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash -s \"$figdirname\"  \n",
+    "figdirname=$1\n",
+    "\n",
+    "cd $notebookdr\n",
+    "if [[ -d $figdirname ]]\n",
+    "then\n",
+    "   echo \"existing fig firectory\",$figdirname\n",
+    "else \n",
+    "    mkdir $figdirname\n",
+    "    echo \"made fig firectory\", $figdirname\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h3>Make a single data structure for the ensemble</h3>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "range(1, 13)\n",
+      "RTM_ens1_case_\n",
+      "1\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_1/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_1/run/RTM_ens1_case_1.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_1/run/\n",
+      "2\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_2/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_2/run/RTM_ens1_case_2.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_2/run/\n",
+      "3\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_3/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_3/run/RTM_ens1_case_3.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_3/run/\n",
+      "4\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_4/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_4/run/RTM_ens1_case_4.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_4/run/\n",
+      "5\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_5/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_5/run/RTM_ens1_case_5.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_5/run/\n",
+      "6\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_6/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_6/run/RTM_ens1_case_6.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_6/run/\n",
+      "7\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_7/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_7/run/RTM_ens1_case_7.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_7/run/\n",
+      "8\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_8/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_8/run/RTM_ens1_case_8.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_8/run/\n",
+      "9\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_9/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_9/run/RTM_ens1_case_9.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_9/run/\n",
+      "10\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_10/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_10/run/RTM_ens1_case_10.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_10/run/\n",
+      "11\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_11/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_11/run/RTM_ens1_case_11.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_11/run/\n",
+      "12\n",
+      "output in run dir\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_12/run//2000combined.nc\n",
+      "no file exists\n",
+      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_12/run/RTM_ens1_case_12.clm2.h0.2000*\n",
+      "/glade/scratch/rfisher/RTM_ens1_case_12/run/\n",
+      "end\n"
+     ]
+    }
+   ],
+   "source": [
+    "if doanalysis ==1:\n",
+    "    vs=range(1|0,ncases+1) \n",
+    "    print(vs)\n",
+    "    count=1\n",
+    "    ncol=3\n",
+    "    print(caseroot)\n",
+    "    for i in vs:\n",
+    "        print(i)\n",
+    "        run=caseroot+str(i)\n",
+    "        arc = output + 'archive/' + run + '/lnd/hist/'\n",
+    "        f2= arc + '/'+str(ychoose)+'combined.nc'\n",
+    "        if(os.path.isdir(arc)):\n",
+    "            arc = arc\n",
+    "        else:\n",
+    "            arc = output + run + '/run/'\n",
+    "            print('output in run dir')\n",
+    "        fileout = arc + '/'+str(ychoose)+'combined.nc'\n",
+    "        #os.remove(fileout)\n",
+    "        print(fileout)\n",
+    "        if(os.path.isfile(fileout)):\n",
+    "            print('file exists')\n",
+    "            arc=arc\n",
+    "        else:\n",
+    "            print('no file exists')\n",
+    "            print('fileroot:',arc +run+yr+str(ychoose)+'*')\n",
+    "            ds0 = xr.open_mfdataset(arc +run+yr+str(ychoose)+'*', decode_times=False)           \n",
+    "            ds0.to_netcdf(fileout)\n",
+    "            print(arc)\n",
+    "\n",
+    "print('end')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n",
+      "10\n",
+      "11\n",
+      "12\n",
+      "figs/ensemble_GPP_delta_abs_RTM_ens1_case_12.png\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAvoAAAGQCAYAAADfmMR0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOy9eXgkV33v/Tm9aNdImtHsnsXLeMYrXsbGxgQbAsQ2JqwBMwkOTnLBkEBIeEkI903Cc8lNbpIbeEkI+HG4BAgxDlngGmzssDjY2MbgfRl7vI3Hnt2aRRqN1FK3+rx/VEvqXd2qbul0ne/nefqRuqv61Gl9+jtzqupXp4y1FiGEEEIIIUS0iC12B4QQQgghhBCNRwN9IYQQQgghIogG+kIIIYQQQkQQDfSFEEIIIYSIIBroCyGEEEIIEUES9aw8ODhoN27c2KSu+MEDDzwwZK1dnv/akv7TbSZ9vOr7xsdevN1ae3lTO5dDnhvDfFwvpGeQ60agTPuDMu0HyrQ/tEKmw1LXQH/jxo3cf//9zeqLFxhjdhW/NpU5zmlnf6Lq+x786YcGm9apIuS5MczH9UJ6BrluBMq0PyjTfqBM+0MrZDosdQ30RfMwcbPYXRALhFz7gTz7g1z7gTz7Q5Rca6DvAsZgkvHF7oVYCOTaD+TZH+TaD+TZHyLmWgN9FzBgYtHZexRVkGs/kGd/kGs/kGd/iJhrDfRdwBCpvUdRBbn2A3n2B7n2A3n2h4i51kDfAQwmUvVgojJy7Qfy7A9y7Qfy7A9Rcx1qoH+j2Tzz+za7I1Qb831/s8j/bPMhFoNstsaVDcSS7t7SIMqeoTmuK35OuV40lOlZouwZlOl8ouxamZ4lyp5BmQ6Djui7QMTqwUQV5NoP5Nkf5NoP5NkfIuZaA30XiNgV3qIKcu0H8uwPcu0H8uwPEXOtgb4DmIidJhKVkWs/kGd/kGs/kGd/iJrrugf6YeukKrV1U3wzsdzf9V3pha8Pa+Tnqhvj5oUfjfqb5Ldzowk8L5brRfUMTrpWppuAg56hOZm+KR78rky7gzLdBBz0DMp0U3DU9XzREf0mkX/RR/4FH79qyn95TCI6p4l8o5LrSsh1a6JM+4My7QfKtD/4nGkN9F3AROt2y6IKcu0H8uwPcu0H8uwPEXPd1IH+TfHNM3tRXZ3Bz1gMEnNs9eae2dM2k+nZ98HsXtk7JxpzKunf2jfXPr1WkzAtfuFHvmeYn+tiz9BY1y54hmi5djHT/9a+uaDNxSJKnkGZrkaUXCvTlYmSZ1Cmq9Hqroupe6DfyPlVB5dBJjP7Jctmg0cm07BNtAwuTuXUKNfFnqE1XG+zO5pSK+iaa2W6ObjmGZRpZbp+lOlZXPMMyrQvmQ6DSndcwJhIXeEtqiDXfiDP/iDXfiDP/hAx1xrou0DE6sFEFeTaD+TZH+TaD+TZHyLmet4D/YdO28LoKCzphayFVCp4ALx231PcsXpLo/pYlun2EwmYmLBMTsLkZNAXgLePB6ez/nNwM8mkKTgdNTFhaW93R6IxEHf0Cu9iz1DoeiG4Y/WWAs9Q6rqcZwjnuimnA1vItTI9f1rJMyx+pqdzrUw3lmqZXgiU6YVBmW4sLrueD009or+kF/r6DBMTFmMMbW1BrdfUVGA+HjdAIDiRCC7w6OgobOPoUejvD943/YDG1Yz198HIscLXyl0MEouVbnP6yxq+L4ZYC9eD5XsGSlznewbKus73DI13Xc4zlLou53m6z435zkXHtYuZ7u8LfobJtDzXl+npfweV6dZEma6V6HgGZbo6re26GJXuOIAxEI9QPZiojFz7gTz7g1z7gTz7Q9Rc1z3Qf/41Z8+5zqH3vnpenWkk953c3DKDeri1Pzi1dOXR8lfHGwOJhHtfqlpcu4Brrit5BjddK9P1o0w3F9dcRzHTLuCaZ1Cmm4Vrrlst02EIdUT/5POW0NaTJHVkgraeJNmsJdkZNHnmpUsxccPYwTGmMlkyYxnGjk3R2R0jkVsnm86SHg/Os0yfmmnvTsxcBJFNZ5mcnKItCaOj0NYGK5YbstnZWu3UBPT0GMbG4NgxSyZTeKpp7RpDW2ectp4kAEf3pWhbZkhNBMvb2oL22tsN2WxwCiuVCk7/TM8ZO92/jo5cfWGur21Bk2VPFW1YH5wiq61GzhCLzf9LZYxZB3wNWAVkgRustZ8rWscAnwOuBMaA91lrH6yl/XzPQIHrbDpb4BkocZ3vGUpdF3uGUtf5nqHUdbFnKHRd7BnKu873nN/XtmTlU4JRdd2KmW5ry20nRKZ98wzhMp1/Wn2+mT52LCgnUKYXLtPZdPCHUKaj5xmikenp8rGwmd5md3D3hi2RcV0vKt1xAGMgEe40UQb4mLX2QWNML/CAMeb71trteetcAWzKPV4JfDH3Uywgcu0H8uwPcu0H8uwPUXMdnXMTrYwJbs5Q7VENa+2+6T1Ba+0x4ElgbdFqbwG+ZgN+CvQbY1Y34+OIKszhei7kukVQpv1BmfYDZdofIpbpuo7oT+zYDuee0ox+eI0xppZ6sEFjzP15z2+w1t5Qpq2NwLnAfUWL1gIv5T3fnXttX7mNtUrdX6tRg+uaPOfa2khI18p0c1Cm/UGZ9gNl2h9cy3RY6i7dmZqYAmD91kGy6Szx9gSxZJruVd0kNiyZWc+mpjDJGN3DE2TH0hx76Rgdo5N09HfQ3tcebLyvnbE9x8hMTJEZy5DoSmBzNVkAo3tHWb62jY6BDkaOjQCQSgXL29qCdTq7Y4wfz9LVBePjFEwLBUHtlokZ0mMZjg9nGBuHpeu7yO4Nir3bkrBqYyeH96bIZGB01NDbG7zvyNFgWzEDmangZ37Z1lvHgos5bopvLqhpm74l9QObtwCzn6cSBojNfXOGIWvt1qrtGNMD/DvwUWvtSJnNFFO1c1MTUyWegQLXxZ6BEtf5noES1+U8Q6HrfM9Q6rrYM1DgutgzlLqu5BkC15U8Q0Ndz+kZGus6Spmevm4mTKZvim+e2c40ynTlTGfGgkCFyfT4eLBcmV64TNtUsI4yrUy7munR0eDP0YhMX7LrqZbOdBhUo+8CxpAIeXMGY0yS4Av1z9ba/yizym5gXd7zE4C9oTYq6keu/UCe/UGu/UCe/SFirlWj7wCGcLV/uau3/w/wpLX2MxVWuxm4xgRcBAxbaxt+ikhUZy7Xc75frlsCZdoflGk/UKb9IWqZ1hH9ENyxeguv3fdUzevvfcuF5ReEv8L7EuC9wGPGmIdzr30SWA9grb0euJVgGqdnCaZyujbMBn1j+lbutVDRM8i149TjGZTpVkaZ9gNl2h+U6fLUNdCPxQ3LTlsKQOfaXuyUJd7XTvc5y2HKYlNTMzVhU4dTxPrbMR1x7O5ROvo76FrWyVQ6S2IgmFQ1uWEJPX3tTB04zuRomsxYmtRoaqaWu2tFF1OpDJmxNCvXBcV+J935KE+es2Xm9sR2yjI2DjtfCEqb8mssAZ48ZwsmbmjrSdLe18bYjjFG94/R3h189FgyxtJTlxJLHqVreRfDu0ZIj6ZJpSxdXcE2jh+3jI5CTw90dhrGx4NbhU9z9VT5Gy+cv2N2J+Dob13G2MtjZdczhlC3W7bW/oTy9V7561jgt2tts2Ogg46B9lLPUOC62DNQ4jrfM1DiupxnKHRd7BkKXRd7Xnfbg9x74pYZ18WegRLXxZ6BAteVPMOs62qewT3XUct0LPePc5hM1+IZlOl8z0DoTM/lWZlubKanDgcTiivTyrSrmR7eFZS1+57psOiIvgPUeDW/iABy7Qfy7A9y7Qfy7A9Rcx2dT7JIPHL6Fh45PeStnQ3Ek/Gqj4Vk8untc6/kIaE9w5yuxeKzEJ6VaTdQpv1AmfYHZbqU+kp3kjFMbj6j7LFJxg6O0d7XTnJ1N9nDqeA0y0+Di4ZTR1J0regi2Zlg/yNDZDLBVEidvQlW5E7FZUcniQ92Qtxw+OnDjB1N09WfnLnYoa07SWJ5F9n0FG09s6eK4skYvSf0zjzf/OB9XFyhz209SRLtcbLpLBt++PDMJc67rwxmRupZ08Pk6CR9G/oY3jXMknW9HN9/nN6eNjK5aajS4xlGD6dJJIJbMHd1GnoH2zg2NFnz3659dTdtg53B5RdFGEyo00TNoGdVN1PpbIlnoMB1sWegxHW+Z6DEdSXPUOi6Hs8AF+8MTtPtvnJriWegxHWxZ6jf9YxnaAnXUct0z5oeAGW6DM3K9OGnDwMo045Qa6ZTR4LSHWV6FmXarUwvWRe06Xumw6LSHRcwROo0kaiCXPuBPPuDXPuBPPtDxFxroO8ABoiZ6Ow9isrItR/Isz/ItR/Isz9EzbUG+g5gjCEZob1HURm59gN59ge59gN59oeoua5roG+zls6Nuan2jqToXtvDyK4RJp49wtF9uXq/3uBChURXgqmJKYafHyY1EdSD9XTDsaMZVuTae+Bbe0gkYNW6JH0blrDqvE6Gnhgimav/6hzsJNYeJ9bXTjY33RNAeiLL8f3Ha+rzyT95rOzrgxetBiC2tJOpoTGGHx9iaNcYo0+MsaQXTn3bGmw6uI9yrK+d7PAEk4dTxOKGeHuciZEJBk6p/YvQ+elbGP/jN1Vc7lI9WHCL6jTdmwZKPAMFros9Q6nrfM9AietKnqF215U8Q+C62DNQ4rrYM1C367k8g1uuo5bp2NKg7lKZLqSZme7LTb+qTLtBrZlOdAX//SvTsyjTbmV69Ikg175nOiw6ou8AxkAiHp29R1EZufYDefYHufYDefaHqLnWQN8RorT3KKoj134gz/4g134gz/4QJdd1DfQTg93YbHDHs853nMOzv3cL6964kf337GFgbSfJnraZ5Q//eJiOjhQjI5CagLY2GOg3rFlt+Nm3gun6RkchMwWHDk3Cw0PBOgOGDecGd+R77kd7OOnSNSRO7J85PQdwxqNPEZaOP/kOAFM3XsPLt+9k4IxBJo6kGEzGiCXjHN1+aGZqpz337GHtFSfRfeoAsb52THcHyR0vM/nc0bq22fnpW+DPSr88xhiScXe+VImeJAPXbmXizmdLPAMFros9Q6nrAs9Q4rqSZ2ic62LPQInrYs/AvFx3fvqW4JdWcB2xTE/deA2AMl1EUzP98NDsOsr0olNrph/+cTAlqTJdiDLtTqYHc1O8+p7psOiIvgOYiE3lJCoj134gz/4g134gz/4QNdca6DtA1KZyEpWRaz+QZ3+Qaz+QZ3+ImmsN9BeIzFd/jeEfvFB+oTGR2nv0maqeQa4jhDLtB8q0PyjTfuBbpusa6B9/YZjE6uB21Ic+fzen/PeLGf/xi3Qu62TgwtUcunsP/ZuXAjDy3WFGjkFXZzA10rJlhiW9cHTYkrs7N2PjwS2YMxno74O+PsO6M5eQHg1quTdfvYn4yuB2zjP1VA3GDC5h7OAYu7fvZHjYcv4Vy+lc0cVzt79I6mhQ9zlyKE3HT/ey+tozMWedDkDbldfTVq3hevoAxB268MOms9z3m7ex9RPnlHgGClwXe4ZS1/meodT1YngGSlyX8wzRdh21TJvBYFo4ZbqQZma6vy9YR5l2g1ozPfLdoEZfma6xH7jl2YdMn3/F8mB7nmc6LDqi7wBRm8pJVEau/UCe/UGu/UCe/SFqrjXQd4QoTeUkqiPXfiDP/iDXfiDP/hAl1y0z0M/+5OMAxF7914vck8ZjjInU3mMYpj2DXEcdZdoPlGl/UKb9QJluLeoa6HefdSbJD9wEwPIPwJ43X8DQc8dYur6L7f/4JCMj0LV9BAhqwdpyBVOxGBw/bjlwIJinNZubgjWR2/qmUwypVHA75tSRFCY3f2l2NE129CidH/wl7J69Dfi4pYx/bwfLz1rO0A/3k0wa0uMZ4sOTnPbxrTAVdHTD+kHMGWfC5DgAZsPv1r2dyUcPcvCxobLLDG7tPcbWncrF998PlHoGClwXe4ZS1/megRLXi+EZKHHdbM/gnuuoZXr8ezuCz6JMF9DMTKeCEmll2hFqzXRXUMqtTOehTLuV6fR4cGGf75kOS8sc0Y8yxkAyQnuPojJy7Qfy7A9y7Qfy7A9Rc13XQP/wA49zc89mAJYvN6w/s7cpnfIP49Te45EHH+em+Ga6OuW58bjlWpluFm55VqabiVuulelm4ZZnZbqZuOU6LKGO6L/4+DEu3hnc+njsvNN45tksHe25hhNw+Ah0dEAiHnwRTzytnQfuSc28vy0Ja9catrz9JEx7HICX79lDojMJQOcH3gCAWbMZBlaF6WpFuj/7fcb+4HJeftly2hkJOvo7WPJr5xF7zZuwO34OgN1yCZPZTtI2ONfZM4/tdP3Nf3Jw7Zayy4IrvN39UuV7hkLXxZ6h1HW+Z6DE9WJ4BkpcN9sztJbrVsx092e/H/Rdma5KIzM97RmUaReplOnpUg1lehZl2q1Md/R3ACjTIVHpjgMYIBGhvUdRGbn2A3n2B7n2A3n2h6i51kDfEaJ0u2VRHbn2A3n2B7n2A3n2hyi5Dj3Qv9FspqMDzjgtOhcuNJI7Vgenh44ctSxbWv6LYwwkHd97nPYMcl2JO1ZvqeoZWsu1PJdHmfYHZdoPlGl/iEqm66Hugf5YMKMRu160M9NvATzyWJZsFkaP5xpOBPVgk5MwCQwPWxK7J3j1mwfYce9RAHp6YMPWZcEb4jHazlrByt42EicvBcA+8RSxX/4HAEz7/D5gLXT91W20fWkzG67ewu5vPcOSjnbS9JLoD/qRtUmyNkmcDJ2JV8x7O3v22orLXPpOWQuYwHWxZyh0XewZSl0XeIYS14vhGShxvRCewS3XoEwr0yEznZudQpl2h1oyPV2jr0wXokzjTKZ3f+sZAGU6JCrdcQCDIRHT3rcPyLUfyLM/yLUfyLM/RM11dD5JC2NMsPdY7TF3G+bLxpiDxpjHKyy/zBgzbIx5OPf4k0Z/DjE3c7me+/3y3Aoo0/6gTPuBMu0PUct03Uf0i08PQXCn00SicFk2y8zd1bo64cyLenl55ygTR1Kc/gvBqbbu9Uvo+p8fxR7ZS+bfb4f+PpJXX4AZWDOvDxOWiaePsOqCVWS37yJ++MtYIHbl9SQmbiWRnN+5qn37q58emqYBV3h/Bfg88LUq69xlrb2qlsYqeYZC18WeodR1vmdg0V1PPH0EoMR14hdPmLdnWDDXX6GBnkGZrhdlemmpZ1Cm589XWIRMT/9UppVpVzO96oJgGk9lOhwq3XEAQ/grvK21dxpjNjaiP6J5hHUtz62BMu0PyrQfKNP+ELVMq3THAYwxJGLVHw3iYmPMI8aY7xljzmhUo6J25nLdIOR5kVGm/UGZ9gNl2h+ilmkd0Z+Dib94K+2///6Z5z948TAAr1+/tKHbqWHvcdAYc3/e8xustTfUsYkHgQ3W2lFjzJXAt4FNdXbTG6Y9w4K7lucmo0z7iTIdXZRpP1Gma6NhA/1MpvB5fu3Y2DiMHxqnuydG25J2+l4V1HslNg5gH7wLc/6lJF6/FbN2E3boJezBnZj1H25U12ri8sM7ALAPfYrssy9gNm9i8pt3ATDxmRs48OFvMND+QlO2XeNd2IastVvnuw1r7Uje77caY75gjBm01g7V21a+62LP2+wOnnnlGQWu8z0Di+p62jOUcf1Icz1DTa6d9AzKdD34lOnE64OPoExXxHnPoEzPhTK98Jm2D30q6L8yHQod0XeAhbg5gzFmFXDAWmuNMRcSlG0daupGRQnNdi3PbqBM+4My7QfKtD9ELdMa6DtC2It8jDHfAC4jOKW0G/hTIAlgrb0eeCfwQWNMBhgHrrbW1nb5uWgoYVzLc+ugTPuDMu0HyrQ/RCnT7g7007dx7T/0AvCPH7pkkTvTXIKbM4S+mv89cyz/PMF0T85x7RfuBqLvGcK7bmXPynR9tLJrZbp2WtmzMl0frexama4d1zzXNdDv7jJ05fY5pm+xXdBY0bzbsdjsnK2b7nuCna99BUsvXkPipOA2yze9+b+4+juXYVKjMLCSbOcyWLeMWOb4vD5MQ1i5itiKlWAMz193IwDbh0Zh3zHesX4n563MfSBqu/DjzdetBSA9nublR4fgoTIr1XgThoWiowMuODvBE49lynqGQtf5nqHUdYFncNZ1ec9Qj+sZz9ASrpVpZXqaeWd6YCWAk66V6dLlynQpyrSjmV4ZzKPve6bD4u4RfY8wWOJGZ+d8QK79QJ79Qa79QJ79IWquNY++IxiTrfpYuH6YP1+wjXmKC56Dfsh1M1Gm/cEFz0E/5LqZKNP+4ILnoB/hXdd1RL9tsJM3vuckANrPXcHk40McfvggQ88dY9NVG7HpKR799ksAHDgQ7A1dNTI79dmqS9cR621j6qWjJD/4L2yzkJp6iPZDD2GWn4i95esA2Ku2AdA/2B3289WNWXPdzO+nTX0fgIGOc4MX2q+s8eTQLBOf/ScAxqf62fT9j8DbnirdJpa4Sc+rv03g8q6TB9n4G2exdudwiWegwHU5z1DoepvdMeMZKHG9GJ6h1HUYzxC4nvEMLeFamVamIVymzfITAZRpN6g509OeQZlWpt3MdL5n8DfTwCfDNKDSHSewGBZ2L7EK8cXuQLSRaz+QZ3+Qaz+QZ39wy7UxZoBgev8SrLWHy72ejwb6DuDY3uOWxe5AlJFrP5Bnf5BrP5Bnf3DQ9QOUH+hb4KS5Gli0gf6NZjMAb8/ctFhdqJuHh0bpTMQ5dfyf+G/fORuAL73/ovANGxa87qsK24FzGtngjWZzS3oG5LoOlOk8IuwZlOkCIuxamc4jwp5BmS7AMdfW2nPDNFDXQN8sHaDz1y8FwD63k46P/Ardfa9hzZNfh8HlTN1+FxueHwbgyI+HS9//x58mft9N3HTJt2de64ify/96vJs/HLiRfz35fwDwboKpnc7dsnd+n6pB3Jj4HQC2ZT7PD/acz2BX/W0sO/4jAA50XcGxK/8I+HKZtSwxkynz+uJgO5aQvPptJPbuLPUMBa7LeYZS19OegRLXi+0ZAtdhPEPgetYztIJrZbr+NpTpwkz/4UAwvaEy7Qa1ZrpWz6BMB7jlWZmeXxutmOmwaNYdB5g+TVTtsYB8biE35htzuV5g5LpJKNP+oEz7gTLtD1HL9KIP9D/3k+dLXvvN6+/lN6+/dxF6Uz8f+urP+dBXfx66HUO26mMBea4ZjZbzDLSMZ6AhnqG66wVmwVy3WqYbgTLtPsp0bSjTAcq0+0Qx08aYa2b6Zcy/GWN+lHu8rpYG6qvRn0xhNgTXgNgtl5Cx7RwYWc3LGz/O3S8c5tfP2kvHncFUfGddVDoVU0f8XO458STg2wWvv+fCDbzIH/HunnY+/h+Pzry+rLe9ru41mm12diqqs5cf4L59Wa7Y+Cz3jr+bU045wIsvlT8dls/3R98EwEVLhnh5fH3ZdQyWmDsXfnzKZFLY3c9hTjy9xDNQ4LqcZyjv+j0XbgAocb3YnmHWdb5noG7X1TyDe66VaWUawmX6Rf6IDT3tvBuU6cWn5kzX4xmUadc8K9MeZRo+nPd8M/A+oJtg2s0fzdWAZt1xAuvShR9LFrsD0Uau/UCe/UGu/UCe/cEt19ba7XnPn7HWPgBgjPmLWhrQQN8R4jhz4Uf/Yncg6si1H8izP8i1H8izP7jq2lr79rynK2tpYNFr9PP5+uP7FrsL8+bLD+2e93uNsc7cWhsovU1cE2hV12E8w9yuF5imu25lz8p0fbSy6zAo062BMl0/rew6DK5l2hjzptI+mquAHWXWL6G+I/qdq7FdAwDsOX4eP9t7nIGOFOevPMT7ztrFfZv+lfP+IJjaNZur6y3mVav7eFVeTd2f/+BpnjsyNvN8xUAnR4aC53/zv+8C4E1//9a6utkMlvz1b3HOx27i0UNncvdT+/jmH/2A3i3LAPj1j15S8X1v3DB9k+alLElWWsupmzP8PomlV5kzPonlxyWegQLXlTxDoetizzDr2lXPQIHrap5h2nU1z+Cc687VVynTZ87DMyjTs5439AT1u8r0olNzpmv1DMp0gGOelWl/Mg3fNca8E3gw99r5wKuAq2ppwKkj+j7jytX81tpnFmxjnuKCZ5DrZqNM+4MLnkGum40y7Q8ueIYZ12cDdwEbc487gbOttU/X0oYG+g4wfYV3tceC9cUY3Vq7iczlekH7ItdNQ5n2B2XaD5Rpf3At09baCWvtl4FPWms/Zq39srU2ZYyp6TbAdV+Me9sLwamSb/3gcX7nbWfyw+37uezJ/4/MwWEuvPv/gWxwAcOyN4NZc92c7X3y9afyrzsOct7qJTy5Z5hLT1/F7v2jwQeMGfpWdvPZu55j6GiKF54NTkn98++9pt5uh6bjkx9mcizOnmOjJBIx1r9pE+PHA+F33buLE09aNjN/6xd+/YI6W7fE3Lnw48bpX2574cwSz0CB63o9AyWuiz0Di+Y63zNQ4Dq8Z3DRtTI9WuIZUKbnIN/zcyMphkcnlOnFp+ZM1+oZlOkA9zyDMg1eZPq83O/35v0O8IWi52XRrDuuYJ2Zysksdgcij1z7gTz7g1z7gTz7g5uui73X9D3QQN8FrIXs1GL3Yhq72B2INHLtB/LsD3LtB/LsD+66LvZe0/egJWv079xzdLG7UJVbdh6q/002W/2xcJywkBubC5dd37LzUONdLyzOuHbZMyjTjcRl18p043DZMyjTjcRl1/PyDK54BjjBGPO3xpi/y/t9+vnaWhqo+4j+pX/3HgDGrvs6zxw+znsv6MA80ofdOcRLPb8KwPqezrra/NkT+1nX18Evn7Wcbz9ykIN7RwBYsbGfb3zsUq7/2S6u+YWTuH48zdsu2VhvlxvCQ2d9hEO330PMGF7cd4xs1pJsjwOw6dTlnLCih99//RQ/fmnVPFq3MOVMPdjHga9A4LrYMzBv1z97Yj9Aietiz8Ciuc73DBS4Du8ZXHStTJsSz4AyXQPTngFl2g2UaWUaUKYjlulp7i9aVvy8LCrdcQFrXaoHO77YHYg0cu0H8uwPcu0H8uwP7rn+rrU2Nd8GNNB3BXf2Hn91sTsQeeTaD+TZH+TaD+TZH9xy/QVjzG3AN4D/tNbWdQFBS9boRw+b24Os8lionlj7tgXbmJe44Rnkurko0/7ghmeQ6+aiTPuDG55hxvUpwIM64X0AACAASURBVA+BjwAvGWO+aIypeU7Tuo/of/szwXy02/7sp/zg5VczmPkJnHE+sQvfROfE9AUZ9dX+/fXbzwbgySNjXLN1ikceby9Yft2FG3jXX97B//tbF/KFm58A4DXXXlhv10Oxb59l6/I0xmSJXbiOyfPXMjYR7FTd9fOXeMfWdXTd8xmOLP1Y/Y1bZuYqd4lvf2ZXiWdg3q6nPUN519OegUVzne8ZKHAd2jM46VqZzpZ4BpTpGlCmcdK1Mq1MK9PRybS1dgT4KvBVY8wy4J3A3xljllpr1831fpXuOIHFulMPJpqKXPuBPPuDXPuBPPuDm66NMQPA24F3A0uBf6/lfU0r3fm7e3byd/fsDN3OcyMpfvTSkQb0yGFs7grvao85MMZ82Rhz0BjzeIXlJjcl07PGmEeNMWXvpmaM6a2n6/JcJ3O5noNGec6tK9fNQpn2wzO0bKanPct1jSjTfngG5zJtjHmvMeZW4EngAuDPgPXW2o/W8nHmfUTf7n+OkwffiM1MwNgwsR2P8Mya3wdg+er5tXnaQBdwCl96/ykA7Dg6PrPsI+89j3ueG+KcM1Zy3YUb5tvteXN0GLLvfQsr//Z99LW/h7Z4jE3rDgBwyfozaYsf5/7Nf8qpwIUr68pgQPibM3wF+DzwtQrLrwA25R6vBL6Y+1lMwb8GxZ6BAtcwvwvB810XewYWzXW+Z6DAdUM8Q1jXX6ExnmEO175m+pL1ZwIo03WiTM+br7AImW6EZ1Cm6+QrKNOh8TDTtwNfAA4AE8AOa2u/WEAX4zqBDX0jDmvtncDhKqu8BfiaDfgp0G+MKTd8O2l+n0HUxhyu53p34zyDXDcRZdoflGk/UKb9wblMv0yw03A9Qa3+88aYTwAYY86dqz+q0XeB6dNE1Rk0xuTfHOEGa+0NdWxlLfBS3vPdudf2Fa33Z3W0KeplbtcL5Rnkunko0/6gTPuBMu0P7mW6E9hgrT0GYIxZAvxvY8wXgcuBE6ttrCkD/SePjIV6f/a2DwW/XPQ3ZZffuecor1nbH2obzjH3XuKQtXZriC2Yclst89qVIbZRN9nbPlTRM3jpeqE8Qx2ulel5oEyXxUPXTmY6LMp0WZTpqOBWpjfll+pYa0eMMR8EhgjKgKpS90C/pzv4mb33IU580/+Fzj5SvVu4n5PAwrLOJADvPKev3qZL2LT9U5CaYOP+w8TOPZ0Tz/gQzx1dnCuht9kd3Nq/mcTZn+UN39vD6DnbuHP3CgCu7P1X9na+lX2juTq4emvCrIWp0LV/c7EbyJ+G6QRgb5n1Zv7APd2lnoEC183wDCya63zPQIHr0J5hIVzX6hlyrpXpz5Z4BpTpECjTDaUpmW6EZ1CmG4wyXQO+ZbpcPb61dsoY83Ku9KcqqtF3hZC1fzVwM3BN7mrvi4Bha22500TbG7ExUQU3PINcNxdl2h/c8Axy3VyUaX9wwzPAdmPMNcUvGmN+jWAWnjlxrkZ//zsvYsVvVZxpKJrUVvtXFWPMN4DLCGrHdgN/CiSD5u31wK0Ep4CeBcaAays09dsEF4o0HbmunwZ6hgVyLc/zQ5luEZRpP1Cm/cG9TP+HMeY3gAcISnwuIKjbr+kOyXUP9EePBz8f/fTPeMWqpdjXvouOzAFSmWB6pS2jXwfgD+74BQD++u1L690EE3e9AMD4nmMAZNNZUl/fzpr3P8PaX5r+bv9y3e2G5cqjO7jRbGZq+056Nt7HL20ITpHxzH7Wrr6dNYnpMy+/W3/j2XB7idba98yx3BJ8YeZqZ8/WrUHp2ejxUs9AgeswniFwXewZWFTX056BQteN8AyhXDfKc27dPVu3blWmizP9zH4AZVqZrp0WzPS0Z1Cma0aZVqZroNGZBl5pjHkdcAZBff/3rLU/rLU/zh3R9xJrIdP02j/hAnLtB/LsD3LtB/LsDw66ttb+CPjRfN6rgb4rhDxSIFoIufYDefYHufYDefaHCLnWQN8FrIVMuNo/0SLItR/Isz/ItR/Isz9EzHXdA/1tdgcAN/ds5oQbfsYywA70M94X1IvZ/S8CcO47fiV4Q279Wjn20jHsVDCTUKI9TmZiismRCZ7fnqLv9p10HLgRgOQHFr72b5rYsm5G+1/J+ERQ77ZizR5+dPR1EIPXrRuov0FHv1Tb7I4Sz0CB6/l6hlnXxZ4BJ12H9gxOulamSz0DyrQyXRsOuq4l0zOeQZmuBQc9gzINfmQ6DDqi7wrZSvdKEJFDrv1Anv1Brv1Anv0hQq410HeBiO09iirItR/Isz/ItR/Isz9EzLUG+o5gG3MTBtECyLUfyLM/yLUfyLM/RMn1vAf6XV3w1N2HOaPjAfrfeiqd5wU32Y296i8B2Gb/cl7tjo5M0b1q9pTJs/cPk05bli01pI6kSLw4AuTuPLAIdHXC1J5heobuonfpCbkXl/C6rvsh/ob5Nerw3mOxZ6DA9Xw9Q6HrfM/Aorvu6gx+FrgO6xlayrW3me5aAqBMzwNl2i2qZbpRnkGZXmyUaX8yPR90RN8VIlQPJuZArv1Anv1Brv1Anv0hQq410HeBiO09iirItR/Isz/ItR/Isz9EzPW8B/qvP7iDly4/j56tqzEXXsAv8k3MmutCd+jMj7yCQz/cBUD32h5OOifNxPAE40cnGd41wsAVJ4XeRhi6uuDlW59n6YHjtF9xzszr5oJPz79Ri7M3Zyj2DDTcdbFnYNFdd3UFP4tdh/IMLeXa50z75BmU6VC0kGtlOgQt5BmU6VA47Ho+6Ii+E0Rr71FUQ679QJ79Qa79QJ79IVquNdB3AWsjtfcoqiDXfiDP/iDXfiDP/hAx15EZ6NuXvwKAWf6+pm1j4q/e1pyGLZCZak7bEWPaMzTPddM8g1zXgTLtBy3tGeS6DlratTzXTEt7hsi5DjXQX3fbg43qxwzJD/4Lqz44+zxXgsXBd11M3ytXEz9vS8O3WQ/LlhkyY2nGXxjBfvuBmdc7LwjTqtuniZrhGQpd53sGFt31smXB9GHFrsN5Bh9dt2Km5Xl+KNPuoUzLcxiU6dYnMkf0WxoLdio6UzmJKsi1H8izP8i1H8izP0TMdWyxO9AI0l96z2J3IRzWQjpb/SFa3zPM7VoAEXCtTNdEy3sGZbpGWt61Ml0TLe8ZIpfpljmiv+Kb95K99TqmHnwKgMRZhcuz//VfAMR/5X1N60N2eIJMBp59bAweG+N1+3c0pF0L2AjdnCEMK755L0BF19OeoXmupz2DXDcTZdoPas30QngGuW4myrQfKNOtRcsM9CNNFpiMzoUfogpy7Qfy7A9y7Qfy7A8Rc62BvhPYSO09imrItR/Isz/ItR/Isz9Ey3XLD/TTX3w3JFv8UgNLS9Z9LSSR8AxyXQORcC3PcxIJzyDXNRAJ1/I8J5HwDJFz3VID/diV15e9etgk4/zLu4KasW1N3Akb3nGYI0cssUZ/jyN2hXcjKOc63zM0z/W0Z0Cum4wy7Q9zZXohPIMy3WyUaX9QpluDlhroRxZrIR2dejBRBbn2A3n2B7n2A3n2h4i51kDfEaJUDyaqI9d+IM/+INd+IM/+ECXXGui7gLUwGZ16MFEFufYDefYHufYDefaHiLlu+YF+8oP/AsC2X2/+tp77+VFisSbcGdmCjdBpomawGJ5BrhcDZdoPlGl/UKb9QJl2kwhcHt36WBucJqr2mAtjzOXGmB3GmGeNMZ8os/wyY8ywMebh3ONPmvJhRFXmcl0Lcu0+yrQ/KNN+oEz7Q9Qy3fJH9CPB9O2W54kxJg78PfAGYDfwc2PMzdba7UWr3mWtvWr+HRWhkWs/kGd/kGs/kGd/iJhrDfTroK0NeroNyzctaXjbIadyuhB41lr7PIAx5ibgLUDxl0rUwLRnQK4jjjLtB8q0PyjTfqBM145Kd1xgeiqnag8YNMbcn/d4f14La4GX8p7vzr1WzMXGmEeMMd8zxpzRxE8kKjGX6+qeQa5bA2XaH5RpP1Cm/SFimdYRfRewNU3lNGSt3VphmSnfagEPAhustaPGmCuBbwOb6uuoCM3crqt5BrluDZRpf1Cm/UCZ9oeIZVpH9F3Agk1nqz7mYDewLu/5CcDegk1YO2KtHc39fiuQNMYMNvJjiBqYw3UNyHUroEz7gzLtB8q0P0Qs0zqiXwcXPPNU09oOWQ/2c2CTMeZEYA9wNbAtfwVjzCrggLXWGmMuJNjJOxRmo1GlmZ5Brl1CmfYDZdoflGk/UKZrRwN9B7DWMhXiCm9rbcYY8zvA7UAc+LK19gljzHW55dcD7wQ+aIzJAOPA1dba6Nz6rUWQaz+QZ3+Qaz+QZ3+ImmsN9OfJjWZzwfNtdse827IWsplwN2fInfq5tei16/N+/zzw+VAb8ZR812E8g1y7jDz7g1z7gTz7g1xXRgN9F7A27Gki0SrItR/Isz/ItR/Isz9EzLUG+i5gIRviNJFoIeTaD+TZH+TaD+TZHyLmWgN9R6j1tsqi9ZFrP5Bnf5BrP5Bnf4iS66YN9KvVsBcvq5ew9VdhCdv/YsJe+LGYzHWtglwXElXX8lxIVD2XW14vcu0G5f4OynRlWtUzKNP10squy6Ej+i5Q2404RBSQaz+QZ3+Qaz+QZ3+ImGsN9B3ARqweTFRGrv1Anv1Brv1Anv0haq410HcCi81G50slqiHXfiDP/iDXfiDP/hAt13UN9A8/8Pi8a6EaWUNVqa2FqBNryud3bO/RFc+V2mtZzyDXdbbVsq7lua72WtYzyHWdbbWsa3muq72W9QzOuQ6LjuiHpBFfZmshG6F6sKgi134gz/4g134gz/4g16VooO8C1kZq71FUQa79QJ79Qa79QJ79IWKuvRroN/p0VcO2E7HTRIvNQnme17bkuqEo036gTPuDMu0HznqGyLn2aqDvKpZoTeUkKiPXfiDP/iDXfiDP/hA11xrou0DEbs4gqiDXfiDP/iDXfiDP/hAx1xroO4AFIjSTk6iCXPuBPPuDXPuBPPtD1FxHaqC/kHWcDd2mhUwmfDO+sBieG7Zdua4LZdoPlGl/UKb9QJl2h0gN9FsVC0SoHExUQa79QJ79Qa79QJ79IWquNdB3ABuxvUdRGbn2A3n2B7n2A3n2h6i51kDfBWy06sFEFeTaD+TZH+TaD+TZHyLmWgN9B7BEa+9RVEau/UCe/UGu/UCe/SFqrjXQd4GI7T2KKsi1H8izP8i1H8izP0TMtQb6DhC1ejBRGbn2A3n2B7n2A3n2h6i51kDfASwwNRWhS7xFReTaD+TZH+TaD+TZH6LmWgN9F4jYaSJRBbn2A3n2B7n2A3n2h4i51kDfAaJ24YeojFz7gTz7g1z7gTz7Q9Rca6DvAhHbexRVkGs/kGd/kGs/kGd/iJhrDfQdIGoXfojKyLUfyLM/yLUfyLM/RM11bLE7IAKytvpjLowxlxtjdhhjnjXGfKLMcmOM+dvc8keNMec143OIuQnjGeS6VVCm/UGZ9gNl2h+ilGkd0XeAsHuPxpg48PfAG4DdwM+NMTdba7fnrXYFsCn3eCXwxdxPsYDItR/Isz/ItR/Isz9EzbWO6DuAJagHq/aYgwuBZ621z1trJ4GbgLcUrfMW4Gs24KdAvzFmdaM/i6jOXK5rQK5bAGXaH5RpP1Cm/SFqma7riP5OJoZ+lad3NaMjHrGh+IWdTNz+nuzTg3O8r8MYc3/e8xustTfkfl8LvJS3bDele4bl1lkL7CvTH3luDPNxXc0zyLWLKNP+oEz7gTLtD85nOix1DfSttcsb3QEB1trLQzZhyjU7j3Wm+yPPTUKu/UCe/UGu/UCe/cE112FR6U402A2sy3t+ArB3HusI95FrP5Bnf5BrP5Bnf3DKtQb60eDnwCZjzInGmDbgauDmonVuBq7JXel9ETBsrW34KSLRdOTaD+TZH+TaD+TZH5xyrVl3IoC1NmOM+R3gdiAOfNla+4Qx5rrc8uuBW4ErgWeBMeDaxeqvmD9y7Qfy7A9y7Qfy7A+uuTbWNqUkSAghhBBCCLGIqHRHCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiiAb6QgghhBBCRBAN9IUQQgghhIggGugLIYQQQggRQTTQF0IIIYQQIoJooC+EEEIIIUQE0UBfCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiiAb6QgghhBBCRBAN9IUQQgghhIggGugLIYQQQggRQTTQF0IIIYQQIoJooC+EEEIIIUQE0UBfCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiiAb6QgghhBBCRBAN9IUQQgghhIggGugLIYQQQggRQTTQF0IIIYQQIoJooC+EEEIIIUQE0UBfCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiiAb6QgghhBBCRBAN9IUQQgghhIggGugLIYQQQggRQTTQF0IIIYQQIoJooC+EEEIIIUQE0UBfCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiiAb6QgghhBBCRBAN9IUQQgghhIggGugLIYQQQggRQTTQF0IIIYQQIoJooC+EEEIIIUQE0UBfCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiSKKelQcHB+3GjRub1BU/eOCBB4astcvzX1vSf7rNpI9Xfd/42Iu3W2svb2rncshzY5iP64X0DHLdCJRpf1Cm/UCZ9odWyHRY6hrob9y4kfvvv79ZffECY8yu4tcy6eNsOfMPq77voZ/99mDTOlWEPDeG+bheSM8g141AmfYHZdoPlGl/aIVMh6Wugb5oDsZALKkqKh+Qaz+QZ3+Qaz+QZ3+ImmsN9F3AGEwyvti9EAuBXPuBPPuDXPuBPPtDxFxroO8CBkzMLHYvxEIg134gz/4g134gz/4QMdca6LuAIVJ7j6IKcu0H8uwPcu0H8uwPEXOtgb4DGAwmHp29R1EZufYDefYHufYDefaHqLkONdC/0Wye+X2b3RGqjfm+v1nkf7b5EItBNlvjyo5f+BFlz9Ac1xU/p1wvGsr0LFH2DMp0PlF2rUzPEmXPoEyHQUf0XSBi9WCiCnLtB/LsD3LtB/LsDxFzrYG+C0TsCm9RBbn2A3n2B7n2A3n2h4i51kDfAYwhUvVgojJy7Qfy7A9y7Qfy7A9Rc133QD9snVSltm6KbyaWK4l6V3rh68Ma+bnqxhgn68Ea9TfJb+dGE3heLNeL6hmcdK1MNwEHPUNzMn1TPPhdmXYHZboJOOgZlOmm4Kjr+aIj+k0i/6KP/As+ftWU30s0ieicJvKNSq4rIdetiTLtD8q0HyjT/uBzpjXQd4GInSYSVZBrP5Bnf5BrP5Bnf4iY66YO9G+Kb57Zi+rqDH7GYpCYY6s398yetplMz74PZvfK3jnRmFNJ/9a+ufbptZqEafELP/I9w/xcF3uGxrp2wTNEy7WLmf639s0FbS4WUfIMynQ1ouRama5MlDyDMl2NVnddTN0D/UbOrzq4DDKZ2S9ZNhs8MpmGbaJlcHEqp0a5LvYMreF6m93RlFpB11wr083BNc+gTCvT9aNMz+KaZ1Cmfcl0GFS64wIRu/BDVEGu/UCe/UGu/UCe/SFirjXQd4GI1YOJKsi1H8izP8i1H8izP0TM9bwH+g+dtoXRUVjSC1kLqVTwAHjtvqe4Y/WWRvWxLNPtJxIwMWGZnITJyaAvAG8fD05n/efgZpJJU3A6amLC0t7ujkRjIO7oFd7FnqHQ9UJwx+otBZ6h1HU5zxDOdVNOB7aQa2V6/rSSZ1j8TE/nWpluLNUyvRAo0wuDMt1YXHY9H5p6RH9JL/T1GSYmLMYY2tqCWq+pqcB8PG6AQHAiEVzg0dFR2MbRo9DfH7xv+gGNqxnr74ORY4WvlbsYJBYr3eb0lzV8XwyxFq4Hy/cMlLjO9wyUdZ3vGRrvupxnKHVdzvN0nxvznYuOaxcz3d8X/AyTaXmuL9PT/w4q062JMl0r0fEMynR1Wtt1MSrdcQBjIB6hejBRGbn2A3n2B7n2A3n2h6i5rnug//xrzp5znUPvffW8OtNI7ju5uWUG9XBrf3Bq6cqjFa6ONzi591iLaxdwzXVFz+Cka2W6fpTp5uKa6yhm2gVc8wzKdLNwzXWrZToMoY7on3zeEtp6kqSOTNDWkySbtSQ7gybPvHQpJm4YOzjGVCZLZizD2LEpOrtjJHLrZNNZ0uPBeZbpUzPt3YmZiyCy6SyTk1O0JWF0FNraYMVyQzY7W6udmoCeHsPYGBw7ZslkCk81rV1jaOuM09aTBODovhRtywypiWB5W1vQXnu7IZsNTmGlUsHpn+k5Y6f719GRqy/M9bUtaLLsqaIN64NTZLXUyBkMiRD1YMaYdcDXgFVAFrjBWvu5onUM8DngSmAMeJ+19sFa2s/3DBS4zqazBZ6BEtf5nqHUdbFnKHWd7xlKXRd7hkLXxZ6hvOt8z/l9bUtWPiUYVdetmOm2ttx2QmTaN88QLtP5p9Xnm+ljx4JyAmV64TKdTQd/CGU6ep4hGpmeLh8Lm+ltdgd3b9gSGdf1otIdBzAGEuFOE2WAj1lrHzTG9AIPGGO+b63dnrfOFcCm3OOVwBdzP8UCItd+IM/+INd+IM/+EDXX0SlCamVMcHOGao9qWGv3Te8JWmuPAU8Ca4tWewvwNRvwU6DfGLO6GR9HVGEO13Mh1y2CMu0PyrQfKNP+ELFM1zXQn9ixfe6VRN0YY0gkYlUfdbS1ETgXuK9o0Vrgpbznuyn94s3QKnV/rcZcrutsayMhXSvTzUGZ9gdl2g+UaX9wLdNhqbt0Z2piCoD1WwfJprPE2xPEkmm6V3WT2LBkZj2bmsIkY3QPT5AdS3PspWN0jE7S0d9Be197sPG+dsb2HCMzMUVmLEOiK4HN1WQBjO4dZfnaNjoGOhg5NgJAKhUsb2sL1unsjjF+PEtXF4yPz055Gcu5yGaDPbP0WIbjwxnGxmHp+i6ye4Ni77YkrNrYyeG9KTIZGB019PYG7ztyNNhWzEBmKvgZy3P81rHgYo6b4psLatqmb0n9wOYtwOznqYQBYnPfnGHQGHN/3vMbrLU3FLRjTA/w78BHrbUjZTZTTNXOTU1MlXgGClwXewZKXOd7Bkpcl/MMha7zPUOp62LPQIHrYs9Q6rqSZwhcV/IMDXU9p2dorOsoZXr6upkwmb4pvnlmO9Mo05UznRkLAhUm0+PjwXJleuEybVPBOsq0Mu1qpkdHgz9HIzJ9ya6nWjrTYVCNvguYmi78GLLWbq3chEkSfKH+2Vr7H2VW2Q2sy3t+ArC33q6KkMztuqrnoAm5dh5l2h+UaT9Qpv0hYplWjb4DGMLV/uWu3v4/wJPW2s9UWO1m4BoTcBEwbK3d19APIuZkLtdzvl+uWwJl2h+UaT9Qpv0hapnWEf0Q3LF6C6/d91TN6+99y4XlF4S/wvsS4L3AY8aYh3OvfRJYD2CtvR64lWAap2cJpnK6NswGfWP6Vu61UNEzyLXj1OMZlOlWRpn2A2XaH5Tp8tQ10I/FDctOWwpA59pe7JQl3tdO9znLYcpiU1MzNWFTh1PE+tsxHXHs7lE6+jvoWtbJVDpLYiCYVDW5YQk9fe1MHTjO5GiazFia1Ghqppa7a0UXU6kMmbE0K9cFxX4n3fkoT56zZeZmBnbKMjYOO18ISpvyaywBnjxnCyZuaOtJ0t7XxtiOMUb3j9HeHXz0WDLG0lOXEksepWt5F8O7RkiPpkmlLF1dwTaOH7eMjkJPD3R2GsbHg1uFT3P1VPkbL5y/Y3Yn4OhvXcbYy2Nl1zMhb85grf0J5eu98texwG/X2mbHQAcdA+2lnqHAdbFnoMR1vmegxHU5z1DoutgzFLou9rzutge598QtM66LPQMlros9AwWuK3mGWdfVPIN7rqOW6VjuH+cwma7FMyjT+Z6B0Jmey7My3dhMTx0OJhRXppVpVzM9vCsoa/c902HREX0HmL7CW0QfufYDefYHufYDefaHqLmOzidZJB45fQuPnB7+1s4mFqv6WEgmn9b0bOVohGeo7losPgvhWZl2A2XaD5Rpf1CmS6mvdCc5+yGzxyYZOzhGe187ydXdZA+ngtMsPw0uGk4dSdG1ootkZ4L9jwyRyQRTIXX2JliROxWXHZ0kPtgJccPhpw8zdjRNV39y5mKHtu4kieVdZNNTtPXMniqKJ2P0ntA783zzg/dxcYU+t/UkSbTHyaazbPjhwzOXOO++MrhgumdND5Ojk/Rt6GN41zBL1vVyfP9xenvayOSmoUqPZxg9nCaRCG7B3NVp6B1s49jQZM1/u/bV3bQNdgaXXxRhjAlbD9ZwelZ1M5XOlngGClwXewZKXOd7BkpcV/IMha7r8Qxw8c7gNN3uK7eWeAZKXBd7hvpdz3iGlnAdtUz3rOkBUKbL0KxMH376MIAy7Qi1Zjp1JCjdUaZnUabdyvSSdUGbvmc6LCrdcQFDpE4TiSrItR/Isz/ItR/Isz9EzLUG+g5ggJiZ/4UfonWQaz+QZ3+Qaz+QZ3+ImmsN9B3AGEMyQnuPojJy7Qfy7A9y7Qfy7A9Rc13XQN9mLZ0bc1PtHUnRvbaHkV0jTDx7hKP7cvV+vcHdxBJdCaYmphh+fpjURFAP1tMNx45mWJFr74Fv7SGRgFXrkvRtWMKq8zoZemKIZK7+q3Owk1h7nFhfO9ncdE8A6Yksx/cfr6nPJ//ksbKvD160GoDY0k6mhsYYfnyIoV1jjD4xxpJeOPVta7Dp4D7Ksb52ssMTTB5OEYsb4u1xJkYmGDil9i9C56dvYfyP31RxeZipnBpNcIvqNN2bBko8AwWuiz1Dqet8z0CJ60qeoXbXlTxD4LrYM1DiutgzULfruTyDW66jlunY0qDuUpkupJmZ7stNv6pMu0GtmU50Bf/9K9OzKNNuZXr0iSDXvmc6LDqi7wDGQCIenb1HURm59gN59ge59gN59oeoudZA3xGitPcoqiPXfiDP/iDXfiDP/hAljFG9gwAAIABJREFU13UN9BOD3dhscMezznecw7O/dwvr3riR/ffsYWBtJ8metpnlD/94mI6OFCMjkJqAtjYY6DesWW342beC6fpGRyEzBYcOTcLDQ8E6A4YN5wZ35HvuR3s46dI1JE7snzk9B3DGo08Rlo4/+Q4AUzdew8u372TgjEEmjqQYTMaIJeMc3X5oZmqnPffsYe0VJ9F96gCxvnZMdwfJHS8z+dzRurbZ+elb4M9KvzzGGJJxd75UiZ4kA9duZeLOZ0s8AwWuiz1DqesCz1DiupJnaJzrYs9Aietiz8C8XHd++pbgl1ZwHbFMT914DYAyXURTM/3w0Ow6yvSiU2umH/5xMCWpMl2IMu1OpgdzU1z6numw6Ii+AxiitfcoKiPXfiDP/iDXfiDP/hA11xroO0DU6sFEZeTaD+TZH+TaD+TZH6LmWgP9BSLz1V9j+AcvVFwepb1Hn5nLM8h1VFCm/UCZ9gdl2g98y3RdA/3jLwyTWB3cjvrQ5+/mlP9+MeM/fpHOZZ0MXLiaQ3fvoX/zUgBGvjvMyDHo6gymRlq2zLCkF44OW3J352ZsPLgFcyYD/X3Q12dYd+YS0qNBLffmqzcRXxncznmmnqrBmMEljB0cY/f2nQwPW86/YjmdK7p47vYXSR0N6j5HDqXp+OleVl97Juas0wFou/J62qo1XE8fHJuz1aaz3Pebt7H1E+eUeAYKXBd7hlLX+Z6h1PVieAZKXJfzDNF2HbVMm8FgWjhlupBmZrq/L1hHmXaDWjM98t2gRl+ZrrEfjnn2IdPnX7E82J7nmQ6Ljug7QNROE4nKyLUfyLM/yLUfyLM/RM21BvqOEKXTRKI6cu0H8uwPcu0H8uwPUXLdMgP97E8+DkDs1X+9yD1pPMaYSO09hmHaM8h11FGm/UCZ9gdl2g+U6dairoF+91lnkvzATQAs/wDsefMFDD13jKXru9j+j08yMgJd20eAoBasLVcwFYvB8eOWAweCeVqzuSlYE7mtbzrFkEoFt2NOHUlhcvOXZkfTZEeP0vnBX8Lu2duAj1vK+Pd2sPys5Qz9cD/JpCE9niE+PMlpH98KU0FHN6wfxJxxJkyOA2A2/G7d25l89CAHHxsqu8y1qZxi607l4vvvB0o9AwWuiz1Dqet8z0CJ68XwDJS4brZncM911DI9/r0dwWdRpgtoZqZTQYm0Mu0ItWa6KyjlVqbzUKbdynR6PLiwz/dMh6VljuhHGWMgGaG9R1EZufYDefYHufYDefaHqLmua6B/+IHHublnMwDLlxvWn9nblE75h3Fq7/HIg49zU3wzXZ3y3Hjccq1MNwu3PCvTzcQt18p0s3DLszLdTNxyHZZQR/RffPwYF+8Mbn08dt5pPPNslo72XMMJOHwEOjogEQ++iCee1s4D96Rm3t+WhLVrDVvefhKmPQ7Ay/fsIdGZBKDzA28AwKzZDAOrwnS1It2f/T5jf3A5L79sOe2MBB39HSz5tfOIveZN2B0/B8BuuYTJbCdpG5zr7JnHdrr+5j85uHZL2WXBFd7ufqnyPUOh62LPUOo63zNQ4noxPAMlrpvtGVrLdStmuvuz3w/6rkxXpZGZnvYMyrSLVMr0dKmGMj2LMu1Wpjv6OwCU6ZCodMcRIrTzKOZArv1Anv1Brv1Anv0hSq410HcAAyRi0akHE5WRaz+QZ3+Qaz+QZ3+ImuvQA/0bzWY6OuCM06LzR2kkd6wOTg8dOWpZtrT8LqIxkHR893HaM8h1Je5YvaWqZ2gt1/JcHmXaH5RpP1Cm/SEqma6Hugf6Y8GMRux60c5MvwXwyGNZslkYPZ5rOBHUg01OwiQwPGxJ7J7g1W8eYMe9RwHo6YENW5cFb4jHaDtrBSt720icvBQA+8RTxH75HwAw7fP7gLXQ9Ve30falzWy4egu7v/UMSzraSdNLoj/oR9YmydokcTJ0Jl4x7+3s2WsrLnPpO2UtYALXxZ6h0HWxZyh1XeAZSlwvhmegxPVCeAa3XIMyrUyHzHRudgpl2h1qyfR0jb4yXYgyjTOZ3v2tZwCU6ZCodMcBDCZSp4lEZeTaD+TZH+TaD+TZH6LmWgN9BzAmWnuPojJy7Qfy7A9y7Qfy7A9Rc133QL/49BAEdzpNJAqXZbPM3F2tqxPOvKiXl3eOMnEkxem/EJxq616/hK7/+VHskb1k/v126O8jefUFmIE18/owYZl4+girLlhFdvsu4oe/jAViV15PYuJWEsn5navat7/66aFpEiG/VcaYLwNXAQettWeWWX4Z8H+BnbmX/sNa+z8qtVfJMxS6LvYMpa7zPQOL7nri6SMAJa4Tv3jCvD3DwrhutGdQputFmV5a6hmU6XmyWJme/qlMK9OuZnrVBcE0nsp0OHRE3wEMEDOhdx+/Anwe+FqVde6y1l4VdkNi/jTA9VeQZ+dRpv1BmfYDZdofopZpDfQdwBgT+kiBtfZOY8zGhnRINI2wruW5NVCm/UGZ9gNl2h+ilunoXG3QJCb+4q0Fz3/w4mF+8OLhhm8nZkzVBzBojLk/7/H+eWzmYmPMI8aY7xljzmjwR4gU054X2jXy3HSUaT9RpqOLMu0nynRtNOyIfiZT+Dy/dmxsHMYPjdPdE6NtSTt9rwrqvRIbB7AP3oU5/1ISr9+KWbsJO/QS9uBOzPoPN6prNXH54R0A2Ic+RfbZFzCbNzH5zbsAmPjMDRz48DcYaH+hKdsObs4w597jkLV2a4jNPAhssNaOGmOuBL4NbJpPQ/muiz1vszt45pVnFLjO9wwsqutpz1DG9SPN9Qw1uXbSMyjT9eBTphOvDz6CMl0R5z2DMj0XyvTCZ9o+9Kmg/8p0KHRE3xHipvojLNbaEWvtaO73W4GkMWYwfMuiXuTZD5Rpf5BnP1Cm/SFKnlWj7wDGNP92y8aYVcABa601xlxIsJN3qKkbFSU027U8u4Ey7Q/KtB8o0/4QtUy7O9BP38a1/9ALwD9+6JJF7kxzCW7OEHrarm8AlxHUju0G/hRIAlhrrwfeCXzQGJMBxoGrrbW1zTPVZK79wt1A9D1DeNet7FmZrrONFnatTNfx/hb2rEzX2UYLu1am63i/Y57rGuh3dxm6cl2ZvsV2QWNF827HYrNztm667wl2vvYVLL14DYmTgtss3/Tm/+Lq71yGSY3CwEqynctg3TJimePz+jANYeUqYitWgjE8f92NAGwfGoV9x3jH+p2ctzL3gVhaU3Nvvm4tAOnxNC8/OgQPlVmpATdnsNa+Z47lnyeY7mlOOjrggrMTPPFYpqxnKHSd7xlKXRd4Bmddl/cM9bie8QxNcd1Iz6BMK9OzzDvTAysBnHStTJcuV6ZLUaYdzfTKYB593zMdFneP6HuEwRI3Tuy0iyYj134gz/4g134gz/4QNde6GNcRjMlWfSxcP8yfL9jGPMUFz0E/5LqZKNP+4ILnoB9y3UyUaX9wwXPQj/Cu6zqi3zbYyRvfcxIA7eeuYPLxIQ4/fJCh546x6aqN2PQUj377JQAOHAj2hq4amZ36bNWl64j1tjH10lGSH/wXtllITT1E+6GHMMtPxN7ydQDsVdsA6B/sDvv56sasuW7m99Omvg/AQMe5wQvtV9Z4cmiWic/+EwDjU/1s+v5H4G1PlW4TS9yk59XfJnB518mDbPyNs1i7c7jEM1DgupxnKHS9ze6Y8QyUuF4Mz1DqOoxnCFzPeIaWcK1MK9MQLtNm+YkAyrQb1Jzpac+gTCvTbmY63zP4m2ngk2EaUOmOE1gMC7uXWIX4Yncg2si1H8izP8i1H8izP7jl2hgzQDC9fwnW2jnvFqaBvgM4tve4ZbE7EGXk2g/k2R/k2g/k2R8cdP0A5Qf6FjhprgYWbaB/o9kMwNszNy1WF+rm4aFROhNxTh3/J/7bd84G4Evvvyh8w4YFr/uqwnbgnEY2eKPZ3JKeAbmuA2U6jwh7BmW6gAi7VqbziLBnUKYLcMy1tfbcMA3UNdA3Swf4/9u79yg56/qO4+/vbkKu5J5ACCEECVC5CCEJCBUsFeVWEUQusVysHhsoUiv1Aqetnuppa71VQcjheDjgoYjQWsrRSFpAJUKEABaEwEJCgNwhkGzIbZPd/fWPmU1md2fn9szs/J7n+3mdMyc7O7PPPMt7v5zfzDwzM+LK0wEIK1cx/LpPMGrsaRz04l0waTJdi5cw49V2ADb/pr3/z//912l94h7uOfX+vd8b3noC//L8KL48/m7ue88/AnAJubd2OuGodbX9VnVy95BrAZjfeTMPrT2RSSOr38bE7Y8AsHHk2bx7zg3A7UWuFWixziLfb44wfAxDL72AIetW9e8MvVoX6wz9W/d0Bvq1bnZnyLVO0hlyrfd1hjS01kxXvw3NdO+Z/vL43NsbaqbjUOlMV9oZNNM5cXXWTNe2jTTOdFJ6151IGF0lT4Po+4N5Yx5F0hnUuqE0035E0hnUuqE0035E0hnq0LrpC/3v//bVft/79MKlfHrh0ibsTfWuuXMZ19y5LNE2cseDdZY8DaKVjdhosc5AajoDiTtD+daDbNBap22mk9JMp4NmujKaac10WmRxps3sir37ZvYfZvZI/nRGJRuo7hj93buwGbnXgISjTqUzDGPj1qm8degXeey1d7jy2HUMfzT3VnzHntz/rZiGt57A4zMPA+7v9f3L5s3gDW7gktHD+OLPntv7/Yn7D6tq9+ptftj3VlTHTd7IE+u7OfvQFSzdeQmHH76RN1YXfzqs0P9uOxeAk8ds4q2dhxS9jhFoieeFH1+zzl2ENSuxme/t1xno1bpYZyje+rJ5MwD6tW52Z9jXurAzUHXrUp0hvtaaac00JJvpN7iBGaOHcQloppuv4pmupjNopmPrrJl2NNPwuYLzRwJXAaPIve3mI+U2oHfdiUKI6YUfY5q9A9mm1j6osx9q7YM6+xFX6xDC8oLzr4QQngYws3+uZANa6EeilWhe+DGu2TuQdWrtgzr7odY+qLMfsbYOIVxYcPaASjbQ9GP0C931/Ppm70LNbv/9mpp/1ixE89HaQP+PiWuAtLZO0hnKtx5kDW+d5s6a6eqkuXUSmul00ExXL82tk4htps3s3P77aOcBbUWu3091j+iPmEoYOR6Atdtn8+S67YwfvosTD3ibq459nSdm3cfsL+Xe2rU7f1xvX6dMHcspBcfU/dNDL7Ny846956eMH8HmTbnz3/n2EgDO/eHHqtrNRhjzrc9w/PX38Nzbx/DYS+u594aH2P+oiQBc+flTB/y5D8/o+ZDmCYwZOtC1ovpwhi8wZMJ5dvSNBH7TrzPQq/VAnaF3676dYV/rWDsDvVqX6gw9rUt1huhaj5h6nmb6mBo6g2Z6X+cZo3PH72qmm67ima60M2imcyLrrJn2M9PwczO7CHgm/70TgVOA8yrZQFSP6HtmdJc8DZYQwiuDdmNOxdAZ1LrRNNN+xNAZ1LrRNNN+xNAZ9rY+DlgCHJo/PQocF0J4uZJtaKEfgZ5XeJc6Ddq+mOmjtRuoXOtB3Re1bhjNtB+aaR80037ENtMhhI4Qwu3AjSGE60MIt4cQdplZRR8DnIoX435vyUo2bdnFaytyT0n9+9+c1uQ9Kq7n/VtvuXJulT8Z1Su8727WDfd0BqJuXXtnUOsczfSganjnlVt3Ff2+ZnrQaabL0ExXRjMdVevZ+a+XFnwNcEuf80VVvdB/8LXcMVH/9dDzXHvBMTy8fAMffPHf6HyznXmP/S10516pPPHPwA5aUHZ7N37oCO5re5PZU8fw4tp2Tn/vgazZsA0AazHGHlD8/V8H2/AbP8fuHa2sfXcbQ4a0cMi5s9i5PXfPbsnS15l52MRE27fuaF7hbT1fPPjaMf06A71aV9sZ6Nc61s5Ar9b16AzxtdZMb+vXGdBMl1HYGaB9W4dmuvkqnulKO4NmukdsnUEzDT5musjXxc4XlYpH9LMvQIjm3mNo9g5km1r7oM5+qLUP6uxHtK37dq/o7yCVx+g/unZLs3ehpF+seru6HwhAd1fp0+A5eDBvrJyYW/9i1dv1bz24omkdc2fQTNdTzK010/UTc2fQTNdTzK2r7gzRzbSZ/cDMbir4uuf8tEo2UPUj+qffdBkAOxbcxSvvbOfyucOxZ8cSVm1i9ehPAnDI6BFVbfPJFzYwfexwPnrsZO5/9k3eXLcVgCmHjuMn15/Owidf54oPHMbCnXu44NRDq93luvj9sdfx9uLHaTHjjfXv0t0dGDqsFYBZR0zm4Cmj+cKHuvjN6gNr2HqArmieJvoicAfkWvftDNTc+skXNgD0a923M9C01oWdgV6tk3eGGFtrpq1fZ0AzXYGezoBmOg6aac00oJnO2Ez3eKrPZX3PF6VDd2IQonqaaHuzdyDT1NoHdfZDrX1QZz/ia/3zEELxV0dXQAv9WMRz7/GTzd6BzFNrH9TZD7X2QZ39iKv1LWb2IPAT4H9CCFUdP5TKY/SzJ+TvQZY4DdaehHDBoN2YS3F0BrVuLM20H3F0BrVuLM20H3F0hr2tDwceBq4DVpvZrWZW8XuaVv2I/v3fzb1N1fxv/I6H3vpjJnX+Fo4+kZZ55zKio+cFGdUd+/etC48D4MXNO7hiThfPPj+s1+UL5s3g4m/+ir/7zDxueeAFAE771Lxqdz2R9esDcybvwayblnnT2X3iNHZ05O5ULVm2mo/Pmc7Ix7/L5gnXV7/xwN63MIzJ/d99vV9noObWPZ2heOuezkDTWhd2Bnq1TtwZomytme7u1xnQTFdAM02UrTXTmmnNdHZmOoSwFbgTuNPMJgIXATeZ2YQQwvRyP69Dd6IQCPEcDyYNpdY+qLMfau2DOvsRZ2szGw9cCFwCTAD+s5Kfa9ihOzc9voqbHl+VeDsrt+7ikdWb67BHEQv5V3iXOpVhZreb2Ztm9vwAl1v+LZlWmNlzZlb009TMbP9qdl2dq1SudRn16py/rlo3imbaR2dI7Uz3dFbrCmmmfXSG6GbazC43s0XAi8Bc4BvAISGEz1fy69T8iH7YsJL3TPowobMDdrTT0vYsrxz0BQAmT61tm380fiRwOD/67OEAtG3Zufey6y6fzeMrN3H80QewYN6MWne7Zlvaofvy8zngB1cxdthl7NfawqzpGwE49ZBj2K91O08d+VWOAOYdUNUM5iQ/7usO4GbgxwNcfjYwK386Cbg1/29fvf5v0Lcz0Ks11PZC8MLWfTsDTWtd2Bno1bounSFp6zuoT2co09rrTJ96SO5TRTXT1dFM1+wOmjDT9egMmukq3YFmOjGHM70YuAXYCHQAbSFUvoN6MW4UQu54sFKnclsI4VHgnRJXOR/4ccj5HTDOzIot3w6r7XeQypRpXe6n69cZ1LqBNNN+aKZ90Ez7Ed1Mv0XuTsNCcsfqv2pmXwEwsxPK7Y+O0Y9BALrLHg82ycwKPxzhthDCbVXcyjRgdcH5Nfnvre9zvW9UsU2pVvnWg9UZ1LpxNNN+aKZ90Ez7Ed9MjwBmhBDeBTCzMcC3zexW4CxgZqkba8hC/8XNOxL9fPeD1+S+OPk7RS9/dO0WTps2LtFtxCVUci9xUwhhToIbseI33M85CW6jat0PXjNgZ3DZerA6QxWtNdPV0kwPxGHrKGc6Kc10UZrpTIhupmcVHqoTQthqZlcDm8gdBlRS1Qv90aNy/3Yv/T0zz/1vGDGWXfsfxVMcBgEmjhgKwEXHj6120/3MWv412NXBoRveoeWE9zLz6GtYuaU5r4SeH9pYNO5Ihhz3Pc785Vq2HT+fR9dMAeCc/e9j3YiPsX5b/ji4ao8JCwG6qvr8g1qsAQrfhulgYF2R6+39Dzx6VP/OQK/WjegMNK11YWegV+vEnWEwWlfaGfKtNdPf69cZ0EwnoJmuq4bMdD06g2a6zjTTFfA208WOxw8hdJnZW/lDf0rSMfqxCN2lT8k9AFyRf7X3yUB7CKHY00TL63FjUkIcnUGtG0sz7UccnUGtG0sz7UccnQGWm9kVfb9pZn9O7l14ytIx+jHoeSunBMzsJ8AHyR07tgb4KjA0t/mwEFhE7imgFcAO4FMDbOqvyL1QRBohYes6dga1bhzNtB+aaR80037EN9M/M7O/AJ4md4jPXHLH7Vf0CcnRLfQ3XHQyUz4z4FuKZlf5F/mUFEK4rMzlgdwfTLntrJ0zJ8mhZ5VT6+rVq3P+uoPSWp1ro5lOEc20D5ppPyKaaeAkMzsDOJrc8f2/DCE8XOn+VL3Q37Y99+9zX3+S9x04gfAnFzO8cyO7OnPvo3rUtrsA+NKvPgDAty6cUO1N0LHkNQB2rn0XgO493ey6azkHffYVpn2k507sR6veblLnbGnjbjuSruWrGH3oE3xkRu5YOF7ZwLSpizloSM8hVn9d3YZDgM6GH/tXtW3b+3cGerVO0hlyrft2Bprauqcz0Lt10s4QZWvN9JH9OgOaac10ZSJsXclM93QGzXRFIuwMmmnwMdMhhEeAR2r52ege0Xcr4SMFkiJq7YM6+6HWPqizHxlqrYV+DEKAzmTH/klKqLUP6uyHWvugzn5krHXVC/35oQ2AB0YfycG3PclEIIwfx86xuePFwoY3ADjh45/I/UD++pV6d/W7hK7cOwkNGdZKZ0cXu7d28OryXYxdvIrhG+8GYOhfDv5Tgj1aJo5i27iT2NmRexpsykFreWTLGdACZ0wfX9tGI7z3OD+09esM9Gpda2fY17pvZyDK1nXpDNG11kz37wxopjXTlYusdSUzvbczaKYrFVln0EyDj5lOQo/oxyDC48GkQdTaB3X2Q619UGc/MtZaC/0YZOxpIilBrX1QZz/U2gd19iNjrbXQj0Soz4cwSAqotQ/q7Ida+6DOfmSpdc0L/ZEj4aXH3uHo4U8z7mNHMGJ27kN2W075JgDzwzdr2u62rV2MOnDfp/2ueKqdPXsCEycYuzbvYsgbW4H8Jw80wcgR0LW2ndGblrD/hIPz3xzDGSOfgtYza9toxPce+3YGerWutTP0bl3YGWh665Ejcv/2ap20M6SqtduZHjkGQDNdA810XErNdL06g2a62TTTfma6FnpEPxbdofx1JBvU2gd19kOtfVBnPzLUWgv9GGTs3qOUoNY+qLMfau2DOvuRsdY1L/Q/9GYbq8+azeg5U7F5c/lT7sUOWpB4h4657n28/fDrAIyaNprDjt9DR3sHO7fspv31rYw/+7DEt5HEyJHw1qJXmbBxO8POPn7v923u12vfaCDat3Lq2xmoe+u+nYGmtx45Mvdv39aJOkOqWnueaU+dQTOdSIpaa6YTSFFn0EwnEnHrWugR/Shk696jlKLWPqizH2rtgzr7ka3WWujHIIRM3XuUEtTaB3X2Q619UGc/MtY6Mwv98NYdANjkqxp2Gx3/ekFjNhzI1IczNFJPZ2hc64Z1BrWugmbah1R3BrWuQqpbq3PFUt0ZMtc60UJ/+oPP1Gs/9hp69U858Op95/OHYPHmxe9n7ElTaZ19VN1vsxoTJxqdO/aw87WthPuf3vv9EXOTbDXue4+N6Ay9Wxd2BpreeuLE3NuH9W2drDN4bJ3GmVbn2mim46OZVuckNNPpl5lH9FMtQNiTnXuPUoJa+6DOfqi1D+rsR8Zaa6EfgxBgT3buPUoJau2DOvuh1j6osx8Za93S7B2ohz0/uqzZu5BIAEJ3KHmS9HeG8q0lJ+2tNdOVSXtn0ExXKu2tNdOVSXtnyN5Mp+YR/Sn3LqV70QK6nnkJgCHH9r68+9e/BqD1E1c1bB+62zvo7IQVf9gBf9jBGRva6rRhYHd2niZKYsq9SwEGbN3TGRrXuqczqHUjaaZ9qHSmB6MzqHUjaaZ90EynS2oW+tmWznuJUgu19kGd/VBrH9TZj2y1Tv1Cf8+tl8DQlB+BFMjU8WCNkInOoNYVyERrdS4rE51BrSuQidbqXFYmOkPmWqdqod9yzsKiLyqwoa389OLcU0nzG3gnrL3tHTZvDrTU++84QOjKzr3HeijWurAzNK51T2dArRtMM+1HuZkejM6gmW40zbQfmul0SNVCP7NCgAy9lZOUoNY+qLMfau2DOvuRsdZa6EciS8eDSWlq7YM6+6HWPqizH1lqrYV+DEKA3dk5HkxKUGsf1NkPtfZBnf3IWOvUL/SHXv1TAOZf2fjbWrlsCy0t7H1Lp7oJ2br32AjN6Axq3QyaaR80035opn3QTMcpAy+PTr+Q/7jlUqdyzOwsM2szsxVm9pUil3/QzNrN7P/yp39oyC8jJZVrXQm1jp9m2g/NtA+aaT+yNtOpf0Q/ExJ+3LKZtQI/BM4E1gDLzOyBEMLyPlddEkI4r/YdlcTU2gd19kOtfVBnPzLWWgv9Kuy3H4weZUyeNabu2074Vk7zgBUhhFcBzOwe4Hyg7x+VVKCnM6DWGaeZ9kEz7Ydm2gfNdOV06E4Met7KqdQJJpnZUwWnzxZsYRqwuuD8mvz3+nq/mT1rZr80s6Mb+BvJQMq1Lt0Z1DodNNN+aKZ90Ez7kbGZ1iP6MajshR+bQghzBrjMim+1l2eAGSGEbWZ2DnA/MKu6HZXEyrcu1RnUOh00035opn3QTPuRsZnWI/oxCBD2dJc8lbEGmF5w/mBgXa+bCGFrCGFb/utFwFAzm1TPX0MqUKZ1BdQ6DTTTfmimfdBM+5GxmdYj+lWY+8pLDdt2wuPBlgGzzGwmsBa4FJhfeAUzOxDYGEIIZjaP3J28t5PcaFY1sjOodUw00z5opv3QTPugma6cFvoRCCHQleAV3iGETjO7FlgMtAK3hxBeMLMF+csXAhcBV5tZJ7ATuDSEkJ03ik0JtfZBnf1Qax/U2Y+stdZCPwZ1+HCG/FM/i/p8b2HB1zcDNye6EUlOrX1QZz/U2gd19iNjrbXQr9HddmSv8/NDW83bCiHQXeGHMMjgK2ydpDOodczU2Q+19kGd/VDrgWmhH4ksfdyylKbWPqizH2rtgzr7kaXWWujHIEB3guPBJEXU2gd19kPQExrKAAAEkklEQVStfVBnPzLWumEL/VKHtvS9rFpJn5ZJKun+95X0hR/NVO4QJrXuLaut1bm3rHYudnm11DoOxf47aKYHltbOoJmuVppbF6NH9GNQhxd+SEqotQ/q7Ida+6DOfmSstRb6EQgZe5pIBqbWPqizH2rtgzr7kbXWWuhHIRC6s/NHJaWotQ/q7Ida+6DOfmSrdVUL/Xeefr7mY6HqeQzVQNsajOPEGvL7R3bvMZbOA20vtZ1BravcVmpbq3NV20ttZ1DrKreV2tbqXNX2UtsZomudlB7RT6gef8whQHeGjgfLKrX2QZ39UGsf1NkPte5PC/0YhJCpe49Sglr7oM5+qLUP6uxHxlq7WujX++mqet5O6MrOvcdmG6zOtd6WWtePZtoHzbQfmmkfYu4M2WrtaqEfqxCguzM79x5lYGrtgzr7odY+qLMfWWuthX4MMvbhDFKCWvugzn6otQ/q7EfGWmuhH4EAZOidnKQEtfZBnf1Qax/U2Y+stc7UQn8wj+Os620G6OxMvhkvmtG5brer1lXRTPugmfZDM+2DZjoemVrop1UAMvROTlKCWvugzn6otQ/q7EfWWmuhH4GQsXuPMjC19kGd/VBrH9TZj6y11kI/BiFbx4NJCWrtgzr7odY+qLMfGWuthX4EAtm69ygDU2sf1NkPtfZBnf3IWmst9GOQsXuPUoJa+6DOfqi1D+rsR8Zaa6EfgawdDyYDU2sf1NkPtfZBnf3IWmst9CMRQoZe4i0lqbUP6uyHWvugzn5kqbUW+hHI2r1HGZha+6DOfqi1D+rsR9Zaa6Efgay98EMGptY+qLMfau2DOvuRtdZa6McgYy/8kBLU2gd19kOtfVBnPzLWWgv9CGTtaSIZmFr7oM5+qLUP6uxH1lq3NHsHJKc7lD6VY2ZnmVmbma0ws68UudzM7Af5y58zs9mN+D2kvCSdQa3TQjPth2baB820H1maaT2iH4Gk9x7NrBX4IXAmsAZYZmYPhBCWF1ztbGBW/nQScGv+XxlEau2DOvuh1j6osx9Za61H9CMQyB0PVupUxjxgRQjh1RDCbuAe4Pw+1zkf+HHI+R0wzsym1vt3kdLKta6AWqeAZtoPzbQPmmk/sjbTVT2iv4qOTZ/k5dcbsSOOzOj7jVV0LL6s++VJZX5uuJk9VXD+thDCbfmvpwGrCy5bQ/97hsWuMw1YX2R/1Lk+amldqjOodYw0035opn3QTPsR/UwnVdVCP4Qwud47IBBCOCvhJqzYZmu4Ts/+qHODqLUP6uyHWvugzn7E1jopHbqTDWuA6QXnDwbW1XAdiZ9a+6DOfqi1D+rsR1SttdDPhmXALDObaWb7AZcCD/S5zgPAFflXep8MtIcQ6v4UkTScWvugzn6otQ/q7EdUrfWuOxkQQug0s2uBxUArcHsI4QUzW5C/fCGwCDgHWAHsAD7VrP2V2qm1D+rsh1r7oM5+xNbaQmjIIUEiIiIiItJEOnRHRERERCSDtNAXEREREckgLfRFRERERDJIC30RERERkQzSQl9EREREJIO00BcRERERySAt9EVEREREMuj/AZbaLrDyYqCTAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1080x504 with 24 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import time\n",
+    "rel=0\n",
+    "\n",
+    "if doanalysis ==1:\n",
+    "    conv=24*3600\n",
+    "    fig = plt.figure()\n",
+    "    plt.rcParams['figure.figsize'] = [15,7]\n",
+    "    fig.subplots_adjust(hspace=0.3, wspace=0.2)\n",
+    "    vs=range(1,ncases+1)\n",
+    "    ncol=7\n",
+    "    nrow=2\n",
+    "    count=1\n",
+    "    for i in vs:\n",
+    "        index=((count+1) % 2)*ncol + ((count+1) // 2)\n",
+    "        print(i)\n",
+    "        ax = fig.add_subplot(nrow, ncol, index)\n",
+    "        count=count+1\n",
+    "        #ds0=dse1.isel(realization=i)\n",
+    "        #dsdef=dse1.isel(realization=0)\n",
+    "        mod=np.multiply(np.mean(ds0.QVEGT,0),conv)\n",
+    "        plt1=mod.plot(cmap='RdYlBu')\n",
+    "       \n",
+    "              \n",
+    "        ax.get_xaxis().set_visible(False)\n",
+    "        ax.get_yaxis().set_visible(False)\n",
+    "        \n",
+    "        fig.canvas.draw()\n",
+    "        time.sleep(1) \n",
+    "        \n",
+    "if(delta == 1):\n",
+    "    if(rel==1):\n",
+    "        fnmfig='figs/ensemble_GPP_delta_rel_'+caseroot +str(i)+'.png'\n",
+    "    else:\n",
+    "        fnmfig='figs/ensemble_GPP_delta_abs_'+caseroot +str(i)+'.png'       \n",
+    "else:\n",
+    "    if(rel==1):\n",
+    "        fnmfig='figs/ensemble_GPP_error_rel_'+caseroot +str(i)+'.png'\n",
+    "    else:\n",
+    "        fnmfig='figs/ensemble_GPP_error_abs_'+caseroot +str(i)+'.png'       \n",
+    "\n",
+    "print(fnmfig)\n",
+    "plt.savefig(fnmfig)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Pangeo (2019.09.12 - py3.7)",
+   "language": "python",
+   "name": "pangeo-2019.09.12"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/jupyter_ppe_scripts/generic_ensemble_script.ipynb
+++ b/jupyter_ppe_scripts/generic_ensemble_script.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,14 +561,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "file does not yet exist: /glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_default.nc\n",
       "default parameters in/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_default.nc\n"
      ]
     }
@@ -595,7 +594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -641,7 +640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -715,31 +714,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_0/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_1/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_2/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_3/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_4/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_5/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_6/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_7/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_8/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_9/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_10/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_11/user_nl_clm\n",
-      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_12/user_nl_clm\n"
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_0.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_1.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_2.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_3.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_4.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_5.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_6.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_7.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_8.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_9.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_10.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_11.nc\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_12.nc\n"
      ]
     }
    ],
    "source": [
     "if(dosetup == 1): \n",
     "    root= '/glade/work/'+USER+'/git/'+ctsmrepo+'/cime/scripts/'+ens_directory+'/'\n",
-    "    fatesparamfile=root+'fates_params_'+ens_directory+'_'\n",
+    "    fatesparamfile='fates_params_'+ens_directory+'_'\n",
     "    vs=range(0,ncases+1) \n",
     "    for i in vs:\n",
     "        pftfilename = paramsdir+'/'+fatesparamfile+str(i)+'.nc'    \n",
+    "        print(pftfilename)\n",
     "        unlfile=root+caseroot+str(i)+'/'+'user_nl_clm'\n",
-    "        print('unl='+unlfile)   \n",
+    "        #print('unl='+unlfile)   \n",
     "        fin = open(unlfile, \"rt\")     \n",
     "        data = fin.read()   #read file contents to string   \n",
     "        data = data.replace('pyton', 'python') #replace all occurrences of the required string        \n",
@@ -758,13 +758,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_0.nc\n",
       "actual ratio: [0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75]\n",
       "target ratio: 0.75\n"
      ]
@@ -774,6 +775,7 @@
     "i=5\n",
     "paramnum=2\n",
     "pf= paramsdir+'/'+fatesparamfile+str(0)+'.nc' \n",
+    "print(pf)\n",
     "find = nc4.Dataset(pf, 'r+')\n",
     "vardef=find.variables[parameter_list[paramnum]]\n",
     "pf= paramsdir+'/'+fatesparamfile+str(i)+'.nc' \n",
@@ -792,1721 +794,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "submitting\n",
-      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1\n",
-      "0\n",
-      "RTM_ens1_case_0\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_0.nc\"\n",
-      "submitting job,RTM_ens1_case_0\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:23:11 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:23:11 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:23:13 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:23:13 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:23:13 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:23:13 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:23:13 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:23:13 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:23:13 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700331.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700331.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700332.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700331.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700332.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "1\n",
-      "RTM_ens1_case_1\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_1.nc\"\n",
-      "submitting job,RTM_ens1_case_1\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:23:18 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:23:19 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:23:19 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:23:19 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:23:19 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:23:19 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:23:19 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:23:19 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:23:19 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700333.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700333.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700334.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700333.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700334.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "2\n",
-      "RTM_ens1_case_2\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_2.nc\"\n",
-      "submitting job,RTM_ens1_case_2\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:23:23 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:23:23 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:23:23 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:23:23 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:23:23 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:23:23 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:23:23 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:23:23 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:23:23 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700338.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700338.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700339.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700338.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700339.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "3\n",
-      "RTM_ens1_case_3\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_3.nc\"\n",
-      "submitting job,RTM_ens1_case_3\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:23:28 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:23:28 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:23:28 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:23:28 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:23:28 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:23:29 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:23:29 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:23:29 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:23:29 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700354.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700354.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700355.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700354.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700355.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "4\n",
-      "RTM_ens1_case_4\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_4.nc\"\n",
-      "submitting job,RTM_ens1_case_4\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:23:32 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:23:33 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:23:33 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:23:33 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:23:33 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:23:33 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:23:33 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:23:33 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:23:33 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700359.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700359.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700360.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700359.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700360.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "5\n",
-      "RTM_ens1_case_5\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_5.nc\"\n",
-      "submitting job,RTM_ens1_case_5\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:23:38 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:23:38 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:23:38 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:23:38 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:23:38 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:23:39 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:23:39 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:23:39 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:23:39 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700365.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700365.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700367.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700365.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700367.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "6\n",
-      "RTM_ens1_case_6\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_6.nc\"\n",
-      "submitting job,RTM_ens1_case_6\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:23:42 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:23:43 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:23:43 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:23:43 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:23:43 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:23:43 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:23:43 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:23:43 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:23:43 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700374.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700374.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700375.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700374.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700375.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "7\n",
-      "RTM_ens1_case_7\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_7.nc\"\n",
-      "submitting job,RTM_ens1_case_7\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:23:48 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:23:48 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:23:49 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:23:49 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:23:49 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:23:49 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:23:49 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:23:49 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:23:49 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700385.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700385.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700386.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700385.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700386.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "8\n",
-      "RTM_ens1_case_8\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_8.nc\"\n",
-      "submitting job,RTM_ens1_case_8\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:23:52 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:23:53 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:23:53 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:23:53 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:23:53 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:23:53 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:23:53 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:23:53 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:23:53 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700387.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700387.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700388.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700387.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700388.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "9\n",
-      "RTM_ens1_case_9\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_9.nc\"\n",
-      "submitting job,RTM_ens1_case_9\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:23:58 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:23:58 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:23:58 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:23:58 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:23:58 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:23:58 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:23:58 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:23:58 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:23:58 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700389.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700389.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700390.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700389.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700390.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "10\n",
-      "RTM_ens1_case_10\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_10.nc\"\n",
-      "submitting job,RTM_ens1_case_10\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:24:02 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:24:02 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:24:03 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:24:03 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:24:03 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:24:03 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:24:03 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:24:03 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:24:03 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700391.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700391.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700392.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700391.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700392.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "11\n",
-      "RTM_ens1_case_11\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_11.nc\"\n",
-      "submitting job,RTM_ens1_case_11\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:24:09 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:24:09 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:24:09 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:24:09 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:24:09 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:24:09 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:24:09 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:24:09 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:24:09 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700393.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700393.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700394.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700393.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700394.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "12\n",
-      "RTM_ens1_case_12\n",
-      "!----------------------------------------------------------------------------------\n",
-      "! Users should add all user specific namelist changes below in the form of \n",
-      "! namelist_var = new_namelist_value \n",
-      "!\n",
-      "! EXCEPTIONS: \n",
-      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
-      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
-      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
-      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
-      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
-      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
-      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
-      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
-      "!                        (includes $inst_string for multi-ensemble cases)\n",
-      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
-      "!                        or set it with an explicit filename here.\n",
-      "! Set maxpatch_glc       with GLC_NEC                            option\n",
-      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
-      "!----------------------------------------------------------------------------------\n",
-      "\n",
-      "use_fates_sp=.true.\n",
-      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_12.nc\"\n",
-      "submitting job,RTM_ens1_case_12\n",
-      "For your changes to take effect, run:\n",
-      "./case.build --clean-all\n",
-      "./case.build\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "env_batch.xml appears to have changed, regenerating batch scripts\n",
-      "manual edits to these file will be lost!\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating batch scripts\n",
-      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
-      "Creating file .case.run\n",
-      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
-      "Creating file case.st_archive\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "  2022-10-03 06:24:13 atm \n",
-      "Create namelist for component datm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
-      "  2022-10-03 06:24:13 lnd \n",
-      "Create namelist for component clm\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: CLM is starting up from a cold state\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2022-10-03 06:24:14 ice \n",
-      "Create namelist for component sice\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
-      "  2022-10-03 06:24:14 ocn \n",
-      "Create namelist for component socn\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
-      "  2022-10-03 06:24:14 rof \n",
-      "Create namelist for component mosart\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
-      "  2022-10-03 06:24:14 glc \n",
-      "Create namelist for component sglc\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
-      "  2022-10-03 06:24:14 wav \n",
-      "Create namelist for component swav\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
-      "  2022-10-03 06:24:14 esp \n",
-      "Create namelist for component sesp\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
-      "  2022-10-03 06:24:14 cpl \n",
-      "Create namelist for component drv\n",
-      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
-      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
-      "Checking that inputdata is available as part of case submission\n",
-      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
-      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
-      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
-      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
-      "Check case OK\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "submit_jobs case.run\n",
-      "Submit job case.run\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
-      "Submitted job id is 6700396.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Submit job case.st_archive\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700396.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
-      "Submitted job id is 6700397.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.run with id 6700396.chadmin1.ib0.cheyenne.ucar.edu\n",
-      "Submitted job case.st_archive with id 6700397.chadmin1.ib0.cheyenne.ucar.edu\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%capture\n",
     "%%bash -s \"$ctsmrepo\" \"$defcase\" \"$ens_directory\" \"$caseroot\" \"$ncases\" \"$dosubmit\" \n",
@@ -2570,7 +860,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -2600,14 +890,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "dir exists already/glade/u/home/rfisher/fates_sp_ensembles/figs_RTM_ens1\n"
+      "dir exists already:/glade/u/home/rfisher/fates_sp_ensembles/figs_RTM_ens1\n"
      ]
     }
    ],
@@ -2616,7 +906,7 @@
     "current=os.getcwd()\n",
     "figpath = os.path.join(current, figdirname)\n",
     "if(os.path.isdir(figpath)):\n",
-    "    print('dir exists already'+figpath)\n",
+    "    print('dir exists already:'+figpath)\n",
     "else:\n",
     "    os.mkdir(path)\n",
     "    print('made: '+figpath)"
@@ -2631,7 +921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 168,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -2754,18 +1044,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "['dataout.nc']"
-      ]
-     },
-     "execution_count": 112,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "NameError",
+     "evalue": "name 'figpath' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [40]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m outfile\u001b[38;5;241m=\u001b[39m\u001b[43mfigpath\u001b[49m\u001b[38;5;241m+\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m/dataout.nc\u001b[39m\u001b[38;5;124m'\u001b[39m \n\u001b[1;32m      2\u001b[0m dsc\u001b[38;5;241m.\u001b[39mto_netcdf(outfile)\n\u001b[1;32m      3\u001b[0m os\u001b[38;5;241m.\u001b[39mlistdir(figpath)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'figpath' is not defined"
+     ]
     }
    ],
    "source": [
@@ -2776,41 +1067,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 167,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<xarray.Dataset>\n",
-      "Dimensions:    (time: 12, lon: 72, lat: 46, ens: 4)\n",
-      "Coordinates:\n",
-      "  * time       (time) float32 396.0 424.0 455.0 485.0 ... 669.0 699.0 730.0\n",
-      "  * lon        (lon) float32 0.0 5.0 10.0 15.0 20.0 ... 340.0 345.0 350.0 355.0\n",
-      "  * lat        (lat) float32 -90.0 -86.0 -82.0 -78.0 ... 78.0 82.0 86.0 90.0\n",
-      "Dimensions without coordinates: ens\n",
-      "Data variables:\n",
-      "    FATES_GPP  (ens, time, lat, lon) float32 dask.array<chunksize=(1, 1, 46, 72), meta=np.ndarray>\n",
-      "    FSR        (ens, time, lat, lon) float32 dask.array<chunksize=(1, 1, 46, 72), meta=np.ndarray>\n",
-      "    SABV       (ens, time, lat, lon) float32 dask.array<chunksize=(1, 1, 46, 72), meta=np.ndarray>\n",
-      "Attributes: (12/37)\n",
-      "    title:                                CLM History file information\n",
-      "    comment:                              NOTE: None of the variables are wei...\n",
-      "    Conventions:                          CF-1.0\n",
-      "    history:                              created on 09/30/22 09:01:33\n",
-      "    source:                               Community Terrestrial Systems Model\n",
-      "    hostname:                             cheyenne\n",
-      "    ...                                   ...\n",
-      "    ctype_urban_shadewall:                73\n",
-      "    ctype_urban_impervious_road:          74\n",
-      "    ctype_urban_pervious_road:            75\n",
-      "    time_period_freq:                     month_1\n",
-      "    Time_constant_3Dvars_filename:        ./RTM_ens1_case_0.clm2.h0.2000-01.nc\n",
-      "    Time_constant_3Dvars:                 ZSOI:DZSOI:WATSAT:SUCSAT:BSW:HKSAT:...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(dsc)"
    ]
@@ -2824,40 +1083,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 1 0 1 0\n",
-      "8 2 1 1 0\n",
-      "2 3 0 2 1\n",
-      "9 4 1 2 1\n",
-      "3 5 0 3 2\n",
-      "10 6 1 3 2\n",
-      "4 7 0 4 3\n",
-      "11 8 1 4 3\n",
-      "5 9 0 5 4\n",
-      "12 10 1 5 4\n",
-      "6 11 0 6 5\n",
-      "13 12 1 6 5\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+kAAAGeCAYAAADohUAvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAEAAElEQVR4nOy9d5wkR333//52T9zZ2byX8+kknbJQRAhlZCEEAtkEEU14yDbGGCOwDZjHsoV5bJlgG/QTGEQQYKIAgQIoIoRyOp2ku9Pl20ubw6Sert8f1dMzu7dhdifszE69X6+9m5mu7qru+XRVV803iFIKg8FgMBgMBoPBYDAYDPOPNd8NMBgMBoPBYDAYDAaDwaAxk3SDwWAwGAwGg8FgMBhqBDNJNxgMBoPBYDAYDAaDoUYwk3SDwWAwGAwGg8FgMBhqBDNJNxgMBoPBYDAYDAaDoUYwk3SDwWAwGAwGg8FgMBhqhBkn6SJyjIg8LiLDIvKX1WhUpRGRHSJyyQxlPisi3ylTfR8QkQMiMiIinXPYv2xtmWW9q7w22xWs41MicuMc971ARPaUu00Gg8FgMBgMBoPBMF8U80v63wJ3K6XiSqkvTVdQRNaIiBKRQHmaV/+ISBD4d+BSpVSzUqp3vttULEqpXV6bsxWs45+VUu+p1PErgVm4Kkt9JS1ceceYsc21hNFNWeqbk24qtaAnIi8XkefLfdy50Kj6qgcqtdBeyiJ3mdvRkNqrhb6tknhtWTfPbWhIbTUytTSuzjfFTKZXA9+vdEPmiojYlZxEloHFQATYNN8NMcweEflz4AKl1J8XfJxbuDq1iP3XANuBoFLKqUQb642ChauzlVJPznd7qojRTQnUom6UUvcBx8x3OzyMvgpohHNUSv3zfLfBw2ivBGbTt4mIAjYopbZWul1KqeZK11EERlsFzNc5isgFwHeUUisqXVeNjavzyrS/pIvI74ALga94K2pHi8irvFWtIRHZLSKfLdjlXu//Aa/8S73jvEtENotIv4jcJiKrvc9FRK4XkYMiMigiT4nICTO06Zsi8t8icquIjAIXztAmRORtIrJTRHpF5O9mdYXyxzhbRB4QkQERedITbG7bO73zGxaRF0Xkfd7nRwO51aAB73pOV8fxInKHiPR5K6qfmqTMEb8IFa7KeSu7/ysi3/Ha87T3vX3Su867ReTSgn3vFpF/EZGHvO/g5yLS4W0bZxnhlf2/IvJ779i3i0hXwbHeXnCd/2G2K9EF9b1DRHaJyOHC70tEot733y8izwJnTDjWMhH5sYgcEpHt4q26ikiHiOwRkVd775tFZKuIvH26tk3Damp40UUq6J5QJqq6cOXdM3dXo64ZMLopjTnpRmrcsquM+jT6qkHqQH+fnfjMNAeM9kpjwf6YI3pRoRSMtgyzpoae+0pi2km6Uuoi4D7gw57Z8wvAKPB2oA14FfABEXmtt8t53v9tXvk/eNs+BVwFdHvHu9krd6m3z9He8d4IFGMO/mbgWiAO3D9dm0TkOOC/gbcBy4BOYFYrQSKyHPgV8E9AB/A3wI9FpNsrchC4AmgB3glcLyIv8a7X8V6ZNu96TlVHHLgT+I3XzqOA386mnQW8Gvg20A48DtyG/q6XA58Dvjah/NuBd3n1OsB0bg1vRp/jIiCEvha56/xfwFuApUCrV99cOBe9inYx8GkR2eh9/hlgvff3J8A7cjuIiAX8AnjSq/di4K9E5E+UUn3e+f1/IrIIuB54Qil102wbJmbhqvAYFV24EpFzvIWald77k726jp1Le+cTo5txx6jGgqcSkQ+JyBZgS8HnH/OuUY+IvLPg81YRuUn0At9OEfl7EbFEJOy184SCst0ikhCRRTJh0VREPiEie732Py8iF8/lGs2WRtaXiJwpIo94xzwgIv8+l3P0tikR+aCIbPG+w/8rIutF5A/e8X8oIqEZ2nOB6EXhT4jIfuB/vE0hT2PDIrJJRE4v2Gej6EXwAW/ba7zPzxaR/VIwERCR14nIU97rwkXuiOjF+V7vOA+LyOJirmEpNLL2Jqm30mNi7to96V27N4pIu4j8UnTf1e+9XlGwz7gfSyZo5jci8uEJdTwpIld5r5WIHOW9vlxEnvXav1dE/mYu12g2NLK2pIb6NRGJAb8Glnl1joj+UexM7xgDosfUr+SOI5O4P4vu494jdTKu1gRKqWn/gLuB90yz/T+A673XawAFBAq2/xp4d8F7CxhDr45dBLwAnA1YM7XF2/+bwE0zlCls06eB7xdsiwFp4JIZjvFZtGkHwCeAb0/Yfhvwjin2/RnwkamuyRT7XA08XkRbLgD2TNi+I3c+Xtk7Cra9GhgBbO993GtPW8H3e11B+eO862NPbLtX9u8Lyn4Q+E3Bdb65YFvTHK5zrr4VBdsfAt7kvX4RuKxg23tz1wI4C9g14difBP6n4P2XgaeBfUBnkXr7c+Cb090T3ndyIlrbJwEHgNdOc0+8FtgKbES7nPw98IC37U+AR9ELTuKVWVrEPTEIvMxrQ2SGNh3naeI8IIw2s3Nm+V0tRy+oXe7V8Qrvfbe3/VXoxRQBzkff8y+ZzT3hlb0W+B0QBZ5CLxgeofsZjnEB2lxuxu+7kn9GN1XVjQLuQC+qRr3zctCLlEGv/jGg3St/E/BzdP+4Bj0uvdvb9g3g2oJjf4h8v3cB+T7oGGA3sKygveurpc8G1tcfgLd5r5vRJsOzPscC3dyCXnA/HkihF8vXoReen2WKcX/CdXeAz3vnEUXfA0lPdzbwL8CDXvmg16ZPoRe+LwKGgWO87duAVxQc/3+Baya5t96HXqhu8uo4DWgpQjefBT5rtFdXfdtRBe87gT/1vve4p4+fFWzfUXgeE9r8duD3BduOAwaA8MS6gB7g5d7r9lzbi2mv0daC6dcmzj1OQ8/fAl67NgN/NU07/e+SOhlX5/tv1inYROQsEbnLW7UbBN4PdE2zy2rgi96qyQDQh74Zliulfgd8BfhP4ICI3CAiLUU0Y/cs2rSssLxSapTifq2feA6vz52Ddx7non8xRkReKSIPijZTH0B30tNdk8lYiR6My8GBgtcJ4LDK++0nvP8LfY0Kr+dO9EPDVO3fX/B6rOA4E6/zGLO/zrOqw2trjtXoVb7C7+hTaDOyHDcAJ6An7lO2TUT+q+AY/wW8ueC4T00sr5S6Wyn1tFLKVUo9hbYUOX+a83sf8C9Kqc1K+xT9M3CKt/KZQQ+0xwLilemZ5lg5fq6U+r3XhuQMbfoz4JdKqXuVUingHwC3iDoKeStwq1LqVq+OO4BH0NpHKfUrpdQ2pbkHuB14+SzrAP1A0YperNmH7isWBEY3FdUN6GvVp5TK9XkZ4HNKqYxS6lb0g9Mxon+lfCPwSaXUsFJqB/BvaOsrgO+hF1FzvNn7bCJZ9EPYcSISVErtUEqVq0+fNQ2krwxwlIh0KaVGlFIPzvEcc3xeKTWklNoEPAPcrpR6USk1iP7RYUbfWK/dn1FKpQr0d7+n+yza0u1k7/Oz0WPcdUqptPdc9Evymrs591q0xd3l5K0RJ16HTvSkKquUelQpNVREW8tOA2mvkGr2bT5KqV6l1I+VUmNKqWH0wvZ017qQnzJe/28BfuJdg4lk0H1bi1KqXyn1WKltnwsNpK1a7NfG4fUxDyqlHG/c/BrFa68ux9VqM5c86d9Dr8isVEq1Al9FT7pBr5pMZDfwPqVUW8FfVCn1AIBS6ktKqdPQqztHAx8vog0T65muTT3oCTAAItKEHshmw270L+mF5xBTSl0nImHgx8D/AxYrpdqAWwvqn00d64soN4peMQV8f5juqYsXxcqC16vQncPhWR6jhwI3AhGJMvvrXEwdE9uaYzewfcJ3FFdKXe61x0Z3IDeh3SGOmqoSpdQHc8dAWwt8r+CYJ00sbxauKrZwhVIqg165PgH4N6XUZH3MEYjINQXt+iVw7oS2zjtGN5XTjcfuCe971fhAO7kFwC70L5iFi347ybvr/A6IetdmNXAK+uF2HEoHcvor9MLSQRH5vogsm6xh1dBnA+nr3ehnh+dEm3hfMZdzLCgzcZF74vtigmkdUkolJ3w2cfE5ItoUdBmwWylV+OBeqL/vAVd5zxpXAY8ppQq1muPbaAu/74vIPhH5V9EByY5AtEl07hpcA1xToL9fFnF+09JA2pt4DtXq23xEpElEvibanHoIbQ7dJkX4SnuT+l8Bb/I+ehPw3SmK/6nX5p0ico94ZtaTtOeIvqzwvYicO7szPOL4jaKtWuzXxiHa/eCXol1yhtCLA8Vqui7H1Wozl0l6HOhTSiVF5Ez06keOQ+gVosKUDV8FPikix4Pv+/d67/UZ3hcURE8+k+hVk3K26UfAFV7HEUKbO872vL8DvFpE/kREbNG+XxeI9vsJoVd5DgGOiLwS7Ws/W34JLBGRvxLtrxEXkbMmKfcCenB/lXfd/t6rvxTeKiLHiV7A+BzwIzX7iPk/Ql+jc7zr/I/MfqFiJn6I1lK7d+3/omDbQ8CQaN+VqPc9nSAiueByuSB870IvqNxUzCBWJGbhqjILV4iOB/EZtF/nv3nHnhGl1HUFCy1XoH/Faiv4rBYwuqmQbjyKWtBBL0hm0A86OVYBewG8ydMP0av+b0b/KjI8aYVKfU8pda53LIU2eZ6sXDX02RD6UkptUUpdjY6T8nngR6J9KGd9jmWkWO2BthBaKTquSo5C/T2LnrS/kql/bUJpC5F/VEodB5yD1tWkwVGVUlcUaO069K/4uesx3WSgWBpCe5OcQ7X6tkI+hjYJPksp1UI+NlTu2ON+2AGWTNj/ZuBqb9IdBe6arBKl1MNKqSvR99nP0H3iZOWO6MsmXJP7Z3uCE2gIbdVgvzZZvf8NPIfONtCCfs4u1B1Mob06Hlerylwm6R8EPiciw2g/ZP9GVdrE+Vrg997KxdlKqZ+iL+j3vZWWZ9CDDWj/iP8P6EcPQr3oTqycbdqE9nX4Hvpm6QdmlS9XKbUbuBItwEPoG+LjaD/6YeAvvTr70WK7ZbYn4B3nFWgf8v3oYEcXTlJuEH2+N6IH8dHZns8kfBv9a+V+tH/NrHNRetf5L9Dp+nrQPnUH0b4v5eIf0TrZjjYV+3ZB/Vn0tTvF234YfY1aReQ04K+Bt3vlPo++0a8pU7vMwlUFFq5ERNC6/Dp6VbkH+L+zPU4NY3RTmQXPWeH1CT8ErvUWR1ej+4vC/MffQ5vEv4UpJkmi8/le5D2QJ9G/TsxnetCG0JeIvFVEur2HvgHv4+xsz3Ee+SP6mv6tiARFBxt7NeNT334PPS6fh/Y5PgIRuVBETvQWn4fQC0/zpb+G0N4EqtW3HWD8tYuj+5oB0Zl5PjOh/BPAmzxtnY42vy7kVvTk53PAD9R4iw4ARCQkIm8RkValrduGMNoqtk0LpV87AHSKSGvBZ3G0FkZEB/T9QG6DUuoQeo7yVu9+eBdHWgvX47haXVQNOMabv/n7Y4bAgCUctxkdHGPtfJ9jpa8ZetDbiV6Y+CXafOo7Bds/h+5YB8gH/3gbOojdEHrR5xve5xejA6SNoBcavgs0z9CebwL/NOGzmdr0DmAXemHs7ygiCBsFAWe892cB96BNqw6hzeZWeds+hO7UB9CLKd/PtZHigyl+xLsWIe/9Mq+eXPCaGdvslbuAGgggYnRTHd14ZRXjgytdwPQBN9vRD9m5RdhPMyGYKTowT19OjxOPiw4Y9JB37fq867esWvpsYH19B70gPIJO1fTauZzjFLq5H/jzgvf/BNxYxPc5UWufnXCe47SM/hXvHnRAqmeB103YfxX6wfxXUx0X/YvU8+jJxgF0lpZi7pXPUv7AcY2ivYnfazX6tvejF6wHgDegx8W7vevzAto/uVBb69ALQSNee75U2GavzNe9fc6Y8LlCZxoKoTMP9Xvfz8PAuUVqQxlt1X+/5pX7hncOA57uzkP/kj6Cztz1OfSv17nyr0T/aDaAjvNyDxPmG9T4uDrff+KdjKFBEZ1H8DtKqRvLcKxXoyNGCvqGPAsdAdSIzGAwGAwGg8FgMBiKYC7m7hVHdJ7QkUn+3lLmen49RT2fmnnvOdX38inqG6lEffPAlWj/un3ABnTqNFXt62wwGAwGg8FgMBgM9Yr5Jd1gqANEZBPjA1vleJ9SaqporHOp59dMnhbmn5VS/1yuegrqezk6/ccRKKVmHW3UMB6jG0MlWaj6KqI9nyIfjLSQ+5RSr5zkc0OZWajaM33b/LNQtVVEe0y/VmOYSbrBYDAYDAaDwWAwGAw1Qk2auxsMBoPBYDAYDAaDwdCIBOa7AZWkq6tLrVmzZr6bYZiERx999LBSqnuyba1txyvHmdpNf2x0121Kqcsq1rg5YLRW20ylN6M1Q7mZq9ag9vRmtFbbLCStgdFbLWOe2QzVYqFprRQW9CR9zZo1PPLII/PdDMMkiMjOqbY5zggbT/nklPs++vsPdFWkUSVgtFbbTKU3ozVDuZmr1qD29Ga0VtssJK2B0VstY57ZDNVioWmtFBb0JN1Qp4ggQXu+W2FoBIzWDNXCaM1QLYzWDNXE6M1QLRpMa2aSbqg9BMSS+W6FoREwWjNUC6M1Q7UwWjNUE6M3Q7VoMK2ZSbqh9hAaaqXMMI8YrRmqhdGaoVoYrRmqidGboVo0mNbMJN1QcwiC2I2zUmaYP4zWDNXCaM1QLYzWDNXE6M1QLRpNa2aSbqg9BKygyQ5oqAJGa4ZqYbRmqBZGa4ZqYvRmqBYNprXGnKS7vwXxvmS5sDzHVHeV93jzgfvb8e+9a6TEQlzniM8LURM+E+VCOqHfhKLjygnnT9+OEn1ORCQC3AuE0Rr/kVLqMyLSAfwAWAPsAN6glOqfc0XFkL0jf72si8tzzIWkNeUW3IuWryNxHb3NOrKLmqg1AMl4WguEx5WrtNZqCcU9/usZz3uWxy3n8apN4XUpRJSrt0+mJ2/bVGQJY0lm/D5V0JqIfAO4AjiolDphku0XAD8Htnsf/UQp9bmSKp0Eo7WpmUxv02ktt33SMRRwVBTbSo3fZvq1shx3IWhNKW/MlHyfldPTZNty2ycjo2IErMQRnzei3sqttXIfs9pMN45O1a/ltsP4vk+UO+kYCo2ltWJozEm6obYpPXpjCrhIKTUiIkHgfhH5NXAV8Ful1HUicg1wDfCJ0htsqFsaLFKoYR4pj9a+CXwFuGmaMvcppa4otSJDHVMGrdXKgpChDjDjqKFaNJjWzCTdUHNIieYsSikFjHhvg96fAq4ELvA+/xZwN2aS3tCUqjWDoVjKoTWl1L0isqY8LTIsVMrUr30TsyBkKAIzjhqqRaNpzUzSDbWHlB4YQkRs4FHgKOA/lVJ/FJHFSqkeAKVUj4gsKr2xhrqmDFozGIqielp7qYg8CewD/kYptakalRpqiDJozSwIGYrGjKOGatFgWmucSXqhb/A0/hNzQt0FOZ9tdbv2pQXIOhCpwUXmQt/zqa5Fga+wFPoNM7Vf3bjdxYJwrGB/7T9d7K0lgWnNWbpE5JGC9zcopW4YV79SWeAUEWkDfioiR5jrVYzsHfp/sfJ/5aJQa/LbvNbcLAQvK1895WRirAPIt1usca/H+cpZgaK0BqCCOu5BBbRW00zlJ1buY7vqvnHbLHl5xeothdlcj6l80VVBbISpsFUKRRExDyYef2atzdi3zcBjwGrP1edy4GfAhlk1cgqy6gGASf0ISyX3vSllobjP+8z2fWoD1tllr7NUitGaUhYi0/tswuRazH0WIIHCG4tnobcqaA0quCCU63OkAs/jGfchbLFwecCrK4DraS1sn17+CktkKq3l9HXE69yzm/d+ot/wVHoMMjonrUF9j6OO++ARcR/KRVY9gHjX1OUBv0+D+urXZtLalMebom+zyI8jjaS12dI4k3RD/SDMtFJ2WClV1EiqlBoQkbuBy4ADIrLU+xV9KXCw9MYa6pqZtWYwlIfitFZ03zYZSqmhgte3ish/iUiXUurwXI9pqEOqoDUquCBkqDPMOGqoFg2mNTNJN9QcUmJgCBHpBjLeBD0KXAJ8HrgFeAdwnff/z8vQXEMdU6rWDIZiqYbWRGQJcEAppUTkTMACeitaqaHmqIbWzIKQIYcZRw3VotG01jiTdPsVs98ndeu49GGM9PkvVSapTYxzWAWiKTRBHv6mv10CIQh6KaKy2bzZshXI23Q1XzX7dhbL0P/q88m1odDUuJCciXahSXIu3ZdzO2IH/aLFpF7QpvOza2qJKRaWAt/y/NIt4IdKqV+KyB+AH4rIu4FdwOtLqWRK5qI153YouK4+2QxjLAVg1OkinT0NS7RuRFwyrtZnOmsTSetnJkscYkH9nNRi7YRMimy4A6B6plaJW/Lp0wLB8Sb/hZordAcYZ+p+8ay0Nu7Y1dXavDKXlC55M1IvxZOb7+OyKuiVCQAdXh3570X5ZnvaqtXCxRZtJmiLc0S53L6V1JrjPuibYM/FNFY4P2/OP8P+M6XSmrGu0lOw3YwOftklInuAz6ADY6KU+irwZ8AHRMQBEsCbvECaJWPLObPeJ+M+BDAurVPSaQPAUSFAm7ULOjyIiDuuj8oqPVZZ8gJC1tdsQNJ+GUeF/PdCtqLmygnnSQJWTu95k8+pOCL1FedX1G1gXF0V7tcqvSA0W5eaybQ2lF7ufwfpbMwfL0XWYUvG15pL/vkt6w4RskcBsCVFxB7G9fqzrBv2j2dJhubA8XM5taIYzmwGIGSNErCCCNlpyxfeOyIuwvk47oMAM5pyF7qZud4YMNsfK+t5HJ3L+JTKPuLrBHS/lhv3CrEkesRnub4PdxNB0Xp1VXCcOXmWAGFr1NtmVbRfG3OeBiBoJbAnuErk2lPIZP0azN5tIK/X2bW3nrU2Wxpnkm6oH0RKje7+FHDqJJ/3AmVKVm5YEJSoNRFZiY5+vARw0X6dXyxT6wwLiRK1BqCUunqG7V9BR+Q2NDJl0Np8LggZ6owy6M1gKIoG05qZpBtqjwbzOTHMI6VrzQE+ppR6TETiwKMicodS6tnyNNCwYDD9mqFalEFrZkHIUDSmbzNUiwbTmpmkG2oOEbAbKHqjYf4oVWteSr9cWr9hEdkMLAfMJN0wDtOvGaqF0Zqhmhi9GapFo2mtoSbp7v0fB0CWLgHH8+9xXUgm9evmGLLh46jt1+v30TgM9+vX4ch4v1rXAcfzwWyK533X0wlwPF8z5cLgoL+LioShrVu/ObgPQp6/bajAV/3Q9WAHIOW1yVXQpFOZEYn55aQtv8itHv8stLXm21a4fyAAI57fTGcXEu/W2wHcTN4POBCa4IMueZ97y9bpvnLk/NOTv0S8NGtz9dGcHMFaAD4nyezjZNyI7+MVtodJZeP+9tbQUQAMprcSshYzmFwOQEBSjDnaHzgaGPBfBySlfYYs7X+ZzsY832EYzTj0J/U1i4eiOEofK2XH2dLfhOU5/XQ3hWgKjAHQMzpCV1R3dgqLwZSD42prxXWtB4kH9wPjfVEf6BlkeTwCwEha67/Fk27UHmDXsNbh0ti5dAdf0O1Ww1pL4+I2eFaR2UzeIUmpfJlc2rac1tzfTpvKTiaLrVAU5dOal1P4VOCPZTngLNg9OkoscAjQvm06PZi+JkErMU5rQasNgLQbQ3An9T3LqkDeLxN3nP+wriPg/W9hie4DQtYoaddLu0jebxNAZV/wXztudNz2oJX09hnvT9yX2kHQ8y/VfstZr21hLHH8NoStKDnrt8K0LhOZ6O/s+/9xjy/BnM9wZfyFF0a/9tCBYVa1aL9Di6zvz9ufbKIpaLO6WXcIe0eHCFqrAUi5zQT82AX62ub2S2djNAV0vJeQPUo6qzWU+34BhjOtBCzx9RALHGYwrfs4Edf/3JYM6aQfzwwAx/NrD1mjfj2WZIgHN/plHjs0Qmc0F49BEbHH/H0tT3cDKZvu6BK/XxQrrydXWQSsvJ98DiGLq4J5Pck9eBbjCOdP6kc9kbmNrQtDa08cHqE1rHWQdFwC3jmlsy4BS1+XY9qibBtKEg0cDcBwOkxokl/a3AJD/KbAGCKu31/lNAIwlskCehyzRGgNNzOY0uUCBdc0aCl68e4DcUg6+e8pZFvEAoe9fVK0hdb52zb3a23FgjLOhznpuEQ9yScc6Ii0+dsscck9rrvKGhf/I9eX6vSF+ngWDpbcg0hea8ns4wCE7fH3RyFKLERN7/s+OfWvt9z3srjpIJa4fnyWoXQ3Ie/eXh5r4VCyx9tjOZbj+ONSwEr7fZYtKT/+Qcge9WNmOCqkfc+9fVLZFtIS8/cPovuBlBtHcEmo3PeXJZF9UR/DDfv9XVYFPG3gx4Yp7Nf2jQ3oY0vKj2WUi6mRa5/jhonl5hWui1j6eFk33/8GrLROu8aRzwqWZLx+DUSCCOeTyj7in/t0zBTTY4q9StaaiFwGfBGwgRuVUtdNUe4M4EHgjUqpH5VU6RxpqEm6oT4QAbuBfE4M80cRWisql7CINAM/Bv6qMOqxwZDD9GuGamG0ZqgmRm+GalGq1ryA0v8JvALYAzwsIrdMdFH0yn0euK2E5paMmaQbag4RCARMh2+oPEVobcZcwqJ/rvgx8F2l1E/K2T7DwsH0a4ZqYbRmqCZGb4ZqUQatnQlsVUq9qI8n3weu5EgXxb9AP9edUUplpdIwk3T3lv+DHH8sAGr33gJT9SikPVO0/gFUz9+M20+inhl7oMBsIxSCdBqV0mYjYg/kTdddN3+8QADV75nLO442p/dsrtTwMNLdpbeNJVCD+/39JRjS7codL2faEY1rc3pA7fwiHNameyqThm3bddncPi3arFpiMW3yDtB7GBUIQd8e7zyieRP3plYk4Jl8hZtAkTcvHhuCphb9usBkWY0N6rRyAN6+vtmxXIh65p/068XLIPBd/XHHW5gZwbLqt8PPmZXZkgELbBn2t4Vt/dpVgQLzM72tLbQb0GZEOZO0rArTGdmqj4fWbLbgts2ZVy1qyptaNgd3+Saj/akltEdcIgWdWs7MaVnzKMPpmNcGl0VNeZNLSxzGnHbv3WbSbjMAJ3aN+CbPbSELSzL+e8cNsTKuzy9kjZJ0tQaH0scSkBTJrNZQa2ivfx0KTe9EuWTJpVzKIAVmnq6ExplaFe6DXIiLl1bMcgHP9Kqo9GSlaU1EBPg6sFkp9e9zPtAceapX90vLYgP0p5YAkHSyNAVt37zTEhhI677KVSt814eglSAgqYKUQnkT8qwK+umvbEn537FSOu1U1g355XLmc5Y4OK5nWmyPopRFyvvOFZZvbmdLhqxXj8LCVjnTzQDDmc3+Phm3heHMUq/deVvViD1G0Er47R51uogEBgBtSl9oOhyQtG9mPdEUPusWai2vrYwbJWRpc0QRd7wrhed+0Z/aQdQeRORxr01HJJOYhPru17YM6uu6tnWEhJdGTWH51zdkW4ykHbYM5lL7BXCV7jeagjZJr9+xpImQncVxc+buitFMu3eMTv+7dlzl91tJJ0vAskh6/YNSi0h4somHMiQcXc9wOost+BpvDin/eIWmxRk3yu5Rfe8MpSAasDwzZ81YJuztH8D1+tuWsEPGjZLy+rX+9GpCXookhUXEHgAgaCXHuWlYkvH7z5A1Ms6VIum5PzWJc4SLRa7/2jKYoC084O2/1XddmZ761hrA3XsG2NBuMZDS30vuO82R8FwWN/WNErItRr3vLGCJ77Y1msmO2y9vBd9EwIqRdLRWU1mHsK2vVyRg0ZvQ30XItkhl46SyWmzRgEVW6YMMpFzsXEpAy8IS/HotUb4JvZsNsHNE3yP9yfx3PJrRZXP9dCRg4XrHtkToS7YB0BGBvtS6AhPnoO/aFLJH/TRdkDd9T2RbidqD4zQ16ujnzaCVyKesLHheA3i2b5Tu6Ih3TjvoCK+hOOpbb/sTh1nRrK9pKttCVuXHq1hg0Dd97xnr810IQI95uXFSubbfF6bdZn8sTTr5MRL095dz+YkHexhxFgP6WS5D1HttEbRSvqtkRuXTuFmS8Z+fUtm4/10GJI2jQvSM6XmBiEvY1prJFLiYJZw2QvZoPnWqnfKfF61AhrSnk8JUam5Wu+wUpr70Uxu6zYSsEb9the0NqPSkrmPC+WzqG6UjoutoChTbr+m9S9TacmB3wfs9wFnjahBZDrwOuAgzSTcYxiMCAWM6ZagCZdDay4C3AU+LyBPeZ59SSt1aatsMCwvTrxmqhdGaoZoYvRmqRRFam8lFcTKH9ompI/8D+IRSKiuzTeJeZswk3VB7CEidByEx1Aklak0pdT+Td/oGw3hMv2aoFkZrhmpSot7qKZCXYZ6ZWWszuSjuAVYWvF8B7JtQ5nTg+94EvQu4XEQcpdTPZt/g0jCTdEPNISLGv8lQFYzWDNXCaM1QLYzWDNWkFL3VWyAvw/xShr7tYWCDiKwF9gJvAt5cWEAptbagvm8Cv5yPCTo0wCTdvfMv9Yu2VtSTzwCQPTCGfYz2dRQ7gHI8H8ahYVTGRWW0r4WEbQh7/ieWBc2x/IGdfAo2lUz5ft9qKIFK5tNjKM/hSCyB0DBs0+kbJGjl/d1dFwmHC46dRR3S6TskGs37z7v7fd93WftR1Ji32Li7FyIRJN6cP4bXVrXpOViySH82loCdu5HV3iJSug9yfvGDB317D2lfhnIdJJT3gyHj+acEQuRc+6TjLeDcrl8rV/u3Wxf7u8iJf6/b8PQ/QauXIq6DGRHAmiSFSj2QcJ700znZkjoixVUOWzK+z9NEUtm4v09Yhn0fdBEXWzIEvLQvEWuYlqDW08S0LDk/tXjwIBk36qcrCtmjtAb3+uVag/o79n2IPD8lF8v3P4rYpzLibAJy6ZJ0nAUh66f/AMhaeV8twE/b1RneSlaF/dRxCovhzBK/vnx6InC9tB9CFlGO/xu1JS8HdZfeX6wjfOkseTmgr3/O/6sY67t61tq2oSRtYX2Su4ZbOTymU8gsj+u+JOn5bI5mXNJZfb1cpQjZudQpNvFQnNZw3s8s51Oeymp/ToBYsM3fx3EVQUv5fpm2KN/3LuG0+boNWCncgnRn4/zd3ZCvfYXrx0iwrRTx4EZctdVrQzyftstO+6mwAlaC3uRiYsGU3+bBdCcA8eDguDrTKkgaL+6CNeTrVXB9H2WF7Ru7iWi9u+o+/zi5FFiFMQ46wmvoTe32/UQjRaRtrWetbeobJR46Mn1d1B7wfRstaSFkhwnI5OnEhrI5f0uFqyzSWf19RgK2f68qhJF0Lj2RIuONn2OZLE1BCHq/oPQmbRw3t3/U9w1uC1t+OkmAvcNZWsN6n6QTIuGs8NuzvkWnktziJDgwmqa7SfdXIVuwRXmvh+lPNgHQEtL1HRjTzw7xUMr3O7bIMpLJ+5a2h3cCOrVXqMBnOKvC2F7/LZJPl5RVD+jz99MavdzfZ0NrlM39uj2t4SitoUkv7zjqWWuPHNT+tt1NQdKuzYFRLxZCW9T/XvRDiJcqSum+KqeNkG2RcHL9HX7fF7AE27smrlKMZVxS2cJyjl8ul2rNFu1HXpi+Led3bgu+PjNuFldB2M6niLMk/zy21uuTHVcx7KUuDdmWr1fQY+HOIX289kjQP4feRBPdTS79Sd1/toZtP1YHGXytKWX5/ZGrgmTcfGpKW6AzvNJrw15/XHUJjNPa8R0xNmmXZuKhFjoKHkuno0S9zVsgr10j+no1BVL5lHmSHjd+ZVV4XMrQ3BjiuGFEXPpSej5X6PedVUIsoMeicCAfk8iSDI4T9v29syrsx+VRyvJ90C1xdao2r66QjPjbHBX24wsASM73XbVxcKyF4zti/rnlfM0j9pDft+SejxJeat+wPezXM5JZ7I+5qWycqJeyMkMU140TVvpc0m7M94vPpZnUr11sgebA8d41etDXmlLWEVrb3J+7HxcV1a/pOkrr25RSjoh8GL3YYwPfUEptEpH3e9u/OueDV4AFP0k31CEiBAJFPPUaDKVitGaoFkZrhmphtGaoJqXpra4CeRnmmTL0bV7MoFsnfDbp5Fwp9eclVVYiZpJuqDkE409nqA5Ga4ZqYbRmqBZGa4ZqUoTepgvmVVeBvAzzS6P1bWaSbqg9TKRQQ7UwWjNUC6M1Q7UwWjNUk5n1Nl0wr7oK5GWYZxqsb1vwk3TVm/dRlNacT/lY3p98cBCSnr91VycyMoI0aR80kkntxw0QCev3gBoeQ405iOeIqJJZ8PzM1FgGlfX80CM29hIvT/BQQjvJev7uKumg9up+yLo8b2Xh/u6v9IsRz4+ttQVO1X63E/M+y8Zr9LG2vx9cF7Vd+yZZV/2PzqMO0NUBQ8PeuY7g9iVRO7RPcWBFHBLaj5VAALG1HNye/Ugshlq2Wm9LjULCa09THIb+Vdd/zN9C4NKCBjEpOd90AOcbb8ZaFJ+8YK68gLUAVsoUtu9vC4zLF+mqIEHL821SYZSyCNn6GrvkfZMKc/u6BPx8lDlyvkRKWVheHvWMihEUfayUG8eWFF1ervWgdSb+eKjuIpDeD0A6cAIiru+DNFFrOR+jQ04PaVffR0FJELZPJuM+BGg/+5xPlohLkIK868r1/eX0tdBtTWdjvt+c4Po5rnX+c4uE8yQA0cDJvv+5+P8cSTRwsv/6YOKA7wc/FfWsteG04+f5LfSjtEQYTmd938nupiD9XpyMWND2/TDzOYK1b+5gysFx836ZubzRI+ms798eCdgsjoWIBb2+sMDvPGCl/PdjTgfLmtr8bfvGBnxtBKyUr/V4sOcIreXypY45fX4+2f1jzZzUqXXXm9pNyLb8e2sk7XBgVH/PrgqytFn7BreEGZcHPkmrr69Y4LCv46wK+37VWfUibaF143znpiLn4wnw/ECC0Ax+cvWstYyryLi67VFgJK1fj9DqxysA7XNriRffoiBfdci2GE7r78gSGbcNsrh+jmqH9oj+zpWySLvaUTFsW6Syrp/z2haF1xwOjaU5vWBMuXfvgH/szXsHOWaZHoMvXvX0EVoD7fN934u9JDubvDbYnLtMx1DZN5YaF7MhICmavdAbqWyEkNe/WFbC76sdFWb3yFHesSw6wi/6edKzbsj35RzKjLIyFvPO5xwApvqRcGO790xCE7/e0ev7z09FPWstF5PAcRWRgD0uHoblvU5nHT9GQlbpGAK56+8qRSxo+/s4bi4/tOvH0tA6yv9Ya0k+X7mr9DH8OiXft/Yls5zSlfc1f6rX68dCur5cn3ps+8OTam19S4THDo34+wykspzUqe+Xw8nDdDd1eOfnkvv6IgHb779B99P5tioOeTESogGLpTGd63vU6SadtWkK6Oe7MSfpx2AIWGf7x5pMbzmfZoCbntLPqKs6mo4sWECJepu3QF6F8YJy48mo04WI6z9ruSrox54I20OkHS/eEzaxwOH8Mw/5Z5xAwXNbk91H1vMbt8QlEhr268qoKOLFWtExh1J+nUmnlUXRxf5xcvnPAbYPar31jKS4asNmr/7z6Y7kz21Vc5SfbtV6WN/e7Mds2NjexMHEASKez7yQJR48COgc7rlYQo4b1fFaAMcNobA5mDwWgKCV8J9nbXHyz4RWkoOpPpZ6Op5Ja/l+DR7o0e3pjC7cvm0uLPhJuqH+MJFpDdXCaM1QLYzWDNXCaM1QTUrRW70F8jLML43Wt5lJuqH2ELCDcw8MISIrgZuAJegQsDcopb4oIh3AD4A1wA7gDUqp/pLba6hfStSawVA0ZdCaiHwDuAI4qJQ6YZLtgs43fDkwBvy5Uuqxkio11B9Ga4ZqUqLe6imQl2GeabBntoU9SR/di4S1+assX4bKpdi4aA14pndqcBDJpQdricPiRZBLjTY66puKs6gg5UEgBMkxVK9nGjwwSHaPnutZHRHcYX1se1krzlad1sEd1qYhORN5u6sJNTB2ZJsdBwIBrNf8f8Wfp6tQh/qwX//NfBtXf8T7HzJfe5Mu1pfEXhnHXqbTFUk8rs39AZJDZL3UJxILQnsccmng2tsg4tnRjOxHHdCmMWrTO7Gu+p/i25lr7mTnXYAgpZqzOMDHlFKPiUgceFRE7gD+HPitUuo6EbkGuAb4RCkV5ci4DvsTh0llj6XZMx3KmUvlTIZEhcaZp2f8lET6Nky5ce9Y0XyKqgJz4qCV8MyM8tty2x037KdRC1tDJNx8rruAlSKZjXvHyLdZiYVEtfZb5Sjv06OnPU/HDTOQagO0mag+5pn+9lzqKoU9ru2AbxamsPzUIACDGZ0eLmoP0GQd9ApbuAR887ERZ5Nvcl8s+8eamSlTRxm0VnUcleFwci8dkQ4intl4xo2ytlXrLeumybhR36TclpSf3iRoJcaZ3jYFD/vf0+Ko45v1jWQWMZrRrwdTjm9eO5x2CNvaLA5gLGP5pqEBSwh7Y+dwymVZgYVkYQq27shSwEshNI3eCl09cqbuoM3MO8Nw954BQJt8toT1seOhAM1B3deOOUEg6puKhmxhUVMuxVyLb0pviUOGqLdPB73JvGnobHAnhjqaQJm09k3gK+hFyMl4JbDB+zsL+G8mREqeDaMZl4cODJN08imuoJ1mLx0ZwFBKv864eTNjGG9S3J/MjDOLjwYshj2z5oTj+tvGMhajmUBBOd1nbO0fozMaZPtY2vvcZklzLj/U+At/YCTN8ha97UNnrynYcqT5cY50JsuvHtwFwPVvOMX/vNBl42DigHdeOZcQ2+/PXfLnHZAUkYB3H6UdRtKr6IzqfsyWDCmvL7Yl45tLF+p7JmJBm4FkZtoy9ag10FrImad3RvU1XNvqpWnCJZ0Vb1vC77dCBWMq6PRQIS/NlBXIm4mLuOPKjGYUUS9K9GgmS9T7dS6X+gzyLhthW5fL9XU5WsO5lKEuq5oLUtZOo7Vcmrb+ZGacm0ZXZDldXrdz954B/zosioXpitp+fzWSCfguS9oVKZdGLsDWAf1sFwtCyFaMZHSbhtOOb058ztLWKds2kfZm3e8nnOy05epxHB1zXA6N5VIbdvom27m0uUlHXyfbSpP13G7GnA5/HBNcDie66E/mx5HcfZ/OunR7fcdQZomfHjftxrDE8fuAwVSIpTHtcph0Wnx9RgMD/licI5nVA2pzsJ9zli4t2LJoynMcHtNtu+XFPfz9pcfk9ygwo084T/rp5lwV8F0tXWURsPT+QSvrm/cDHEq0k3HXAdAWygfmT2WDNAX62Duqr9HyWMuUbZtIc0jvk0v9OhX1qLVSWNiTdEN9IpRkzqKU6gF6vNfDIrIZnebjSuACr9i3gLsp0yTdUKeUqDWDoWjKoDWl1L0ismaaIlcCNymlFPCgiLSJyFKvTzQ0CkZrhmpixlFDtWgwrZlJuqHmEPADBJV8LP2QcSrwR2Bx7gFCKdUjIlMvQRoagnJqzWCYjippbbKcw8vxFi0NjYHRmqGamHHUUC0aTWtmkm6oOUSE4PQrZdPl3Cw8TjPwY+CvlFJDJr+mYSJFaM1gKAtFaq2ovm26aib5bAZDfMNCw2jNUE3MOGqoFo2mtQU/SZelSwBQiQTipTthZBQ62vT2pijEPB8dy4JUAsZG8wfI+aK7eT8lxka17/hhzyd98SICi/WPsmpvD+KlWctsPkhwfbt+va0fe3EM5fmrYwvZA57PaGGDAwHcfb3MRoLWFV+bdnt6k/YjCaxuIbO5l5DnOCprVyNrN+hCqVHk/gcByB5KwL4RlOdkabUe8FPHOftGsLu1n5OEA7NqJ0DgXd8jc+PVM5/T9D4n0+Xc1G0TCaIn6N9VSv3E+/hAzhxPRJYCB4ts9owodEqo5uDBcak7bCtFUPLpqvw0PQR9v2xXBXBUeFyKslyKDqWsvM96Nk5WBbA8H7zRTJfvE9kU6GMwrX27BZeIPQRA2B5GYRGQI1ORHUocSzyo/aGiRfYEudQaU+GnNFH4qTwyKspweinRwAAAIWs0n+rNdfxUHgobZQXyn6skWdF+WUFJMFtO6oz5Pp/TUY/+TQqdsi/l+ZcHrYTvNxewEoTsUcLWsF8+W9DV5/Rp256/pu9Xm7+blbLojGgf3M4Ivp9aJNDFQMphaUzry1V5PYxlsuTcOQ+Mpsel8rHI+jETiqXQH3gyXujRbVja2eT7aMaCNu1hnYqyK5Iio6IMplYBOj3SVi9MZMCyCdn6nNJZl8FULkVdwveNmw3HtEXZMjizRovQ2ox92wwUk3O4aER0eqrClF+WgOPqMSQaGKE9oq9XLt1dwmkDYCDl+KnQYkHb9+e1RMb57+8cTPhpdxbHQjyyQ/cNoZBNtxcbYOveQX7XM0xTVH9ny7pjsFT7O7ZFguPaHAoI927W2i3W//b9Z66GM1dPWyargigsHFf3SbZk2Deir0Mu1kGOnO+m0EEqm/eXdlTY78/TbshPeTgbzlvexu92zxzvtN60BnqGvzyuv3Odgk0K0l8NY0tea7klgkS2jXTW9rUWDbh5f14V9j93CkQXshWt4YB/3wPsHdZ+7G2RoJ9yrTUcGJeSLZUdvwaRj8fhUiyF/eJUHBhOsTiuz2H/SAoIEwvqe2RJ0x4/pVfPaLdftyX4sQq0xrK+v3TQkjn9+vjqdfr593+fn/lRqd7GUQE6vf4kaCXGpY8NWSP+s4dSFpb3bDaYbuHQmH6ec1xF07gYHHosAT3WbB9IeOVaWOrFz/jdcwfpaouy3OuW7t20279uy7pTrOvS2ljdupyoPTCuvbk0o9vSYS5ZVdw5vv2kZfrFSVOXCVoJ/3kz7cZ8//SnDrWxskXPnyJ2mtbwbrqCz+r3gWU4btTfPxenA3Q8m/yzbPE+6bm4HA8dGJ6hZP1prRQW/CTdUH+IQMCe+0qZF3X268BmpdS/F2y6BXgHcJ33/89Laaeh/ilVawZDsVRJa7cAHxaR76ODeA0aH+HGw2jNUE3MOGqoFo2mNTNJN9QkJa6UvQx4G/C0iDzhffYp9OT8hyLybmAX8PpSKjEsDBppVdYwv5SqNRG5GR38sktE9gCfAYLgpyy6FZ0Says6LdY7S6rQULcYrRmqiRlHDdWikbS2sCfp2SzOE9sAnRote1jHOAmceSxqr7bKklWrIOGZVyRTMJZAjtFp21SqwFRWKciZplkBOLQPOclLHRpr02nZABYvwRa9ymO7WdivzYkDYxmsjetwX9gOgLNnWJuVA3lDQrAu+o9Zm5DPROxLdwKQ+IdXYXdFST91CIBwfAs07QVAuruw1mkbGlmaQFYuR21+HgC3bxSV1WZTdkeE7AEvhVrQYryhYXEE33Mz/J/vT7ldRAjOlDtrGpRS9zO5vxzAxXM+8HR1IjiuzUCqm24v3U5ToA/HDftm364K+qaOIWuUQ2l9vVc1P+WnSNPHsnE802VLXA6M6XQbreFRAlY6b/odHJ/WLMe+kQxrWrUZVtBK0KT2Qsr7zppP9svpNBz5VBzlQLzUMyn3cfpSawFtmpjMNnEooU2+YkGb5bHNAERGXiBse2kAsxk/TaJKJ5DmDgIpff9I25I5tWem1Ealam0+cJVNMtvCUAoiXgqhA6NhVrdoM/ZUtoXm4AHfvLzQzSIWOOybs+XIpQi0yZL2trWHd/oma5Y4vjlcc/Agi6OQcfMpynKuC5as4cCo5xYzIR9ZYcqXcvHeM/T9843H93DCMm0/eGgsTVtYu32E7FFC1ghrWwcAnT4nauu+/sBYG6OZXOoiCHsr80nHxZLpU8BMRS4l4VSUQ2tKqWl9hbxI2x8qqZJJ2D2U9NPc9YxkWRzzUhJlorSF9fUazbaSzip6RrTZ8OlL9pLKanNHIevrLGf6PZrR39kJ3XE6IgMA2DLAxcfoez1kZ/3+0hLY8mIfx6zR7mOHB5L0tqS942Rhcb7/vHJ9N1eu7y73JWBpUwdbBhN+6riAZZP2+qvnehM0h3JpuqAl3AbA8ubDiHSwdyQ/UuZMqQ+OjjHXZ82LVrZPu71eteaqvH5awgF6Exlfa+lsjKaAfg4ZznT65tuDKYd1rdvGpfXMp5EKYAe1TvqSXf7+seBhbEnRFGjzzsViaUzvM5CyfTP4kJXGUWFGvO88Z86cY2189qkai+GNGxf7KdMOjToMpx0Wx/T4eWhskW8+3RZO0eZZ9kcCg4w0abfLXP+7rFmf04sDKd/0fS68/pjpY+zW4zgqgn9N2iPRcebuOdcx0Kk8cykin+sd5sJV2pVmzHM3zPVnWRX03f1e6Av4/eXSWJqQrcfIlx/dTTwUIOmltFu1JM4dd3lzlBMX++49AUlhW+NdFM9eUrzp+GwIWGczln0BgJ7RJcSCue8xxWOeS1lz2GZd2zr/HonaA/5zaLYgVVzQSnjp6+be1jML+vLJqEetlcLCnqQb6hJpsBQLhvnDaM1QLYzWDNXCaM1QTYzeDNWi0bRmJumGmqPRUiwY5g+jNUO1MFozVAujNUM1MXozVItG05qZpBtqD5GGWikzzCNGa4ZqYbRmqBZGa4ZqYvRmqBYNprWFPUnPuow+rH1ag/Eg4VO0X2Tm95sIHKVTS6S/+1vsZTqNkbNnmNBpy5FTta+c2AFUzl89k4BB7VdCMgndi7SfOiCxdlCeP0s4BhntU6VG+1EJ7QssKxaRffwFnD36eJFP/6KSZz4phx7cx4q/OJ3gZet1+3p7Ie35KQ0Nw2rtQyyjgxBrRVZ7PurDz5PZpX1TotfeWlIbel53Ft2vXj9tGQHsOgsMYUuGltAhhtLdjGS0/9ahxCosgeagTpfTHX6OIUf7y1ri+P6IAStBkzi+T11UDrJp+BwAMq5iSUzHRghaCcLWkO/bGQscJuv53o057YxltJ9TazjAktAfAVDDh6HtauYUPKAEHBUildX+VQkVIZ11GUlrP7+RtENrSF+jkfAimjyf5iZ6YEDfr4Si0HwV0jz3Njx0YJgV8en9i+tRa0pB0rHY2j9CwNKD1VHtTRxO6H6rOaTY1LvcTy8zmHJYFdf9UGtoN1kvhVRWBciqsJ/OB/BT9SmscWlVcv7pSln+frnP+5LrADicyHL6oun9ySrBtj2DXOj1552RnnGpDV0V9NNhhawR//yWxFwOjnUCsLU/5acamivffHIvZ62awU+Y+tMaaB/qgCUcGtPXLha0eWq/HsdWt0d5rlePd61hh+f3DbHG8ylssvv8653KxnGU7rd2DLWQdFxWt+prkXSgOaBTPGUJ+PEqMm6EkYwes0dSWV5ywhL2HdJ9YSqT5erj5hanohRcBfFQPu3SWEYKXuu+ZnVr1PdbT2XjpLM2Owd1u3sHkn4sBeYoud/t7h+X+mky6lVrWVfxwGathUXtURZ3ROlNaA0tjoV5rF/3Q82RjJ/+bHk8QpPdh+X5FCeybaRd3QeMZsJ+DIC2cL8/Xka8OChBS483jgqR9FIHprIhIt4k4FACgpZTVNq0crN3SN9XnU1BVrZEfE2NpB3fZ35Fcx/JbJu/T0D0PmkVZDST5ZQuPYCuap5d+sscX35Ax1BaMlNsF+pPbwKkvZR6PSMpX08j6SzL4+GCdHtZhlL6ukYDFk2ef3lA0iSzrb4v+6bebgZTep/juqL+80481OPHSDi6bYCMG2UgrTMXOlmXk07S/dgJazs4vqsJgOWxKLNJX1YuApbQl9Q6swQCnu+3Tq/qsnVAp3RbGusalzI4R1dkOZ1h6AwfsWlGnvdS1iWchffMVgoLe5JuqEsaLcWCYf4wWjNUC6M1Q7UwWjNUE6M3Q7VoNK2ZSbqhJmmkFAuG+cVozVAtjNYM1cJozVBNjN4M1aKRtGYm6YaaQ0QaaqXMMH8YrRmqhdGaoVoYrRmqidGboVo0mtYW9iS9fQ1tN959xMc9rzuL1j06p3DkkqOQ9doX2w4EwHUh7flapBPgaF8UUqPg5SSWdcdDMAy2d/myju+TrvY8D3HPN7FnD7LU85tLppADh31f9LGPXUroJO2XG3jHd8p51lOSHEjh9iewQ9o/RsIR1EHtr8niRajHHtGvQyFU/9M4Wwf0ObmqZF/0HF2vWod94sw+6fW2UhaQEJ3hlZ4vTj536u07+2gJa3+uZPxMIrb27R/NjHdItN1Rojkfn9EhWjyfntbQPsKW3sf2fIRzvp17Rk+iNaR96vpTS1jUdEjX47SCpbUpbVfD4A9QB3fp9xs+XsaznpoDY+uJBpIALIs+TiLbQSqrv3dXwXN92lfulEV7cHM53tNjDLacC0BbaF3JbYgFLYLWyLRlStWaiHwDuAI4qJQ6Yc4HmgVh22JDa/SIvNw/3aq//+6mEGtbhZbQDgCWx/K+5Vk374OeVWEcFfb9GMP2MMKR/mAK2/fzFnFJZeMEPK26KujnYH9Jd5T/fV77k65tj1bNPz0WDZJ0cjnPA357ktkWwvYwQ2ntR5dVQd9XtWck5edDL9UfHeCsVe10RQenLVOP/VpTwPL9Wgv5wWadK7g3keE4b3tLyGFRrJtcCtuMG8VROt9wVgUYczoACFiKk7oP+Hl2rUimIK91kEcOrgBgfVuWLf36u1zdFiXZHCLmxVm4+rglfh7pkG1VTWu7hxK0RXQbVsXHsETHgUg6rp/P+9nD+VgR2/qy9A4O0tykt/n+6CUQCVi0R6YPMlKPWgMdT+XvLz1m3Gcf/8lTgD6fC07R9/KxnTFCXh5pFyHtNpNxdX+YcaN+PJSwreiKbAHAlpQ/hma9eBU53+CAlaIv2QbAoqaUf6z+ZIbjO2LcvWcAgMWxEBvbmypx6kfw/E4dy+aY1e0sbQ77OdqH01lfg8/2ttPsxUhIZ9t8v+rexBivWttZchuiXq7vla3T54OvR72FbWvSnNy/2t7LiwMJ1rVpDcRDlp93HmxfG0pZCK7/3hLhrKVezCl7H4si+vvKEsDx8q7/vqeT47uaeOaQfi45bmkLQx1aTy3hgB87oC+1g6CVIB7cWIEzP5K9I7rPzbguK+NadyORRf642hYJ8uJAguVxrYOe0RCd0fxYWo4c7rnYEwu1b5srC3uSbqhLRCDYQCtlhvmjDFr7JvAV4KayNMiwYDH9mqFaGK0ZqonRm6FaNJrWGudMDXWEYFlT/xkM5aM0rSml7gX6Kt9OQ/0zvdZM32YoH0ZrhmpitGaoFqVrTUQuE5HnRWSriFwzyfa3iMhT3t8DInJy2U+jSBb2L+lOL4z8RL+2A6hBbYq59Kd/HFdMbb4OAFmxETV0EDWin7kl3oWIXsdQACkvDdH+F5GVG8HR5hlkHdTO53SV9z+FxHLm5DbWmafqMs0BkvftIfZ6r1LbwtmpzfWq9SUc/fCzpP7tKmzXM83v7YUubRKl9u4j+dsXAQge3UHmhT7w0rw4/UmmN3YqnuB7bkbt+vK0ZaQg9UPdoAYhdStYFgS0rfpYtotLV584rtiYo6+xLSlCtpdOKNuCkCWc0fpU8S7aMruOqEJEm1Y903sUAL98dDt/eZE2j1of+A1D1nEAZK0QrqcqC7RrxoYzy3u+M7C+JQKJ2wFQ+/YSGRnmlKPPAODmzRvZ0OWlm7MHSWS1yehg4AT6U9qcsS1UehuO74iRym6etkw9as1VCRLOkwSslJ/+JeNGed1R48eRvpTux2Kh3aSy2hzNUWFCORcAFwSXrKeVkcwi4sEeAD/NH0A6G2PE0a45Q+l2XKVY0rQDAEsybOnTOl7dHCblpaHaPZSsmgnypy45micO63PKqqBvVh22h0ll4zzXp+/HpqDNobG8+0MuZdZkJo+zZWN7E8OZndOWqUetZVWSocwLhKxRbNHpOocyS3njxpVHlN05kuK49scZzOg0k6NOF/Gg7tNsHF9TdlOc4fQSOiPbALDEJav0OPvgvi5+dIceS9/0J0fTFNSft0cCOK7N1oP576/VM8XNmZZXg0tWdfDrHb0ArGnJu5F0NwU5MKqfB/pH0izzTGWdrMtRS+JkfHPZ0jlnaSs9Y9OvC9aj1gAclWEo8wKg04kNppfzhatOOqLcU72jHNOmyw2mV47ruwAsz20n5TbTm9KuU4sim3G81JFKWQykV/ruFCE75qecbAm5fnqpzQeTnNLV7JuRHxpLV83cPWf2/0+3P8/6jiZ2eunn2puCbB/QKTWTaZeVbfrprD/p4HjPdmmnPHp7z2n6Pt8+nJy2XD3qzVUJMu5DgB4Hc64Pr1q7fFy5nSMpTu3WzxGjThcjjk4L2RLswZKM7z62Mg6jTjcAEXsYy+svHTfEz57VZW75xWN8+gMv5ZRFeo6QdkN+OsWhVL4/CVhpP81pNchp+qEDw4Q9l0xXBVjfrl13nzk0TDRg++knE47rm8JHypSz/Jyl+jmw0n2biNjAfwKvAPYAD4vILUqpZwuKbQfOV0r1i8grgRuAs+ZcaQks7Em6oS4R8HObGgyVpAitdYnIIwXvb1BK3VDZVhkWIqZfM1QLozVDNSlVbyJyGfBFwAZuVEpdN2H7W4BPeG9HgA8opZ6cc4WGuqUMfduZwFal1IsAIvJ94ErAn6QrpR4oKP8gsKKUCkvBTNINNYkl5gHDUB1m0NphpdTp1WqLYWFj+jVDtTBaM1STueqt3n7ZNMw/M2htph9WlgO7C97vYXotvRv49awbWSbMJN1Qc4hA0PwKYKgCRmuGamG0ZqgWRmuGalKi3urql03D/FKE1mb6YWWynSf1DxGRC9GT9HOLb2F5WdiT9EAImrSfA24W6dLpTxT3+EXEdZB1ns9TIIh0rkT17dXvU6P+/hKNQ0r7AZHN4D5wJ7JR+wAzNozarv0RnZ4Rwmd79fSNoDY/r6s/METsS3f69Tb962/KfrrFEP7YT1DbrwfA2XyAwEuP1q+f2OGXGfljD4neBM6Y9qlZdcfjJderHv4H/WL9scjSDTOWr7vnC7FQ4RiuCuJ6PkpBKzFOa64KEvZcfZWyUJ4fZiSxHSLNZII6FZStUsStPbpgOoE6rBf9sstPY/vQMZzQqTUVOGMDHUEdX0Ed3AtLtB4XhZ4CeUW+bU2vnbRXqjjR1+j/k/9G5o5HCGzfAUDkqH/0/YH3jJ5Gs+e3OpDq1r7sJaIGbgZA7BDh5o4Zy5eiNRG5GbgAvXq7B/iMUurrcz/izFjiEAkMAPgaCtuZcVoDaA3lU5nkyiedNj9ljPa7TPi+bw4Ou0d17ILuyAu+v/uh5NEMp/XrpiCMZlz6PD/P3kSGS1blU3S99YSlZTzT4smlCetLHfa1FbIs+lJtuEqnmNs5mGDXfp0iJ5XJcs1FR5dc7/6ETmHZGtxLLDA0Y/l669dsyRAP9uj+yvMpbwvtRvGiXyanweVNQURcOsJ621B6ua+1sD3s+/lm7ChZAmwf0j633dF+tg7ouABtEeGcM/Tz98qWiJ/6KJ11sUR416n5Z/PjO2IVO+/peOUaHcelN7Wb+7Zr//SXr+1k2Evd2t4cYtTTYFtTkIyr/H1KZe/oEK3h3SyaId0f1J/WAAKSJBbQ95SrAnRFtqJI+NtzWjumLeqnU+uKvMDh5NEksrqvbw4cpCmg/VqT2bif3u/xQ0dzVJu+/9NujB2DQs+Q9rVe25H3Mz+UCPv+wVcfp1PoXrSyvTInXAR/f+kxPHF4hP29OvZHS7SVx1/Q12hJZ5MfB6R/KMngiI6L8OnLji253rv3DHB8l772K2K7Zyhdkt7m5ZdNSxxsL/2oq4K0hXQTFFv1/xP6NYCW4F7GPJ1lVZCApGgJ6jS4TYF+P4Vpb+ooP7XpEweDnL5Kj7Ghq05gWXPST8XrpJezpEnH2Tipc7HftpZg6WPTXDhzcZwRzzV+70icVXF9bo7bRMi2GPTui3go4Mc/mCxF52w5lOwh7l3HRdHEDKVL7tv2AIVBVVYA+yYWEpGTgBuBVyqlekuqsQRMdHdDzSEIAcua8m/G/UW+ISIHReSZgs86ROQOEdni/T9/o66hZihVa0qpq5VSS5VSQaXUikpP0A31y0xaK7Jvmykq7QUiMigiT3h/n67IyRhqGqM1QzUpYhztEpFHCv7eO273I5npl81PTLbdsPAp9ZkNeBjYICJrRSQEvAm4ZVwdIquAnwBvU0q9UPaTmAUL+5d0Q10iUvJK2Tc5Mnf1NcBvlVLXeQ8c12A6+oanDFozGIqiVK0V6bsJcJ9S6oq512Sod4zWDNWkCL1NZ4JcV79sGuaXUvs2pZQjIh8GbkMHKvyGUmqTiLzf2/5V4NNAJ/Bfov3fnfmKTbTgJ+nK8k7RmvxUlRVAguM/kw4vBUNyGCzPPjmdRjnafIWsg5x8GuzTJu5q7z6S9+rXhx8/wJJWbdoikQDuTm3Wkh1M1c7FjmgzwcyuIbKHdYBMe2kz4bN1+qum13+T5OvOomlR+VKNyGkXAPp6F5McpJTojUqpe0VkzYSPr0SbJQN8C7ibCkzSLcn4qTcm25YzvSss48a6cVXQTwFjuUmUrXOQjQRW0LTCM4Pf/xTHHr6TxHd/D8BJ565Cneudkm3T4ujURYSi5T6t0ghFCL78BJwH9fPd687/Az/d+1IAzlvexid+NgBAwB7i2lcfX3J1qtUzifVM1GainqMgyzTnOJkOI4EBsm7Y3zfrhnE9sz5LMnRH9KLxQHol+0d1j3Xjrc+wYZ028btw42KSjsvOQW2SNpbK8pLu0s3dykXQSvgmeb0Jm+ZQlnVt+nwvWNHGrwK6Py/XV744umlW5SsdlbZSiLi++8Nk2wAsMuP0GA/2+ObuQtZPC5lRUcacDhY16efs0UwXS5u1BvcOJ2mN6b7vhb4xljbr7y5gCalscfdztQhIihf3aPPicNCmrUn37a3hoJ9O6AebD9DeFJzyGLNlWax417N61Vqu35qs/8rpK+c6kaMr8oJvhizikslq3WVVvn/b0D7I7mFtQDeQdOhPptm8Q5vFJ9KOnzYP8N0VaoX2SJD9vdrdcn/vmJ8P2hLh7Sfp57Z3f/UPtHWV75ntvOVPTzu+TKQEvfm/bAJ70b9svrmwQKV+2cydX87sfbJthf2aUhZNttZMxo2Oe6bLuBGG0nruEAkM+ubyZy3Nu/q0R9axb0SxzBsyo/YAWVW+/qEc2Ojxc/PBEUA/ey6OZUlnXT+t6k+3HvJTYJbD7agzvLVaWgNAKXUrcOuEz75a8Po9wHtKqqRM1My80WDIIVQkMu1ipVQPgFKqR0QWlbsCQ/1RIa0ZDEdQBq0V67v5UhF5Ev1r1N8opWa3kmCoe4zWDNWkFL3V2y+bhvml0Z7ZzCTdUHOIiMldbagKRWjNYCgLRWptur6tGN/Nx4DVSqkREbkc+Bkwc6ROw4LCaM1QTUodR+vpl03D/NJoz2xmkm6oSSqQu/qAiCz1fkVfChyce+sMC4lGWpU1zC9FaK0k302l1FDB61tF5L9EpEspdXgu7TXUL0ZrhmpixlFDtWgkrZlJOoB4EQGdFCpY4M/b1I64Xj6CyBXQ99V8+V07UcrzoQgESB7U6THEFrKHtf+JvbQZ5aWQabqu5IwRZUOW6sCasevfywtn6LRdK85bgbN9AID9Xz6Jdfc+xeG3vAyAJ487lo5V2tdp5W8em1OdaoqYAJO2j4r4Cd8CvAO4zvv/5+WuoBhyKToK/c5B+0TlfJuwX4HrpQWN2MPYyvO/616DGhog8hqdMtB5bDuB5ocBSJ77TsL2sHesc6pxKkUjKz8EKyGw8rsAqJE+nKy+L9TAzXz+tVcDcP++Qb5w1xYA7vzNFm77/OVzq28Wvk0V0lpNoeMd5P07bSvvfxewziaR2ey/H8noNDBKWb7f9tpVbTz2mH4+b2+JcFSBD/obN+bTxtQC8eBGztZZk/jmk3tZ1dHE4THtN/zh/3cft3z2UkD7Cl/3O+3auHF1O1eu765428qgtWJ8N5cAB5RSSkTORGdwqUqQJRF3nNZEXEK2HheVsghaOr1fb+owWTfEjkHd/zUFXaLe8LD10Chxz4c7HrIZSGa8MjZnL2mpxmkUTWvoKD73Kv36Ldffy8UX6LSE4a4YNz2l75e3n7SMH285yFcf0jFrArbFe05bOenxykkjaC2d1b6wOY3lU7cFiQZOBqBvdAjb0vf/nuEw6WzWK6PYtX/Y11o6nWX/oE7Hlkw5vPeMVdU4jaJZ3RzmX648AYC3ffE+upZq3+DDg0m+/MB2AL7+/pfykZt1zII3fP4uAH74iQvnXKcZRzUiru9fXnhNQvYoSlkErLMBGE0d9rcfHOskEtD7xIO97B/Tvurt4SGWxMLsGdaxNlrDATa01lYMody9c/Vx8E+363S/px3dRWc0xN5RvS73uqO6+d3ufkD7px/q18+oc71vjNamxkzSDTWHCARLuAkny12Nnpz/UETeDewCXl+GphrqnFK1ZjAUS6laK9J388+AD4iIAySANymlionVaVhAGK0ZqokZRw3VotG0ZibphpqkFHMWpdTVU2y6eM4HNSxYGsl0yjC/lKq1Inw3v4JOP2locIzWDNXEjKOGatFIWjOTdEPNITRWYAjD/GG0ZqgWRmuGamG0ZqgmRm+GatFoWlvYk3TlImPab4JIfGq/aM+3XI32I3E7/7mbBUf7MxEFWfZ+XW7nF1GJBNnNewEIfOCDhG/R6UPdjIvy/G0H799D9/e1b/HeV5/B1seGOX/vc+U8w5Lp7/PyRP6xhyVnaGfO1tUtfE+O4c1K+6PsPOZYnFSJeUN7d+n/7QASniGvopQvj3G1cFWAhNNB2o0RD+4HJs/zqvD05WYRpX2DHauFrAqQdvV1iQfzfuV24mdkozpbnDWyE445C9n1FADBxYtgQPsIHUhsYG08og/9s3eT+J32gYx96c5KnO6ckID2QX3CvZJzV3r3VW8f7/7+HwDtU5fLcX3s+86ccz25XKWpbJym4AwxjOpQayC4KohS1jj/8qnIuFFClr5/C/3rFDa2aD9ugMPJvX5e6z3DaV669FEAHmpey7LVbQD0Dmjfsz8/WV/jt1x/L1tv2wbAH3/zzjKdX3l4cc8gAdsiGtb3XCgU4B1fuR+Ab334XP5uq9bGrgMjMEef9JxfrCUuljjTF65DrSksHDdKVgUJWSPA1P6DSlmksnEi9kDB/vraO24I72tgSbSLnrE+co8fe4eTXLbmGQAeCx7rx6sIWELPkNb3Gzcu5tc7eukd0f3GW09YWtbzLBXXVdz3B93nLn7lsaxo1/fRdb97gWsuOpr/fHAHAK3NpeVEHkyvxBKHkDU6fcE61BpovYw6Ojdzk903rdaGM1oD7Za+7q7SenLcsB/jYHmshS2Dus8aSiXZtHsAgA+fs4sXetZgOfoihUI2jz+nY8le/4ZT/HgVh/oS/NufnVzmsyyN9q4mEqP6Pogta2FRu44X9JrP3u7H3Hjnf/2eWDxcUj19qXXY3jNMxB6cvnAd6k1hk3TaAAjbQzP0azoeRiQw4I+frgriqDCRgn7tULLH2ytEf1KPB2viW9k3quMzJrJthO1hvG6M0xfFOZg4AOh+tTtSW/3aisU6/swfNh3gqrNWEQ3okBO/2p7hVWs7AbhzVx+dy0qLF9KfWu2/ji5ArZXCwp6kG+oSQWGLcW0zVB6jNUO1MFozVAujNUM1MXozVItG05qZpBtqktlEezQYSsFozVAtjNYM1cJozVBNjN4M1aKRtLawJ+ljo6h+z/wk2AeD2lRDbdmGLF+mP2+O4W7X5lKyfBmF6zPSdjVMYp2mnn4W2bCe4AX/7n/27K/fB8Dxf7qW1MExALJOXkh22GbtcbWVagHgrG1Hmt/3vuJULnl9h//+tOdLN9FP3/BjAJyeESIvXzFtWb1SdqSpeC0zmAryq22LOa47RnNImwJvH0jwwHMHuegE7UbguIp0VmvivOXPExjTaXoOWmeyrKnNNwctRI0NsV9dBMDyNm0Cr3JZLnqeRxavBWBN6n+BtwEgG9bTdOJxlTjN0mjRAfVPKfgoGT6HL78n3w3lTKhK4eM36fv8hT88wVmvPmbasvWotawKMOp0EZQEjtImjY4K+abXASuNJRkSjr6Hg1bC31fIErYnT428Z6SVVXFtenfO0jXA+QD88dE/cNZpWtOJlMMjT/X45u6di2JkL15b9nMsB5971fh74LETFxMO5m+ya199fMl17E+cCOiUTs3B/mnL1qPWhtNh7tlzFEd3RAl4rhW7hiweflHfY+cfs4jWsL5/73j+IC9f38Xy5hf9/ZsD+hrbE/q2vmSYZc3abFSnVtNa23d4G2es1+bOB0bTRELWuP06m0PUIjd/7Pzx75/VLk8nev3Zh85eU5Z6rvnuYTbfu5Mr3n7KtOXqUWsACSfiuyslrA7GnA62ey42HdEgMe/+3TucpC2SfzgTcekM69R2wfGS4Yn9OjXpMV0x/uKcXF+1lmeef4STjtWuZL0DCdataPX3sb3AVDlz31riS285bdz7z/1GP59dfMlR/mf/88GXlVzPj59SpDL6OqxavPCe2QaSQXaNHA1AJGDxfK92IbnriX287uzVfr/2m2d6uPxEbYa+IvYCjtJ9UDy48YgJVNIzi48FhY3tOe2cTzqrNWiJQ3+yifXt+ZlGzsWscJyuFXLjPN7/m/q0Ho7rynfol6zqOGK/2fKhr+xk6y+1i8l5H5re1bEetVYKC3uSbqhTFELjrJQZ5hOjNUO1MFozVAujNUM1MXozVIvG0pqZpBtqjkZbKTPMH0ZrhmphtGaoFkZrhmpi9GaoFo2mNWvmIgZDlRFtvjbV33wjIn8jIivnux2GMlAjWjOaagBm0Fot9G2FiMjfzHcbDHOkDrVm+r86pkbG0WIwWqtzGkxrC/qXdLdvhPRNtwEQPHkJ6ce1f/qun22h4+h2AALRIKMHtC/Kkqs36lWLRcunPW7/DzbR/ro0HHMPAML5nLFF+wXtu/JMOs/W/u7Jh3r8fZb86EH2vvqMsp1bJVl5x3+w57KPsvWlJwAw2OcQb9HrOS88n2XlCu2XcvKzxfuqP/dtXXZoGFZv7p2htJo5ndH8shx4QES2AzcD/9uyZAPfvOkxjj55iV/oucd7GNs3xF2dOkXK2O4hjr14HQC7XrqKtyd+DkDL6ccAbZNWpO69C+fSN+rX3INwPuL5b9KVQA1o38cXgm8k530tx38Ktfm6Mp5u5QjbQ34qHdzfctFfaN+tP33bKWx6/hD/ee69AMj6jxV9zFRSr7J2rG3joVtfmKF0zWjtCE0ppSbNH5dxQ+wdWUHAEtrCAwAknDZ2DGqf4bZIkLBt0ZvQeV5Wt8RwXO273hw8OGUDvnvvi/z5BesBaA/f4+vs6+9/Ke//n4cA+JOXr8VVeX+6L73lND5y8+NzPulq8k+vPsw1P9P+c++98Y+ceJz2Rw0GLA4PJAG47ZuPcd/3ri76mHdty39FazpnSC1ZO1orluX9Qyl+9NutrFrZxopF2sfyrvu38+S3ngTgJycvJjum7zcrHMD68Nlccaz2KY8G+qY88KGxDBlXP36sbM5r7aMvX8+vtuvxYXk8wva+MX+fV67p5He7p/f7rxXedJxOX/qTLRv5weYDbPFSf8Wbgjy/TZ/fy89YydXHLZnqEJMSCtksO2ERz2w6MEPJ+tMa8MBQIs2Pn9Df8cYVrezqPcQTz+pz7eqM+ekUM1nFqiVxAJLdLaxpGZv0oAA79umUTomUw4mdjwD6me0rbzudrz6k4xG1NofZc3DE3+fjF24A4J/vnGn8mH/+4TJ9fb50/0rfP71/KEliNM22p/W2y193HB99+fpZHfcPD+9msE/7ScfbIjOUriu9LQceGBxO8YMHc99/iHvu1rE0dvziBe5d1UrGO/fWkxcTCOjn37edFkWYOh1xzq+8NxFFkZ8fnL5Ia7VnrI9YMMreYX2tVsZ0mkCAfWO1NcGcjOM69P2za+Rstg/rMfOx/UN+3vLNO/t59znxWaeSe8lLlrHIS+N22IshMTX1p7VinuumwvySbqg5cuYsU/3NN0qpjwKrgH8ATgKemt8WGeZKrWhtMk2JyK9F5O0iEq9aQwwVYyat1ULfVoinSUMdUqdaWzVjQUNNUivjaDEYrdU3daq1OT/XmUm6oSYR3Cn/agGluUcp9QHAmE7VMbWitUk09R/AR4GZfjYz1AnTaa1W+jbDwqDetKaUapzkxwsQozVDtag3rZXyXLegzd0RIbVDmzodvGcXOzZpk6hMRvGiZ6bY2iosXqlTKiQe2EtTcxgJeak9psgG1fnt++l927l0XJX/bP+fnQ1Ay8o44U/+DIClaPN3gMGdQyw/a3YmIPOFcD4rf/MY287V6YVaOwJkEtq85LhTwgQ8k7Pdl72Elb95rKhjDuivgaPPbKVlZRzunK5+hVVjK2JTISInAm8KRwKsPbaLj15+DKvcXwIw9LqTGUitpDW0F4BLr7iHlg6dbuMdJ29l20t/AcD67y2CtZOng7Ku+h+WZB8Z95l791/ruo85Fln6XgCOAdLX/ykAwUtPQ23ZpstsLN+5VgLhfFq8201t+hFfv06f2y+f7uFL9pdIflObzCb33kL7N+4p6pjPfPdpAB75RYy3fnvNDPXXntZymgLeCPQCnyrcnnVhOJ2lZyTJjh5tXjc8NkQgoE3ODvUluOAly32zdEvCLG3WJsgBK0VkklR/AF+46iTfvPO4S/Kfv+Hzd7F6g+4MX3dUNxzVzfnv+AEAzStaWbq6rfSTrgLC+Xz+tfr1B7/1MIf69bXrbo9yz2/0eQfbo5x+3g08cu97izqm46XZfOq5g6y7YHpz0lrU2ky0NIe5+Jw1OFmX0YRueywe5sS3nQSAZQkvPqxTSZ58yXr2HBhhzwqdrmll3CU+SQpTgAtWtHH7Ts8cviv/+d17BuiM6p3OXBznzMVx//PhtMPiWLjcp1gRcub7f7oBfrr1EOu99F6DIyledZ52eQpa4pv2F5t6Mt4S4RUvXe2n8rxpyvrrT2sAtmUx7LlP3PbIHvbtHCDg5VQbHkz65ZyMy76eIQDSJywhEmhn0RQZbnOm619+YPu4z7/zTA/d7XqnP92wyP/8B5sPsHmH1uYxq9vLcFaVJae1j5wLn/z5MwA0RYPs3trHZVfqB4BoOOCnBSzWxSIxmuGKVx0LQCwSnFJrug31p7eO1ggXnKivRci2iMf0PCB96QYi4QDf/ZZ+tj3zwnX+Phk3SkBSUx5zSVR3ZgknOe7zgbQ2pQ/bFkubOljVHPXKPclgRrvXNgf7mMrtsVbIaW11M+wc0ddhQ0eMLX3aZfjd58QJWaMks9oFLmKfWtRxI+EAn3yt/q1rz3CYm/5iujbUn9Zg5ue6qVjYk3RDnaJqLgBEISKyAbgafcNlge/Pb4sMc6c2tDaFpi5VSr047Y6GOqI2tFYsIrJh3fEnz3czDHOi/rQGXL3q2BPnuymGOVE/estpbcOJpm+rT+pPa5TwXGcm6YaaxKamA0Pchg4C8Ual1NMAi9Ye90/z2yTDXKkRrR2hKcPCo0a0Viy3zXcDDHOnDrV283w3wjB36khvRmt1Th1qbc7PdWaSbqg5RGp7pUwptU5EAuiVMURkZfeaGrcrN0xKrWhtMk0BZwHblFL1ET7dMC21orViUUqtW3/CKcZ3sw6pR615/V9RJqCG2qKe9Ga0Vt/Uqdbm/Fy3oCfp1ooNtHztLgCGX30GG85qAyAYDWCH9aknehN0nKl9xSUeInnPTqJnnjXjsTu/ff+knwfXtvqvk9deSbgl5Ne58/c91KMxV+vqFoLN+jycRIaxg9q3PxANsv1CbTK09q4npz3G+XsnpGv7skxTWpUcpVFELgO+CNjAjUqpsuUkE5H3AP8KjIjI/wU+vqqzia+87XQAHj3mHwDYu1dxyftWIxGttT/e9nF+sV37a6o7v0HbXfqHqidHWjllmvrC9unj3rt7DgFgr8ynClRbvsDzX98EwPEnLocli6g3Et++jzXv075ab/7vH7P9hX5Wv0Uvfuz68TZa7/xLAKxLvjTtcR79wwf819/14lN/76+nKl0bWptMU8BjwKki8g2l1OdzZWNBS/vqLo7zztu0L/WLf9yD7fnyZhMZIuEAr3/paq+8Tb+Xlm5RZPr0Jp+65Gjv1dH+Z8lEhlg071z8iZ89DZb2Ex3ZM8jz2720WO89e7anPW+kU1kSKb0a/5NvPsbYLu3fGl0ex005XPJXtwBw53+8ZtrjvOc0L2bkacXEjqy81kREvO2XA2PAnyuligsccmRd7znttNN4/TG6L/nFizqOy5su3oCXcYeAZdHzJ3mtjKWy/OZJ7aP+npe1Mh2Xru7wXp3vf2YJxEP5oAlPHNZpsZpDNqMZHYcBgMX1lfBgcVz70m/oiuF6yx4DyQyxoD7XH285OM4veiquffXksUuOpP60Bvxrdyzk90HX37eN0zcuJuT5pMeCNls8P/TBkTRBW4vwyecO8cpjmoDpUyD+xTlrgbXjPlvanI9xcO/eAQAiIctPN7i/d3QupzNvJL0+bc2yFs5+00n+5z29Y/51vOHhXbz3jJmDm3//4xeMe/+maUuXprf50FpLKMB5y9sAGExv5czFOmVyxo1ii8NFn9OBWTYdHvPv0+892s+fnqL9zltDU9exNh6hsF8LeKnZcow4+lktao8SdQcAcNxpDliD5Hzzu6IuG9fvAMCWFEOZ5YQs3W/3pnbTGZ55bNT3pmbJFLEl8tRP3zab57qpWNCTdEP9UkqURhGxgf8EXgHsAR4WkVuUUs+WqXkfBdYDcWAzsBo4VKZjG6pMjWjtCE0ppQ6LSBPwMDBjZ26ofaqgtVcCG7y/s4D/9v6fCyYFWx1Th1pbD/TNudGGeWWuejNaM8yWOurbSn6uMynYDDVHLnrjVH9FcCawVSn1olIqjQ7WcGUZm5hWSvUrpXZ59Rwu47ENVaSGtDapppRSY0B6Dscz1Bgzaa0IvRWjtSuBm7y0Lw8CbSIy17QiRnd1Sj1qTSnVP8d9DfNMieOo0ZqhaKr0zFYuvZX8XGcm6YYaRPucTPVXBMuB3QXv93iflYuoiJwqIqcBIREpLs+EoQapGa0doSkReYn3PjKH4xlqjum1VoTeitFaOfu+GQ0PDbVK/WnNjKP1TEnjqNGaYRZU5ZmtZp7rGsbcfezgGOI50rUf1eZ/3rquFYl7+RGf68UK28iS98z6+Et+9CAA/e86H/W5VwMw8nwf4Rbt8xRqDtJ/2OHRY3Teye5VUUKtetvOxwc4a9tzkxx1fmlZof3+mhY1gef/FeqI0LRcfz66a4hop36O237hyTz/ZJLL+p4vS93iThu9sUtECpOH36CUuqFw90n2KWcApB7g373X+wteAzCi3XF49QsfZfgffwAjenUvOnSQH92qv+e7l7ybp/9Bx424/QtXzKrywFu/DYDznbcRWPozANShwxz/79qHKvPwLqxu/b30XHsGh7cN+36QJ1/7Uqyr/mdW9VWLpv/7EXZd/kkArKBN58YOnH3aJ3DjB09C4lp3P992iK/eqL/+X//LK0uut0a0Np2m9k+1UzKh237iJet59ve7ALCbw2xc20E8pLv3wZTj+9RFA7NPO3PLZy/l6n/TOeq/GA+za1sf685YBsCuzYcZ2aKtBs+8+EaCHfl5XWxN66y1XS1OP2UpP/zGowCIJcTWaP/pQDxE/NhOmtr0+PnpXz3L4s4mAD509pqS651BazC93orRWjn7vh7gmNybkaTj/7+2Q18TS6AzqsfPnuEU2/YM4nqdzaLo4llXeN7yNh7oGQTgoQPDjGWyAEQCFmFbGEvrY//ixcO0R3SchJBtsXtI+3wW49ddbZysosOL6WCJ4Cp9Dl1NIfoS+seUSMDmxkd388Pv69gu5bhv6lBr48bR/b1j9A+lOPWYbgAyrvJ9ruNNQbZs1/1OMBxgaVMHs+WtJyzlp1u1l9qvd/QykvK0FrQIef3l4Eiaf7r9eZZ1x7x6Q9z3iH52/9JbTpt1nZUm5MVzOHF1O5aIHzsivrTFj0sSj4X4t3u2AvC727fyq2svK0vdJYyj8661VDbO/jE9B1sT34TCQnm/YR4aSvHwPh0LoX8oybJzxsc1KIbmgI4lMeJsoje1m6Cl+4Mxpx3b0r7dTjbMUEbHmAlbQwSsNAcTer4wF31Xmp5R/ZW8pPtpf3KslEVz4CDJbJtf7qEDOg7O9d95jJs/dv4Rx5kLVXhmm9fnukIaZpJuqCOUAjc7XYnDSqnTp9m+ByiMVrEC2FeOpgEopS6c+Nnpp59uoiDXIzWitck0lUNEglNtM9QRM2sNptdbMVorW9+nlLrQ9Gt1Sh1qDcw4WreUNo4arRmKpzrPbDXzXGfM3Q21iXKn/puZh4ENIrJWRELowKS3VKqpXiRIQ71Sg1oTzUUiciN6wDAsBKbT2sx6K0ZrtwBv9/RzNjColOop/4kYah6jNUM1MVozVIvKP7NVRG9zea5rmF/S9+3JsmyFNgXa8+hhxryMCCs3NpO4fy8AydEsJz5Tmtn5oacPsaJdm7HHNrSz786dAPQdyHDGlvyxN59yrG/uvnRdlINveCkAi374h5LqLyfKM1tUrvJtP1TW8U3fI+0R+l7QJmf7XkzR3S3svuwlAKz8zZyyY+RqgeyMpnpT762UIyIfBm5Dp1j4hlJqUwkNmhQROQt4M/C6ws8zf3gAgK/sGOQdX7mI4fQSAKLR5+g/PADAph8+yyP3vrek+q0V3agxbYYlK1fxQvxdAIyemuUl3TqFzPL3QPANL6V/q1fvp/9A+416kXHFrY8cedB5RD3xewJNenExNZQiPRLA3a3Pz9naz+IPfwiAXQ+MYHvpZC5494+4++t/VkqtNaW1CZrqAD6ETtsxKRuO1aag61a0EvPSPEW99JLPeemDkk62ZDPgSFQf01WK17zyGAZHtIleW1eM67+cj7ly0ft/AoAVCZA6nOC8t34fgHu/M30Cn2pjiYCtNZQdy4CrB/dsIoMz5rBsdRsAoaBNV6s24b9zVx+XrCrF7LAyWhOR93vbvwrcik4bsxWdOuadJTR4HLffvQ2AZSvb/NRUowmHaFiPq7+/bwcr1raXbAZ8aEybgC+OhQl49roPv9iL6yo+cu46v9zPt2lT5e6mEN1N2uT+gZ5Bzlk6feq3apNIOTjeWGoJvrk7QJNnVr1/aIw9B0dwM1qHH/zWw/zXO84oodb61hrAvp0DdCxq5o7f7wCg//AY7V3azaLv4CjJhDbf/tmnXzHnOnLHPue0FYx5x7vn/h1+X3rDe3RA58/+ejMAR61s45TjtBvH/z5/0E9PWCuMDut+Oa+x/O8HudSGO3qGeOIJPd+ItYR5y/X38t2PnldizXPXWy1o7cbfD7KkU3//vUs20JvIYIn2W/zlr59n9YZOAK5/wykl1dOfWkPQSjCS0bp5pGeQVm+8LhxbBtIvEqWP9rCeP2TcrQStM0uqu9y4U9ghWJIhYg8AsHf0KLb1avelob4E773xj0D+vpob9de3zfa5rpCGmaQb6gilil0Rm+YQ6lb0jVZ2RORa4A3ALuBm4HOAifBej9SI1qbQ1CNKqW+V1DhD7VAhrXkPFbnXCv0AUDIicu1pp9We362hCOpQa8AbjN7qlBL1ZrRmKJo66tvK8VxnJumG2qSElbIq8F7geXTuxF8qpZKnnz6dC4yhpqkNrR2hKRExPnMLjdrQWrGUZupjmF/qT2vPA0fNd0MMc6R+9Ga0Vu/Un9bm/FxnfNINNYjyVsum+Jt/lgDXAq8BtorIt+e5PYY5UzNam0xTURExC6kLhhm0Vht9WyFL5rsBhrlSl1q7dr4bYZgrRmuGalGXWpvzc13DPACet/drPLHxfQAcOFDgE7ZjhO4NLQCMbRkquZ6jH37Wf73rFafijE2+4rPxief4ZYvObmNZsHKFdpKvJQ+nrg+/DICxHz7u+6FnhjNkvTQobsZl/44kAIEALDk6zsDO4dIrVsDM6WPmDaVUFvg18GsRiQBXAG/Nbb941dMA3PVkF66Ksjyi/XAeOHAmX/gr7Tv5r0viJbfDuiCfzUHt/CJH93wRgFsj/wc8n3TQcQ66D31Tl9v2PInvPVxy3ZXg8TWf4PiXPQNAZtcQkTOWYi3W96a0t/PDzTodyb5DhzjxNJ0u5bbb7i2t0hrR2hSaagL2iMjvlFJvnmy/f3yV9sv9/rMdxLyUVIGAhesqko6OgOqWZhkGwP988GX+68/95jkeeVCne8t9Dzl+99WrAHjNZ29naDjt9xu1xmtPCPP8hTqVziO/eA47lyIrEsCOOrR7KcaWdDbR7sVJGE7PGC17empEa8WilMoWWgh944O67X/+lX6Gh7Sf/mB/wvfffcmZK7nvt9vgLaXVe+X6bv/1zc/qLDXxWIgtuwYmLffVh3bqGAPA8q5YaZVXgJOWtZB09E1oCaSz+nU665LyXu85OMye3YOcdfF6AD/V2JypQ60Bvy7U200fcbn6C4P09uhninBziOFB/byxZEUrLe3RyQ41Kwr9/t//Pw8BOs7HTi+9W47PvnIjAK/93B10LtJj6+o17VBjPumvPFf3aTsOjXLU4jgJbwxIOq7vp/7U0/vZv3MAgNauGIP9idIrriO9Taa1T17SwzU/0z7hlhcHo3dAX5fLLt3APV7sglJZGYsBMR47pP3dT1ncwn3be/XGVflybaF1PHZoEe0RPUVrD++jLVSWJpSNXLyQ/vQa2kM7AEhlW3BUCFfpMfOpg8M88YJ+Rjnj3NWMenEfSqIOtcYsn+sKMb+kG2oQhVLulH/zjYicISJLAJRSSfRNZ6hLakNrU2gqCPwKqK0If4Y5Mr3WaqFvK0RESolcZphX6k9ruf7PUI/UxjhaDEZr9U59am2uz3Vmkm6oPZQXvXGqv/nna0AaQETOA66b3+YY5kztaG0yTX0LnZvznGo2xFAhZtJabfRthXxtvhtgmCP1qbX0fDfCMEdqZxwtBqO1eqZOtTbX57qGMXendxchL3V8KARJbTWFk4Vopzabau7V5i2Pb9RmtaduLi0d26o7Hh/3/sXzTvLTmmVTWQLe1R9LUHLqt0og570agOiegyQe0GnqBrcPYHspI9IjaVo8q207aDF2cIzjnyrTebglmpZWFlsplbOHeyNwA/CZ3EbxTHFsSxjNdBGwtK4OjKbp9cx99u8e9A/2ud88x6cvO7akBsnqj/ivX0XeTDSVyV1HnaZmxbLXcMmXSkkjVTlO7X4U9fG/BiD4+1uwzrkMRrwUf4FXcN+PtwJweP8Ix56g0+A89scPll5xbWjtCE0ppX4M/FhEnphqp6TTBkAoaPlmeqBN9nJpqXLmtQBfuGsLH79wQ0kN/fRlx0KBXn+6VZuzuUoxmtDaP+e8NQwOp/mXK08oqa5K0R19jrddoKP7xmMhtr2gkzMEghbrj+pileeOEosG2NM3BsC7Tl1ResW1obVisQvf5NIGhSNDtLXpMXN0OM3BvdocuWuCqfl1v3uBay46uqQGXH1cwQ9eJy/n07/S7mQZxyXmuSgc6h2juVlr/b1nrDriGPPNyV2Pct/ekwFwXMVggSn7i3v1ODA4rOcMSzq1UdZfnLO29IrrTGtKqb5CE+RDiWPp7XmI0Rf7AUg2BWk9So9d7V1NpApMZ9/5X78f55IzF776ziNTXJ3/jh8QaImQ3K/NkxO7Btnrub98/a7/U1J9leDytdpd7H8G1vPkjj7fxN0SYX+v7seGB1K0L9Ym+8GQzY8+dVF5Kq8fvR2htYTTQTqdcw9TDI+m2blH35vWKmF0KD+nzz1bjeubZslLCtwR15+sXcZyaf4AYpEAw2MZFnv9wYfOXketcWr3owA8fOAlLI7pe0fQzxpPHtQpOp/f2eenBXzJMYt448bF5am8zrTmvS76ua4Q80u6oQbxUixM9Tf/2AWBHy4GfjefjTGUQs1obTpNNc5i6oJmBq3VRt9WiD1zEUNtUn9aM0Ey65maGUeLwWitrqlbrc3puc4I1VB75MxZapebgXtE5DCQAO6b5/YY5krtaG1STYnIUcDgdDsa6oTa0Vqx3Az803w3wjAH6lNr98x3IwxzpL70ZrRWz9Sh1kp5rjO/pBtqkxpeKVNKXQt8DPgmcK5StZf3wTALakBr02jKAv6iag0xVJY6+nXT06ShXqk/rX1svtthKAGjNUO1qD+tfZM5Ptc1zC/pEgix9nLt5xW+Z7f/ecvKOPsfOwDotGjbzj2RQAWM/BKfvYJlf7IWq0lfcpVxWXFA+21s+fUu7lyk07FdcvD58lc+R4TzAbBf00vspTsB6HvvTfTv0v5ZTW1BVl+6BoD9D+4j0h4pT8VKQba2fU6UUg9Ota0vo9PofDb4/3jDF68iMar9mVo6DrNomU4p9qtrL+P8d/wAgHOuOr6sbet927m8dn2bbudwmqZ/fD+7eCUAW/uTfOJnOkXc5197YlnrLRXhfPrS+t7sPONC1PYnSPzXbQB894pT2LBW+yNGYyFct0zrIjWktck0pZR6Ybp9Apb291rZEiWyQXdclkA8FODAqN72pxsWcftO7RYVCpa3c3ugZ5Dl8YjXFiHQof3ij10c54/bDvNv9+g4Ah87/6iy1lsqwvmc0KEv99qLu/jPoPaVO9Q3xqolcY5drH3Sdw4kaG0uU+6bGtLaXBDRD0Cnn7yUR57sAWB4MElbl/ab3L61l9s+fznvuUFf19NPWVrW+n+9o5eXHq+/p7BtMZzWv6Yc6mxi137tF//xnzzFF646qaz1lopwPqcv1n3uUGYpd27T7U5nsgRs/TvJisXNRMMB38++ZOpQa0qpBwv9hEP2KOtPXMxOLwZONBZk0XI9fu7fPci3P/JyAK749G0sWdFa1ra890adNvXkS48iGM4/Jg/2Jdj0C/2Mds5rb+KBn729rPWWSu6Z7Q0nbmLvyDq++HPto54YTZP04oWccOpSnnpUxxhasqKlPBXXmd4mai2rAlx65jIAfnjrcwz2JYi36XFth2X5fvtv++J9vOHVG8vali2DOmbRG89eTSSg+4Nt/WPs6h3z08CVI25RuclpbWPHZpLZNgB6Rlvojqbo9fzQO1rChIN6WyhYpt+E61Brk3w27XNdIQ0zSTfUGTW2ImZYwBitGaqF0ZqhWhitGaqJ0ZuhWjSQ1swk3VB71JfPiaGeMVozVAujNUO1MFozVBOjN0O1aDCtNcwkXbUuIXK5NivuOpwg66VBEVuwJ5hhjCXKV697t04pFb7gaIiEIanNQEinCTbpNDbHLmum444d5au03DRfhagfA9B5Qhf9e7VJcvtRbQSW6rQ7betaSfanylenW78rZe1h7RqQ7RngM9/7IKN3PgRAbyLDT+/Y4pc79890eqpH7t8JZUhVlfrX1wHQfFwXVrfWVnbfCIl/uZGVb9XWNStjMS565Xpvj9oydwfoDK8EYMQZYuQTnyPWrU1pLUvo9NI+Letu5q4Hd5av0jrWWi6938p4hrGMNmUP2YIzwR0g4WjzsHSmPGZiu0a8elsCWHipa7BwlR5SuqOjRI5ZxGN7BspSXyUIWGcD0BR4iA0r1wAwmsiwpDVCyNZm+6GATLX73KhjrcUCOk3dy49aS8ZL67fnwAjhkNZdn5eqLhTW70cLUmSVyr6xAU7qDhKytYtYxo3iuDqNUXZRnGc7dD+x48Bw2eosJ02BXF/7NLGITt2UzmSJx7QrRXs8TGtzuGz3J1DXWgNoDe3mVecfz/f6dF9jWUImpa9Pv5dODCCbcYlEy/co+51nerjwnNWANtFNpLL+99L9kgidi/QzzyO/fbFsdZab5sDxLI294KdFvP8PuznjMp16s7M1wuqjuwAY6ivnw2796q05eJDTl7QBsPj1J/Ozh3b5rmH9Q0m/XGtHFEvKNyYMZzazRHdd2OLgemHCOiNBTujuYMegdkfYO5yc6hDzTjy4EZFNACxpssi4UWIR7bbT3hzyr9dYyvRtc6FhJumGOkIpncDeYKg0RmuGamG0ZqgWRmuGamL0ZqgWDaY1M0k31CYNtFJmmGeM1gzVwmjNUC2M1gzVxOjNUC0aSGtmkm6oPZQCpzI+JyLyeuCzwEbgTKXUIwXbPgm8G8gCf6mUuq0ijTDUDhXUmsEwjgprTUQ6gB8Aa4AdwBuUUv2TlNsBDKP7OUcpdfrEMoY6x2jNUE3MOGqoFg2mtYaZpAvnw1GbAWh5l43zR50ayDkwhmzu88sFowHO3PaV8lXs5XOTcAQsC2zvkre3geeTHlx7mGC50vxUCs+vRII2Ia+p2WSW5HP62iV6kyz/xcPlqauyN+EzwFXA1wo/FJHjgDcBxwPLgDtF5Gil1KztanKpKQJXHea4oIXs+BcAbrDez64th/1yIyM6NdtvPh+by3kcgb1M+2haLREd/wCwFzVDV4f/PvHFX4CX9qfpXy8vS72VIOuGcTMuzZ95MwCrBlt4/coHAEh98Zu8/pM/K09Fdd7h57TWHNzMMR06PdVAKkLGVfQn8z7BIe87/5sL9wEbSq/XS8cVkHwcCsEl6PnIh6wRgtaisvrvVQrBpTWi++WOljC9o2keev4QAHf+4Gnu/vqflaeiymvtGuC3SqnrROQa7/0npih7oVLq8BTbJiWntaWxF3nNiVpr97dE2L5vCIA2L2ZELK77mr8+fy9QntR7ljgE7QTixT+wbIeIPQCAq4Ic1a7TM/Z76S5rmeExfV8Oj6b9lGsh2yLeEuaSVR3lqaTOtQZabyctSsHrdCyhR717EnQKthyuq/jy20Zne/gpCdoWTeF8qspAVIi1aE13REN0terUXKqc8QMqgCUZUhndT1uRAPEm/eAWDtqcuEH7pL/r1BXlqWwBjKMRW88Pjmob5tJTl3P3M/sB/LgRAMFwgMvXPuO9O7/0esXFxvFf56JjKRyagwc4tiPqfdJVcl2VRCnd8sF0Cz0jKZq9++fYzhjd0W2AjpNQpsrqWmuzpUyJ6wyGMuOqqf9KQCm1WSk1WTL6K4HvK6VSSqntwFbgzJIqM9QHFdKawXAE02mtdL1dCXzLe/0t4LWlHtBQxxitGaqJGUcN1aKBtNYwv6Qb6oiZV8q6ROSRgvc3KKVuKLHW5cCDBe/3eJ8ZFjINtiprmEeK01opfdtipVSPrkr1iMiiqVoC3C4iCvhaGfpOQ61htGaoJmYcNVSLBtOamaQbahKlpg0McXg63zYRuRNYMsmmv1NK/Xyq3SZrxnSNMCwMZtCawVA2itDanPu2WTTjZUqpfd7E6g4ReU4pde8s9jfUAUZrhmpSqXG0mPgHIrISuAmtVxe94PTFijTIMO800jNbY03SE9pvSdrbCazW+Qfd4TROQf6+VXc8XtYqpb0dANXfD5aF5HzSQwU+6KEQcc+fuFZR/T0A2IubWPHSZQCMHhrDzep5bNn80aHklTKl1CVz2G0PsLLg/Qpg35wbAahMEuvkY1HDOnfvU5sP8qmPnOtv/+LVp5Zy+COwL3uFrvfeu8DxfOo62pDFiyDg+aOdNtkzV+3R0vMrWv7rnXzm0XMAyLqHeMnSywBY/8nXlq+iBbIqm1Vh3x88Emgi4Cr2HPL8NNd388o1nV7J0v3oAKKeP/CY0+H7p9uS8X3UFTYBS4g3BctSXyUZdbpY5PkdvuyYRQylHDJL4gDl80eHsmhtur5NRA6IyFLvl82lwMEpjrHP+/+giPwU7dZT9MTJVZb//a/tiLPv0AgA0bD22/3CVScVe6iiGUzFaAlZ2KL9uS1xsK1czIUMuTTZ0QJf4lokkW0jGNBehoGA5edgjkWDXH1cGfvmBaK1/mSGTs9vf1lXjMER3b+kCmIP3Pb58sZWWd/ZxLaCPOyRkEWTlzPbVYomrz2LN3ROun+t0DO6jnBwOwAnnrOKfT06dkQ4aPHxC0uPSzKOyo6jxcQ/cICPKaUeE5E48KiI3KGUena2lQUkxcqWCGkv5sCaZS3+tuvfcMocT2FyDiXW0xXR35GNg5CffNo4uKKvacCq/dguAFv7x9i6bwjXMzuPBW3Wxsvki55jgTyzFYvxSTfUJtX3ObkFeJOIhEVkLTq61kOVqsxQQzSQf5Nhnqmsn/AtwDu81+8AjrAaEpGY9xCLiMSAS9HBNA0LDaM1QzWZx/gHSqkepdRj3uthYDPGXXHhUiGtiUiHiNwhIlu8/9snKbNSRO4Skc0isklEPlJSpTNgJumG2iO3UjbVXwmIyOtEZA/wUuBXInKbrlJtAn4IPAv8BvjQXCK7G+qMCmrNYBjHTForXW/XAa8QkS3AK7z3iMgyEbnVK7MYuF9EnkQvQv5KKfWbUis21BhGa4ZqMvM42iUijxT8vXcWRx8X/wCYKv4BACKyBjgV+OMcz8ZQy1T2mS1ntbEB+K33fiI5q42NwNnAh7zsUBWhoczdZf3HAHDv/Ruyh7RpaGLHEBufeK5idSa+fR8AkYvWk91+GHuxl26rvx9atEml/38No3bvAiCwqgW7qwmAzF07abvx7gpUBriV8TlRSv0U+OkU264Fri1XXdLxFlTiv5El2op+1VgrF6xoK9fhj8C9/U4ArPNfivqjNgKQ9eugcxmkE/42srU/+VQ7d2OdchaXnKJdK75/5xbWt0QqUBEV05qIvB74LLAROFMp9cj0e8ydttA6do3o77g3kWEkneVDZ6+pVHXc+oI2v3v5WqFnWOupPRKiKeillbQSxIIpRpO1r7W+1ApataU28RA4ruLtJy0rf0UV1BqAUqoXuHiSz/cBl3uvXwROLqWejvAatnlm2iHbIRLWjxGV1NsLfaN0N4Voj2h9BSxh77BuQ3dTiMFUxv+8lnFVIJ/eqyWC7bW3rKbusGC0dkpXMz/YfACAnfuHfRPkO//jNaUcdlp++sddHLNa/4D2wKN7WLWyjRWLtDtiZzzMmsX6eW3H2iN+ZKsp+pOOb6odCto8/LROKVZ2U3coRm/ViH+AiDQDPwb+Sik1NJt948GNAOwdHcJxlf+dly1N3SQMphwGU/r5cHFT3oVj93CQJbEACX/4rO1xNKv0ABoN2HS1RRn23FHOW95W/soq27ddCVzgvf4WcDcTXCu8haLcotGwiOSsNmbtWlEMDTVJN9QLjeVzYphPKqq1Z4CrgK9VqgJDPWH6NUO1MFozVJPKxREqNv6BiATRE/TvKqV+MufGGGqcivZtxWatAKpjtWEm6YbaQ6mK/gpgMPhUUGtKqc0AIrX9656hSph+zVAtjNYM1aSyesvFP7iOqeMfCPB1YLNS6t8r1RBDDTCz1qZNLVkLVhuzwUzSDbWHAhzjDm6oAjNrrZRcwgZDHtOvGaqF0ZqhmlRWb9cBPxSRdwO7gNeDjn8A3KiUuhx4GfA24GkRecLb71NKqVsnOZ6hnplZa9O6VtSb1UZDTtKt8/4f1nn6dfv7KltX03W/ztc7YZt76/sByO7s5/CmwwDEJjnG0PsuBKDla3dVookzcvANL6Xr7TqtjsQiSFjfIJEllUobt3BM9WT5B/zX11xU2brsN9+Ur/eqD4zblnG1j3pwbA+pr30HgPDH/uLIg2S8uD7ByyrTyBnI3RO0xFG7t0CbTit3ynGLK1TjjFqbsy+dUuqIFf9Ksqo56v1f+boKfbbXxo+MFbBtSLFzMMFv730RgLeesHTS4/zdLzZx7avLnKKlSN57o7ZQ++ifnkjI1r1zyM4SCVQqnurC6dcK40O8pLvygnv1uq4p2/DzbYewPGsVaxqrlV/v6C1IRVhdfrxFP+sd19XKCd1aXzsHE2QrlkFi4WjtjRsXj/u/0hT2RxNjU9y+s49ez992dDg15TFufnZ/+eMMzIIv3LWFVUtacBz9i2M0HKC9rQIxXXwqp7ci4x/cD5TFZG15TPvxrz9jVTkONy2ndE3edy5t0lrryKUfbJ56Uro/oecOS6JH9pHVYO/oEGFb+6Qf35Ug4YQq2K9Bhfu2mrPaaMhJuqHGUaCyJv2VoQqUqLXpVmUNhnGYfs1QLYzWDNXE6M1QLSqrtZqz2jCTdEPtoRRkjD+doQoYrRmqhdGaoVoYrRmqidGboVpUUGvVttooBjNJn0esy78KQO+bzkGmSB0z+tFXkB5JT7qtWsQ3tCOLvSCHXR3I2o8C0FShLCgKUBU1l2k8gtaZAAz81d8S3dgxeaGxnzEWWg9AU7UaNgF3v46/YS9fhqxYz3mtbUCFUnlQWa2JyOuALwPdwK9E5Aml1J9UpLIaY31LhOt//gzRWGjS7Tc+uhuARe3RajZrHN2LtalhazhN2B4GoDO8kpWT+RyVAdOvVYYr13dz/75BAIbTR5pB5raNpObPR3u55xLSHFLEg/sAWN+yDlZWpj6jtcpw6eoOPvrDJwDoOzh6xPYbHtapagdHUjCP5u4rFsdZ29FExEsjdlJnrKLtMXorP5eu7mAwvRWAkczkQcb3jg7Rm9Rj6JJ5Gko7wtvJelPJgKR55ZpTK1pfo2nNTNINtYcLpE3QG0MVqKDWlFI/BX5akYMb6g/TrxmqhdGaoZoYvRmqRYNpzUzSDTWIaqiVMsN8YrRmqBZGa4ZqYbRmqCZGb4Zq0VhaM5N0Q+2hMP5NhupgtGaoFkZrhmphtGaoJkZvhmrRYFozk/QaoPv7Dxzx2djHLgXAbo/Qef3fV7tJ4wisiEOT5/AyNFz5Ck2k0IrRduPdk37uPvhJ9p7496wIPDLp9mohMZ1yRI47kxFZScWTOxmtVYyvvG3yzHXX37eNU9fqVFjnr3gSWFfFVuU5+3id0iliD2BJFQZ9o7WKce6y1kk/39Q3StLLqftnx2wGJvftrBaOa/NCfzcAZ1Yyo5jRWsW4/g2nTPr5DzYfwPJiC/3NhfuADdVr1ASyriIesqdNSVhWjN4qQmvoKO//8Z+nsvo57VDiWE7uyj2znV/FluVRWDiunh+MZBdX3je+wbRmJumG2kMpyDSOz4lhHjFaM1QLozVDtTBaM1QTozdDtWgwrZlJuqEmaSSfE8P8YrRmqBZGa4ZqYbRmqCZGb4Zq0UhaM5N0Q+2hFKQbx+fEMI8YrRmqhdGaoVoYrRmqidGboVo0mNbMJL1Gafq32+e7CT6Bc0+EUNB7UwXJKFANZM5SC1hn/4uXsnd+/Jr8drzxXQCMOR0Mp5fSXGm5Ga1VnY++fH3Bu/nT29nLMgAErDSWZCpfodFa1Tm+I8bxHbnE9/OntWXNevxMZZXvI19RKqw1EXk98FlgI3CmUmrSYCYichnwRcAGblRKXVexRs0zb9xYGGRg5by1A+DUZS00BW2CVsL7pMKOwqZvqyphW8d7OaUL5vuZLe3GGEovBSDjSsWl1mhas+a7AQbDRJTS5ixT/ZWCiHxBRJ4TkadE5Kci0law7ZMislVEnheRPyn1PAy1TyW1ZjAUMpPWytC3vV5ENomIKyKTR+3T5S7z+ritInJNSZUaapJKaw14BrgKuHeqAiJiA/8JvBI4DrhaRI4rtWJD7WHGUUO1aDStmV/SDbWHUpVMsXAH8EmllCMinwc+CXzCe3h4E3A8sAy4U0SOVko1zpJdI1JZrRkMeSqvtdzE6WtTFSiYOL0C2AM8LCK3KKWerWTDDFWmwlpTSm0GkOmjh58JbFVKveiV/T5wJWC0ttAw46ihWjSY1swk3TAjqrcPLG10kfrdc0Q/+7eVr7NCKRaUUoV+BA8Cf+a9vhL4vlIqBWwXka3oh4w/VKQhhkkZyegUSbY4tIb2Ah0Vr7OR0nkY8iScNgAcN8y2ARuAc5dVts5Kas1MnGqXjKu/k4ST5bl9QwCct7ytonXWQL+2HNhd8H4PcNY8taWh2DucoinosKNPm7u/9YS2itdZA3ozzAPJbAvipTB1VXWMsxtJa2aSbqg9Zk6x0CUihT5wNyilbphDTe8CfuC9Xo6etOfY431mWMg0WDoPwzxSnNbK1bdNhZk4NQJl0JqI3AksmWS/v1NK/byIVky2WtQ4T9eNhBlHDdWiwbRmJumG2kPNmGLhsFJqOp/LGR8uROTvAAf4bm63yVtiWNDMrDWDoTwUp7WS+7YZMP1cI1AGrSmlLimxFXsYH0FtBbCvxGMaahEzjhqqRYNpzUzSDbWHAlWCz8lMDxci8g7gCuBipVTubjcPFI1IiVozGIqmDFozEydDUdRGv/YwsEFE1gJ70TFf3jy/TTJUhNrQm6ERaDCtmUm6YUasC/7dfx09rzp1VsrnxEsJ8wngfKXUWMGmW4Dvici/owPHbQAeqkgjDFMSD26sep2N5N9kyLOqOZcrJsrSpurUWQNaMxOneWB9S8R/fVJnbJqS5aOSWhOR1wFfBrqBX4nIE0qpPxGRZehUa5d7wVk/DNyGTsH2DaXUpoo1yuBz6Wody+XcZa1Vq7MG+jbDPLAk2lX1OhtJa2aSbqg5lFJkK7dS9hUgDNzhBVh6UCn1fqXUJhH5ITqAkgN8yER2X/hUWGsGg0+ltWYmToYcldaaUuqnwE8n+XwfcHnB+1uBWyvWEENNYMZRQ7VoNK2ZSbqh5lAKXKcy82Ol1FHTbLsWuLYiFRtqkkpqzWAopNJaMxMnQw7TrxmqSSX1JiId6AC/a4AdwBuUUv1TlLWBR4C9SqkrKtIgw7zSaH2bmaQbZo+6K/9aLqzA8VVDmbMYpsFozVBFFPcAIJxfgYMbrRny5LQGFdCb0ZqhgIpqDSqtt2uA3yqlrhORa7z3n5ii7EeAzUBLpRpjmJ4611rNYSbphtpDgdtA5iyGecRozVAtjNYM1cJozVBNKqu3K4ELvNffAu5mkkm6iKwAXoW2hvzrSjXGMM80WN9mJumGmqSRUiwY5hejNUO1MFozVAujNUM1mUFvXSLySMH7G5RSNxR56MVKqR4ApVSPiCyaotx/AH8LxIs8rqFOaaS+zUzSDTVHowWGMMwfRmuGamG0ZqgWRmuGalKE3g4rpU6faqOI3AksmWTT3xVTv4hcARxUSj0qIhcUs4+hPmm0vs1M0ieh0Kcix2S+FZOVmysV8d2oAIp7QCwAxElVRkGqsVbKJupoKi2US2/1qDUAqUwlRmtFlJsLotzKxBGoBF7sAwFUgebKW4fRWjHlSqEe+rbC81XKG0vL3bkZrRVVbi6I8iYI9dC3FfRrWcIA2JUYSEvUm1Lqkqm2icgBEVnq/Yq+FDg4SbGXAa8RkcuBCNAiIt9RSr11zo2aqq2mX5uS3DlXrF/TlVSsb6vFIIUVehoxGOaO8nxOpvozGMqF0ZqhWsykNaM3Q7kwWjNUkwqPo7cA7/BevwP4+ZH1q08qpVYopdYAbwJ+V4kJumH+qbDWckEKNwC/9d5PRS5IYUUxk3RDDaJQrjvln8FQPozWDNVieq0ZvRnKh9GaoZpUdBy9DniFiGwBXuG9R0SWiYhJJdlwVFRrV6KDE+L9/9rJChUEKbyx1Apnwpi7G2qPBoveaJhHKqg1EfkC8GogDWwD3qmUGqhIZYbax/RrhmphtGaoJhXUm1KqF7h4ks/3AZdP8vnd6AjwhoXIzFpbUEEKF/gkfbhsfiHl9C+Z7fFrwR9l0vYFLi3PcSaWUeDWnT+d0Vo5KdbvazbHmLRMZbV2B/BJpZQjIp8HPsnU+V1nQX1oTft2e3nHlTvO17uW/DqPjH1Ql1qrEPWhtWLqqIW+bWL7LHl5yceYtExdag3KpbfK92sA9/j9WO6zWu7XbM6Z2zGKKVeXeqt9rRVTRyP1a1CU1hZUkMIFPkk31CVKmV8BDNWhglpTSt1e8PZB4M8qUpGhPjD9mqFaGK0ZqonRm6FalKi1egpSCGaSbqhFjKmeoVpU1nSqkHeho4YaGhXTrxmqhdGaoZoYvRmqRWW1lgtSeB3TBClEW0Xi/ZL+N5UMUmgm6QuQapjfVLINisZKH1PXqLsql7Kq2CZUVmtzNp1SSv3cK/N3gAN8d84NrXPKohEvndDE4000pZ/4+UST1Ny2/JsJn0+TNqZQa1PVO/W+pl+rGzytzWffZsbQ2qfS/dpkdRT2O1O6EUFJ/dpk9U57Chi91QtmfjAt1wE/FJF3A7uA14MOUgjcqJQ6IgZCpTGTdEPtoRRZsyprqAYlam060ykAEXkHcAVwsVLKPMU0MqZfM1QLozVDNTF6M1SLCmqtFoMUmkm6oeZQgMkQY6gGldSaiFyGDhR3vlJqrDK1GOoF068ZqoXRmqGaGL0ZqkWjac1M0g21hwLHme9GGBqCymrtK0AY+P/bO+84Sco6/7+/1WHyzszubM4sy0oSkSgGQJEDRDEhmBOneHreeUb09DgVRT1P8acHcugpqJhRVEQwgCCuJAXJbGDZvDu7Ozl1d31/fzzVYWYn9Ex3V3dPf9+v17ymuuqpep6q/vTz1FP1DbeKCMB6Vb24ZLUZlU2J+zUROR+4FDgcOFFV752g3FNAL5ACkpO5cxhVimnNCBO7ZzPCosa0ZpP0KqASfEjGo1TtUqBULici8ingPMDHRW58S2DKgohcArwdd0PxXlX9TWlaUblM+zsNyWezGrWmqoeW5sjVzWg/yml8rxNobSLfyfT68bZPvk9+fufT9UctpdYCHgJeCXw9j7Knq2pnSVtTYUyrD7F+bSpMa2MIu18br8x0+rWJys/Ezz4EvRkTUInzg5KmQKS2tGaTdKPi0NI+KfuCqn4cQETeC3wCuFhEjgAuBI4ElgC/FZHDVDVVspYYZafEWjOMDKXWmqo+ChBYbRg1jGnNCBMbR42wqDWtlTcss2GMhzqfk4n+Cjq0ak/OxyZXG+Dern9fVYdVdTOwATixsNqMiqeEWjOMUUyhtRD1psAtInKfiLwjtFqN8DCtGWFi46gRFjWmNXuTblQcypRPygrKXS0ilwFvArqB04PVS4H1OcW2BeuMWUweWjOKTLlT9k2HYrY1T61N2rflk/IvD56rqjtEZAEuXsJjqvrHPPc1qgDTWvjUar8GNo4a4VFrWrNJulF56JRPxArKXa2qHwM+Fvigvwf4D8bPIlpDni81ytRaM4zikJ/WJu3bpkr5l1czghgcqrpHRG7AWQzNyolTzWJaM8LExlEjLGpMazZJNyqOQn1OpnFz8T3gV7hJ+jZgec62ZcCOmbfCqAZqzb/JKB+VoDURaQI8Ve0Nls8EPlneVhnFxrRmhEkl6M2oDWpNa9Vjn2PUDAqkUjrhXyGIyNqcjy8DHguWbwQuFJE6EVkNrAXuLqgyo+IppdYMI5eptFaEvu0VIrINeA7wKxH5TbB+iYjcFBRbCNwpIg/g+rdfqerNBVVsVBymNSNMbBw1wqLWtGZv0o3Ko7TmLJeLyDpcCrYtwMUAqvqwiPwQeARIAu+2yO41QI2ZThllpMRaU9UbgBvGWb8DOCdY3gQcU7pWGBWBac0IExtHjbCoMa3ZJN2oOEoZGEJVXzXJtsuAy0pTs1GJ1FoQEqN8mNaMsDCtGWFiejPCota0ZpN0o/KosSdlRhkxrRlhYVozwsK0ZoSJ6c0IixrTmk3SjYqj1gJDGOXDtGaEhWnNCAvTmhEmpjcjLGpNazZJNyoSf/bFfzAqFNOaERamNSMsTGtGmJjejLCoJa3ZJN2oOGrtSZlRPkxrRliY1oywMK0ZYWJ6M8Ki1rRmk3Sj4lBqy+fEKB+mNSMsTGtGWJjWjDAxvRlhUWtaE9XZazcgIntxabaMymOlqs4fb4OI3Ax0TLJvp6qeVZpmzQzTWsUzrt5Ma0YJmKnWoML0ZlqreGaN1sD0VuHYPZsRFrNKa4UwqyfphmEYhmEYhmEYhlFNeOVugGEYhmEYhmEYhmEYDpukG4ZhGIZhGIZhGEaFYJN0wzAMwzAMwzAMw6gQbJJuGIZhGIZhGIZhGBWCTdINwzAMwzAMwzAMo0KwSbphGIZhGIZhGIZhVAg2STcMwzAMwzAMwzCMCsEm6YZhGIZhGIZhGIZRIdgk3TAMwzAMwzAMwzAqBJukG4ZhGIZhGIZhGEaFYJN0wzAMwzAMwzAMw6gQbJJuGIZhGIZhGIZhGBWCTdINwzAMwzAMwzAMo0KwSbphGIZhGIZhGIZhVAg2STcMwzAMwzAMwzCMCsEm6YZhGIZhGIZhGIZRIdgk3TAMwzAMwzAMwzAqBJukG4ZhGIZhGIZhGEaFYJN0wzAMwzAMwzAMw6gQbJJuGIZhGIZhGIZhGBWCTdINwzAMwzAMwzAMo0KwSbphGIZhGIZhGIZhVAg2STcMwzAMwzAMwzCMCsEm6YZhGIZhGIZhGIZRIdgk3TAMwzAMwzAMwzAqBJukG4ZhGIZhGIZhGEaFYJN0wzAMwzAMwzAMw6gQbJJuGIZhGIZhGIZhGBWCTdINwzAMwzAMwzAMo0KwSbphGIZhGIZhGIZhVAg2STcMwzAMwzAMwzCMCsEm6YZhGIZhGIZhGIZRIUxrki4i60TkryLSKyLvLVWjwkREnhKRM6Yoc6mIfKdI9b1LRHaLSJ+IzJvB/kVryzTrXRG0OVLCOj4qItfMcN/TRGRbsdtkGIZhGIZhGIYRJtN9k/4h4DZVbVHVr0xWUERWiYiKSHTmzZtdiEgM+G/gTFVtVtV95W5Tvqjq00GbUyWs4zOqelGpjl8K7MFVUeor6MFVcIwp21xJmG6KUt+MdFOqB3oi8nwRebzYx50JtaqvaqBUD9oLechdxDbUpO4qoV8rJUFbDqmAdtSkvmqZShpXy8F0J9Arge+XoiHFQEQipZxEFoGFQD3wcLkbYhSN9IOrY6cqKCKrgM1ATFWTpW5YNZDz4OpkVX2g3O0JEdNNAVSiblT1DmBdudsRYPrKoRbOUVU/U+42YLoriOn0ayKiwFpV3VDqdqlqc6nryBPTVw7lOkcROQ34jqouK3VdFTauhk7eb9JF5PfA6cBXg6dqh4nIS4KnWj0islVELs3Z5Y/B/66g/HOC47xNRB4VkQMi8hsRWRmsFxH5kojsEZFuEXlQRI6aok3fEpErReQmEekHTp+iTYjIG0Vki4jsE5GP5Xv+Y45xsojcJSJdIvJAINj0trcG59crIptE5J3B+sOA9NOgruB6TlbHkSJyq4jsD56qfnScMge9Ecp9Khc83f2RiHwnaM/fg+/tkuA6bxWRM3P2vU1EPisidwffwc9FZG6wbZRlRFD2UyLyp+DYt4hIR86x3pRznT8+3afROfW9WUSeFpHO3O9LRBqC7/+AiDwCnDDmWEtE5CcisldENkvw1FVE5orINhF5afC5WUQ2iMibJmvbJKykgh+6SAndE4pErT64Mt0Uxox0I7Vj2WX6qkBqQH+mu8Ko1fEwX0xfRm2hqnn/AbcBF+V8Pg04GjfZfyawG3h5sG0VoEA0p/zLgQ3A4bi3+P8O3BVs+wfgPqANkKDM4ina8y2gG3hu0Ib6Kdp0BNAHvACowz2xTAJnTFHPpbinRgBLgX3AOUEdLw4+zw+2vwRYE5zDqcAA8OyJrskE9bUAO4H3B+fUApw0TltOA7aN2fep9PkEZYeCaxsFrsU9dfsYEAP+Edg85vvdDhwFNAE/yalrVNuDshuBw4CG4PPlY67z84A48F9AYprXOV3f/wbHPwYYBg4Ptl8O3AHMBZYDD6WvRfC93Ad8Iqj/EGAT8A/B9jOBXcCC4Pg/ns7vIKe9vwdSwTXuC67FS4C/Aj3AVuDSnPJPB+fUF/w9J1j/NuBR4ADwG2BlsF6ALwF7cDp/EDgqj9/ElcBNQD9wxmRtCvZ5I7AFp+OP5Woon+8q+HwycBfQBTwAnJaz7a3B+fUG38M7g/WHBW1MX5PfT1LfKUAnsDz4fExQ1zPG6r7S/0w34ekmKK/Au4Encf3facA2XP+6B9fXvjWnfCuur9wbnN+/4/qUuqCdR+WUnQ8M4vqS08jpj4EP4/rTXtwD2heZvkqurxOBe4Nj7gb+eybnmKObfwp00wt8Cje2/zk4/g+B+BTtSWvtw7gx5zrcb+CHgcZ6cZOO43P2ORw3nnYF216W81vZBURyyr4CeHDsbwt33/Cd4Np1AfcAC013s6Nfw70E06B8H3AB0A78EtdvHQiWl+XsM+o8xujlZuA9Y+p4AHhlzm/h0GD5HOCRoP3bgQ+UUlemr8rq13Bzg0HAz6l3SdDGP+M0vxP4avo4jD8fvA24iCoZV8v1N90fyW3kTNLH2f5l4EuTfCm/Bt6e89nDTWJXAi8EnsB1bl6e7fkWcO0UZXLb9Ang+2PENpLHD+RSsp3Zh4Hrxmz/DfDmCfb9GfAvE12TCfZ5LfDXPNoySrzBuqcYPUm/NWfbS4MfVCT43BK0py3n+708p/wRwfWJjG17UPbfc8r+E3BzznW+Pmdb4wyuc7q+3EHmbuDCYHkTcFbOtneQnaSfBDw95tiXAP+X8/n/AX8HdgDzZvwDsgdXEMKDq6DsZbiBugE3gL4nZ9tTU7W5kv5MN6HqRoFbcQ/0GoLzSgKfxD2sPCc4dntQ/lrg57j+cRVuXHp7sO2bwGU5x3432X7vNLJ90DrcDdqSnPauMX2VXF9/Bt4YLDfjzIanfY45urkRmAMciXtI/DvcQ99W3ETlzVO0J621zwXn0UD24fk5uLH1s8D6oHwsaNNHcQ+YX4i7GV0XbN8IvDjn+D8CPjLOb+udwC9wY28EOA6YY7qbdf3aoTmf5wGvCr7zlkAbP8vZ/hQTT9LfBPwpZ9sRuIlT3di6cBOw5wfL7em2h/FXw/qqxH5t7NzjONz8LRq061HgXydpZ+a7pErG1XL8FZSCTUROEpE/BCbF3cDFQMcku6wErgjMxLuA/bgfw1JV/T3uycvXgN0icrWIzMmjGVun0aYlueVVtR/XeU6HlcD56XMIzuN5wOKg/rNFZH1gpt6F66gnuybjsRw3GBeD3TnLg0CnZv32B4P/uf5GuddzC+6mYaL278pZHsg5ztjrPMD0r/O06gjammYlsGTMd/RRnClZmqtxFgP/pxME8BMXsKIv+MvLxEpVb1PVv6uqr6oPAtfjBuKJeCfwWVV9VJ1P0WeAZ4lzA0ngBttnABKU2ZlHM36uqn8K2jA0RZteDfxSVf+oqsPAx3FPSKfDG4CbVPWmoI5bcU99zwmuya9UdaM6bgduAZ4/zTrA3VS04h7W7MD1FbMC001JdQPuWu1X1XSflwA+qaoJVb0Jd+O0LjBXvAC4RFV7VfUp4Iu4tx8A38M9RE3zumDdWFK4m7AjRCSmqk+parH69GlTQ/pKAIeKSIeq9qnq+hmeY5rPqWqPqj6Ms9a6RVU3qWo37qXDlL6xQbv/Q1WHc/R3Z6D7FO7t+jHB+pNxY9zlqjoS3Bf9kqzmrk8vi0gL7rdy/QTXYR5uYpVS1ftUtSePthaVGtJdLmH2axlUdZ+q/kRVB1S1F/dQe7JrncsNjNb+64GfBtdgLAlcvzZHVQ+o6v2Ftn2m1JC+KrFfG0XQx6xX1WQwbn6d/PVXleNqGBSaJ/17uCcyy1W1FbgKN+kG99RkLFtxpj1tOX8NqnoXgKp+RVWPwz3dOQz4YB5tGFvPZG3aiZsAAyAijbiBbDpsxb1Jzz2HJlW9XETqcCbi/4UzLWvDmcHIJMebqI41eZTrxz01BTL+MPOnWddYlucsr8B1Dp3TPMZOIBNQQkQamP51zqeOsW1NsxVnxp/7HbWo6jlBeyK4DuRa4F0icuh4FajqHeoi2jer6pH5NMoeXJXswRWqmsA9uT4K+KKqjtfHjEKyqQP7RKRvunWGhemmdLoJ2Drm8z4dHWgn/QCwA/cGM/eh3xbc2zEILDmCa7MSeBbuBncU6oI5/SvuwdIeEfm+iCwZWy4sfdaQvt6Ou3d4TETuEZFzZ3KOOWXGPuQe+zmfgFp7VXVozLqxD5/rA3/1JcBWVc29cc/V3/eAVwb3Gq8E7lfVXK2muQ5n4fd9EdkhIp8XF5RsFCLy+hz9/TqPc5kWNaS7secQVr+WQUQaReTr4mIB9eBM4tskDz/pYFL/K+DCYNWFwHcnKP6qoM1bROR2CeJNjdOeh3O0VfBDiAnqqBV9VWK/Ngpx8a5+KSK7Av19hvx1XZXjahgUOklvAfar6pCInIh7+pFmL+4JUW7ahquAS0TkSAARaRWR84PlE4IvKIabfA7hnpoUs00/Bs4VkeeJSBxn7jjda/Ad4KUi8g8iEhGRenEB3Jbhbu7qcOeeFJGzcf7P0+WXwCIR+VcRqRORFhE5aZxyT+AG95cE1+3fg/oL4Q0icoS4BxifxPlrT/d7+DHuGp0SXOf/ZPoPKqbihzgttQfX/p9ztt0N9IjIh8UFmIuIyFEikg4ulw7C9zbcA5Vr8xnI8sQeXJXmwRUishT4D+D/gC8Gx54UzaYObNbKiVA7HqabEukmYMoHOgGduAeTuW8dVuB84AgmTz/EPfV/He6tSO+4Fap+T1WfFxxLcSbPY8uEpc+a0JeqPqmqr8X5Mn4O+LGINM3kHItIvtoDZyG0XERy70ty9fcIbtJ+NhO/bUKdhch/quoRuHge5+JMmseW+26O/s6eRjvzpSZ0N845hNWv5fJ+nDnwSao6B2dSTc6xR73UARaN2f964LXBpLsB+MN4lajqPap6Hu439jNcfzheuSNztHXHDM4nH2pCXxXYr41X75XAY7iMA3Nw99m52oMJ9FfF42rJKXSS/k/AJ0WkF+eHnPmxqjNxvgz4U/BE52RVvQF3Qb8fPGl5CDfYgPOP+F9coIN0UIX/KnKbHsb5OnwP92M5gAvqkjequhU4DyfAvbgfxAdxfvS9wHuDOg/gxHbjdE8gOM6LcT7ku3ABHk4fp1w37nyvwQ3i/dM9n3G4Dve2chfOv2bauSiD6/zPuHR9O3E+dXtwvi/F4j9xOtmMMxe7Lqf+FO7aPSvY3om7Rq0ichzwb8CbgnKfw/3QP1KkdtmDqxI8uBIRwenyG7inyjtxAU9mC6ab0jzwnBZBn/BD4LLg4ehKXH+RmwP5eziT+NczwSRJXD7fFwY35UO4txPlTA9aE/oSkTeIyPzgpq8rWJ2a7jmWkb/grumHRCQmIqfhxrLc1Lffw43LL8D5HR+EiJwuIkcHD597cA+eyqG/mtDdGMLq13Yz+tq14PqZLnFZef5jTPm/ARcGujoeZ3qdy024ic8ngR/oaGsOAEQkLs76olWdZVsP1q9Np02zpV/bDcwTkdacdS04PfSJyDOAd6U3qOpe3BzlDcFv4m0cbC1cjeNq6dEKcIy3v8r4Y4rAgAUctxkXHGN1uc+x1NcMN/BtwT2Y+CXOfCo36usncR1rF9ngH2/EBbFLRwP9ZrD+RbgAaX24Bw3fBZqnaM+3gE+PWTdVm96MixJaSDTbk4DbcaZVe3GmcyuCbe/GdepduIcp30+3kfyDKf5LcC3S0UKXBPWkA9hM2eZK+jPdhKOboKwyOsDSaUwecLMdd6Odfgj7CcYEM8UF5tlPThRcRge4eSbOoqc3KPdLgmA3pq+S6us7uAfCfbjI6C+fyTlOoJs7gbfkfP40cM0U7RlPa5eOOc9RWsa9xbsdF5DqEeAVY/Zfgbsx/9VEx8W9kXocN9nYDXyFPH4rpruq6tcuxj2s7gJegxsTbwuuzxM43+RcXR2CewjUF7TnK7ltDsp8I9jnhDHrFTgU95DhZtxLqB5c1oDnlVpXpq/K6teCct8kmz1iCe6h4WNBG+8I2nVnTvmzcS/NunBxXm5nzHyDCh9Xy/EnwYkbBiJyG64zuaYIx3opLmKk4H6QJ+GigJrgDMMwDMMwDMMwJqBQc/eSI6ODT+T+vb7I9fx6gno+OvXeM6rv+RPUV9VBDnI4D+dftwNYi0udpmFfZ8MwDMMwDMMwjGrC3qQbRpUhLh3cynE2vVNVJ4rIOpN6fs34qWE+o6qfKVY9OfU9H5f+4yC0yoN/VAKmG6OUzFZ95dGej5INRprLHVqaYGxGDrNVd9avVQazVV95tMf6tQrAJumGYRiGYRiGYRiGUSFUvLm7YRiGYRiGYRiGYdQK0XI3oJR0dHToqlWryt0MYxzuu+++TlWdP962OW1HaDLRP94mAAYHnv6Nqp5VssbNANNaZTOR3kxrRrGZqdag8vRmWqtsZpPWwPRWydg9mxEWs01rhTCrJ+mrVq3i3nvvLXczjHEQkS0TbUsl+zni2Esm3Pe+P72roySNKgDTWmUzkd5Ma0axmanWoPL0ZlqrbGaT1sD0VsnYPZsRFrNNa4UwqyfpRpUigsQi5W6FUQuY1oywMK0ZYWFaM8LE9GaERY1pzSbpRuUhIJ7MfHeRdcAPclYdAnxCVb+cU+Y04OfA5mDVT1X1kzOu1KhOCtSaYeSNac0IC9OaESamNyMsakxrNkk3Kg+hoCdlqvo48CwAEYkA24Ebxil6h6qeO+OKjOqnQK0ZRt6Y1oywMK0ZYWJ6M8KixrRmk3Sj4hAEiRTtSdmLgI2qOqGPi1G7FFlrhjEhpjUjLExrRpiY3oywqDWt2STdqDwEvFjRsgNeCFw/wbbniMgDwA7gA6r6cLEqNaqE4mrNMCbGtGaEhWnNCBPTmxEWNaa1mpyk+3pHZtmT5xflmMrtAAinFuV45SD3ugCI+JllVfejUCJ4ksjreMOpOQDURXpGH3eqazS1z0mHiOSG5bxaVa8+6DAiceBlwHihIO8HVqpqn4icA/wMWDt5w6ZPWhdQPG3MBq3lXpdSUgStVQ/6h+yynF7c4xbzeGGTe11yV4vr00T9cbfnlhmLpEbAi44qZ1or0nGrWWswod6m3G2M1jK6TA5DtG5UOdNakY47G7SW1kmOflQ8p58Jtk2EDByAhtaDytak3oqojdlwz5ZXv6b+KK3B+HoT9WG4H+qaDipXU1rLg5qcpBsVztTRGztV9fg8jnQ2cL+q7h67QVV7cpZvEpH/EZEOVe2cfoONqqXGIoUaZaQIWhORbwLnAntU9ahxtp+GBcQ0TGtGmNg4aoRFjWnNJulGxSFCsXxOXssEpu4isgjYraoqIicCHrCvGJUa1UMRtWYYk1IkrX0L+Cpw7SRlLCBmjWNaM8LExlEjLGpNazZJNyoPkYJ9TkSkEXgx8M6cdRcDqOpVwKuBd4lIEhgELlRVLahSo/oogtYMIy+KoDVV/aOIrCpOg4xZi2nNCBMbR42wqDGt1cwkPemvH+VLnetvXSi+3oGvzmdMuZuUxtyyejREjylaPcVirO85uOuhuHYLKZQIwsHXKF9/dBjtiz5dXxyJFmbOoqoDwLwx667KWf4q7i1B0Smlv3XuscfWU6n+TmH5n6cJW2tlZYb+r9M+tv+70du8F5Wu3kKYxvUYzxd9Mn/NUeUicbd/4LeY73P9PLSWV7yNKShNQMzUre6/V4LbhvG0lvv9RF5c/DoLZYY+mplNU2gtsz3WkNWqnF4bWoOsDvL8TU6HlN5FRH3wA02rZvUWO6vo9RXMRFrL1VfOsozxRc+7X2tsn5HWoMrH0eQtEImV5tj6h+x1zNUbQPTM0tRZCNPU2ijEy0trKh7Ut9Sm1qZJzUzSjSqixsxZjDJiWjPCIj+t5RtvYyJCCYhpVDimNSNMbBw1wqLGtFY7NgNG1SBBYIiJ/gyjWBRDayJylog8LiIbROQj42wXEflKsP1BEXn2mO0REfmriPyySKdlVCBTaa0YfZuq9qhqX7B8ExATkY6CD2xUFaY1I0zsns0Ii1rTWs28SY96J097n8HkA9RHuzKfe0aWAqB4JPyGTFoyOGzcdGVJraM74YKFR2UYEZ+YN5gpkwxM5NPbAObEDpt2O/Nl//BT1Ed6iXuBWbv4CCkAfM2a+oj4oOScXzZVXcK/m2hwDlORNmVJUcd0H3xVc4qFmZidF8MkfLrHKKV5fKHnI5waXpq2ArQmIhHga7j4B9uAe0TkRlV9JKfY2bg3TGuBk4Arg/9p/gV4FJgz/QbMIE3MWDPS5HB2WyoZlEnm1DHmWa764P/ULXseROJuOZIznKSSblt631Ka9SVvAS8yflvzQU7PXJO0EvI1D512VSXu10oaEHMmJueJm93/nBRiDPW67yk54j77qey2sel7UiPB6h+5bZHge841uU+OZLXnRaHunOm3M18Gb4RYfVBXZGq9jd0up2fcBmRMCr9iU9Vag+m71IyntZ49WZPvkUFIDLlDi4dGoqNdKvxg2b8K4o3BsWJIvCFTREcGkYwbQh00vnx6bZwOfUEfG6t3dU3FeFpL3uIWc0y5p9RaxgQ534amq6/ee7YZjU/DN0GONhjqHa2nNLl9VdpMPN33RW4c34RcfUgmst+7eKXt1wZ+5v7H6rNm/7k6GXte42kNIHkLEomVbPzMVl/FWpsmNTNJN6qIGgsMYZSRwrV2IrBBVTe5w8n3gfOA3En6ecC1QWDC9SLSJiKLVXWniCwDXgJcBvxbIQ0xKpziBMS8HjgN50+8DfgPcMFELCCmkcG0ZoSJ3bMZYVFjWrNJulF51JjPiVFGptbaVMGVlgJbcz5vY/Rb8onKLAV2Al8GPgS0TK/hRtVRhH5NVV87xfaSBcQ0qgjTmhEmds9mhEWNac0m6UbFIQKRGoreaJSPPLQ2VXCl8UaLsW+Txi0jIucCe1T1PhE5bdKGGlWP9WtGWJjWjDAxvRlhUWtaq6lJ+l07uwFY2FTHSCrrY9E74nzi6qMez5zXxJPdzue6Mbqanl53iRpjEZK+u/f2BJK+EnykOZYgHukHYCTVxFDK+WgmfeXAkBfsU0dTzGNuvfP/3N4XIxr4VTREIzQE38T2vgE8EfzAaizhKw1Rd4ym2DBxz9XTUb901Hm118cy+0Q9j2TgXxX1PA4MJYLzXoRX5+NJ4G+q4KurOOYN4mu6rVEEf5TPPKTTttVlfJkHkn+nPtIFjJ/STjPpQFIHbZscwZsFPidT+VSnr2PYKcrS5Ftvru96WG1N11P6a1Sw1rYBy3M+L8OlI8qnzKuBlwWRkeuBOSLyHVV9w3QboVu/Bk1t7oOfcj7lgS+cxOqg9QK3rfsHGT+3jH/lRL5nad+0iJfjq54KiqU/+xDEqJB4g/P7hKzfZtofT3+U9Q1NjYzePoHfnXZdj6T93XP89dL7a9BWiTdkfUinsoIb1//vD9nlwGc47S88kW/deOnbpmaW9Gv3/QcsDeTs5Wijaz/U1yGr3+fKbb8y67M51A/RQE/ReBDXILiGI4PQ2AqM1lBuXATt73Z1BVqRpna0e4/bGIlmtRqNw56vubJp0v6f8QYkqAcvCi2vyh7/r5fC3PbsPul2JxPZY/V0Q3sH0rrAfY7Vg+akJPXGuXEUz/1mMtty0hvJ6Rk/aonWmdbGQR/4JMwJjIxGEpC+OR8ahmjQv637ELrxi9AYlOvrhnjQb/hjfM7jQTyBaMx9N2mtpTUCMDAIdLllz0Nb58IBF1uIeCz7BDZeD3uvCMpFYWQoe4z6RqhrytQlbVmjBH38826hoWH07yCZhLqgfcND0OTOR1rmj9az72d/S6oQxBXCi0AqkV2W37kZDTitDd/kFuMNRdYazAa96aOXu4WFy5FIFE1roqczU0ZWvw/d+63ggwciSDSe/Zy+fl40G08jWuf6JXB9pZ/KjmX9XZm+QaLx7Ng83O/GyJFsKj0dvD5zDAniYmhiKFt/eqzN7dd2BkZ/kWh2ezTmxs/B3qCQn+nvRt0PpHJi1WT0lpPaz8/RXbpfEwE5HcmJD2FaK4zaMew3qgYRiMS8Cf8Mo1gUQWv3AGtFZLWIxIELgRvHlLkReFMQ5f1koFtVd6rqJaq6TFVXBfv9fiYTdKM6mEpr1rcZxcK0ZoSJ3bMZYVEMrU2VkSen3AkikhKRVxftBKZJTb1JN6oEoaaelBllpECtqWpSRN4D/AaIAN9U1YdF5OJg+1XATcA5wAZgAHhrwe02qg/r14ywMK0ZYWJ6M8KiQK3lmZEnXe5zuHu7slEzk/Rfbd7HUfObAdjZN4wXmAFFPcmYhvcM+9y7p5d4xD2N6U94xDxn3NQ9nMyYyEc9wVcy5u+DSQ9PXPakkZTPQJDmIx7x6BnOmuwNJT2GA1P4nuEEHY1uuXckye7+rEm4J0JjTr6/rJl9khHfmVA92T3IgaFk0B6PnX1Z05ThlE9LPJppQ9qs/sBQkrrIXJ7qceZ6c+sjpNRta44dyJjSOxN2j4g406m+5AKaos7kJyLZevoSCzIp5aIyOi2bcCr37nHmNEuaU8S8nQDMr1/MVAhCtIp9TvI1zS6Xmft0qfR2jk3XNtZUfvJ9C9dakCP4pjHrrspZVuDdUxzjNuC2adf990+7hSUrYV9gZT+SgMaGjBmlRqPQFZhl+n7WdDLe4NIQpfFyUhKlkjlprca5PomgH1A/Wy4Sz5o+x+pBfXTY9SkZs0uASBRNl1MfieQcv/cn2X0SQzmmzzmmcfVNaKw+c0wd6EEy6ZNSo9sbqx99HrkmdunUc5HYaJP/kcGsqeoYU72M+8WB7yINLZBObV9/7kGXaCxV3689+QW3sHINDHQHK/2su0I0AgOD2XLJFBCUa2yAvgG37HnOVDhtTjqSgMEgNWnu9UmmIB6YWfb1u/2i7jtTVWcSDNDcmjVb3rfHmUGn9dDU5MyIAWI5aVJTI7D1a+5DTzfU17s60u1LLzc3QXq35hZIJbL6PLAj62YhgqSXY3XZa6K+02l6n7qm0SmZ0ianTZFsKkMCU9AgrZFu+AK0zXfr4z/Iuq5MQrVrDcD/4weQNWugc69bEY06X0Nw32nwverfP+3M27v2u23xGIwE2hrIuS/xPGcmD1BfB/TmuFzkuDUMDGbXe54rm9ZQU1O2j+vpDo6D0180EmgeYCDbDyVH0C1B/9vVnT32wEBO+aDd6c+eB7097vxi9bB/2xi3INc/SbwB6gLd+WT7q/4u5/6U039pr7uHk/bFE2vtoU/DomVuQ+S7yNzXkw/VrjfddQ2ybK1bHu5HU4ns91fflC2346ocFy5nJp4Zo7xIdqwZ7s+MNZpKZvunwD0oba6OSNaFLDGUDV7j+xCLZ1x+NDGU6V80ZyyUaDzbnkgEfD9r4q5+Nl1kKglpl9ShfjQaH50+LnfcHzkQHC8G9W7OxMigqyfX7D09po8MZo+VbsvwQPYY45i7C6c6rc1fFFzjXaNcQiajCFrLJyMPwD8DPwFOKKSyQqmZSbpRPYhA1EykjBAwrRlhYVozwsK0ZoSJ6c0Iizy0VnBGHhFZCrwCeCE2STeMMQiImU4ZYWBaM8LCtGaEhWnNCBPTmxEWU2utGBl5vgx8WFVTIuXVtU3SjYpDRIhG7amsUXpMa0ZYmNaMsDCtGWFSqN5E5CzgClxcl2tU9fIJyp0ArAcuUNUfz7hCo2opQt+WT0ae44HvBxP0DuAcEUmq6s8KqXgmzPpJ+u+3Ov+KeQ0xNnc5v5C9/SOsmev8OxqiXiZ12VDSZyCRyviRxyNexj99KMd3KO0jnt7mq2TWHRhKMDCc41+e88Sn14PdfdlUH7l+57nLIymfriBtWjySbZ+vWR+SI+c28LdEHwB7+keoj3rMa3D+IglfqQva9khnH/Ma4sH+ytaeJMvnuK99W+8I7fWxoM42kr7zq1/UVIevUeoivcF+Hgk/7XOSdQtb0LCQ4VTWakTVw5PnZz4fv8ClELl7dy/t9W0AzK9nSgTwItX5VLbS/bdnwlif70pqQ9pHeKap2qpaaxu/CK0upZQ++UjGj1YWB35eaf/LgS40ke13JOOj7Tmf29a2YMuISzkFzt831y83mvZ7C/6n/TI9L+OHpsM5/p+t9Vm/80yDg4fVaf82cL5tiRzf8JZXIf4PguP1Z1PXpP0xAaJ1zv++pT1zPO0O/FZb2jM+cFLXlPUFhsAfOJ1qbYK0cwI0vAz837mPo7adnl2c+3p033VZ38LZ3q89/BloSafCGshev8bWrO+meO67zP2u0kiOP7CfAn/A+QGD81eP5Ogh7UecTDq/XXD6y/FDZmQk69vb2JytZ06r8+PsCXy9d+/JpvDq7kIHs3qQNe93VT75BXRvJzJvntsQj2XbU9/k/NzTxwbYHYx5c9rgwG633DYf7duXOT9pD2KvJBPOXzN9vfxUNqeOAHPOd8upW92qdNo570XZdq79YCY9lLa2Ia1MSVVr7b7/AEDa29AtT2V0IsuXOj/dNGk9eR4MDWX7KN/P0Zo/2s877UPuee64uX1cJiaBZDXtec6PPNO4nGNDVqu+DwOpHB/1BHg5WkunJUx+MavNaBTmzcv2P9E4uvVpV761Netzv/FxZN5c9MmNbtvaNRkfZxUPaVuUbVvub2/Mb1E63uQWkrdk+zX1R2vt6H93v3Vwep9LXhSit3IG8tKn/59baGxFR1xfI01t2XEHIDGU/f160ewYEsTU0P3bs58z6cuS0BSklYw1ZX25E8PZOBbg4pqksj7pmfXRwB89dyxLj5+5sV4isWxsj1QC9u5Cjvxo9tzS/V1Le1ZnkaizGR90MQ+ob870dzrQlR2bt21EVqzL1un3u3YQpIirD/rV3HRs4rvHLM2vDNp0a/ac/OTBWkunvZuTgDbyogh9WyYjD7Adl1nndbkFVHV1pj6RbwG/LMcEHWpgkm5UIVLdQUiMKsK0ZoSFac0IC9OaESaF6a2qAnkZZabAvi3PjDwVg03SjYpDMP8mIxxMa0ZYmNaMsDCtGWGSh94mC+ZVVYG8jPJSjL5tqow8Y9a/paDKCsQm6UblUYRIoSLyFNALpIDk2EAS4pxNrsDlrx4A3qKq9xdUqVF9WFRaIyxMa0ZYmNaMMJlab5MF86qqQF5Gmamxvm3WT9K7A//ywaTPwqZ4sE4yft7DKT/jT95eHyXhK7HgKU3CVwYSzteiPhrJ5En3BAaTqcwxol7Wb7wu4kHgBpReB9A7mKShLkIyOEbKV/YOOF+Slx7SkSl3185uPBGGg3LxiMdxC9zccWze52d1OF+8X/R00hyPsL3X+UqduXIu2/udv8ni5jr6RlKZc41HPLb2ZH1H0+eX9q8H2DvQQmMswoo5sWC/Fnb2uzytc+rgwJDzc3nmvCbqItl+d6K+88SFLZnlax/cwfw54/gs5iAy2pe/AE5X1c4Jtp0NrA3+TgKuZMzT29lIroYm898eq7WJfL5L7a+em/M8v7zn+Z1fpnzxtBY+ff0w5HIDSyyORnN8NAcGs7mCO+Yiab/KxsbROYQ9D9K+5D29Wf/NaATtD/zZBgdH5ReWlhaYl+2zMuT0dzrQjSy6KPt5x1VZf71o3OX3BXTOAhj7vabzQA9ek/X/270DOfrf3T77roO6+qy/eVc3eqAr2Hk7Mr8jOHar8wVM1zvU6/zZAWlqz/p1Joay7Ule7/K15vjOTYTMe2P2/B7/fDan90Tlq1lrySSk4xo0tED3Lrecmyva98HPyV/ueVm/8Wh0jM+vNzoXtZf2T8+NkUBWmyMJ14Z0Xbl+wXt2I8demvnor78k4yucfGAr0WNcjCB54SvG7UNk7QdJ3fUGvByNe6d8Dgh02xY45qrv/DWbg/FsqH+0P3xOrmHd+kTmWDJ3WcbflcSw80MFtOdryPJ3u/WRF7uZygT3nnL4R7Lnd8t7sv7zE1DNWkv3O5KsQ+Z3oHuDIdz3s7EwfM3GGgD3G09f/5ERF+cAXH+WjmOQq5mRhDte+jc7lPUHzhwfghgCkvV37+nN9EMQ5GiHbFvSdRz+nPG1tub96F8vdR8aG6C7O9uvdV6LzJubbV+gYamrg64e56cOzkc+3S+OJLLXp74OFq90y4M9MNAHzcE+A1/MxGAgemZOgw5qYsanGSD5HdfHeSsWHlwwd5/C9Fa+QF45sUmk2f2mMvnk07m/1UcDv29paMmOi+ojja3ZG1/xsjEAojljQW5MirRvedr/PDGcKSvRlmx8FvHQkcFsHAHI5j8H9NHAE6CnF3m5KyOcCgtyTm3FP+Pf/E9ueemSjIbl8I+ge74JDXOyZYNxkfqWbG72pauzy6kkeB66Z7MrF6uDSOC3H4lk88DH6tC912TH/nS/BuP2baP6tfWXuHXp38AEVHPfNhNm/STdqD5Cikx7HnCtqiqwXkTaRGSxqu4sdcVG5WBRkI2wMK0ZYWFaM8KkQL1VVSAvo7zUWt9mk3SjIhGv4B+hAreIiAJfz/F/SjOeH9RSwCbpNUYRtGYYeWFaM8LCtGaEyUz1Vm2BvIzyU0t926yepPcn/IwZ99KWrIn1UfNbMibuvSNJWuIuUmB9NEKjQETctoSfTa3WFIsQDVITeOLM5bPHSGVM14FRZvBb9/Zl1g8MZp8AtTTGM2nScvEV6qMeZ6/KNWeb3Mw36gm7+0d4xaHzM+uWNs0J/sP1jzjTxN7+EZZ2NLGy1ZnxxDzhwJAzZxlKpjgw6JY9z7kE7Bt07WuvH85cx519yr5Bd64bDwyMqjMfWhpjmes2ESIylc/JZEFI0jxXVXeIyALgVhF5TFX/mFvNOMedvGGT0lv2NGWFkI8p+UT7TNfEfCYot8+ojVORh9Yqj+Q+tPNaaG93KaLAmdGuOtQtpxLObC6dRqihBdpdmh6JxLOmt6kE0tiWPe5CL5OCTfv2IWmT0Z4+lyoInMlya2smbQwjQ6NM4bNmod2wKKfNXjRjOifz35JZPanRmp8Ez5nU5ZqYyrw3wjzw//iBoA0jWRO5xsasOfJAnzN3TZtZ19dBh7MHHJXezYug6XQ0A93ogS9lUibljSdZ8+0JKIbWROSbwLnAHlU9apztxY210b8Dvefj6PBQzo3Rvuw1BvddgzPPnds22sQ97VrR0zvaHaC+Lvu99PVDW2B6OTI0OkVVUKdueXq0q4bnZVMNjqWrO2N+HH/fT/I6TR1I0P+jBwFoufL3mfWy5OJsmT3fdOeW/l1F41lT11Qy+5uIxiCdLbW3F+17HOYFdqiRaE76pEjGXDpX31PS2IB2d09apCq1BjC4M/sdL17ovudVwUvUVMrpA9zvLW2OLJ7TSW7Kx5zfdrbBOSbxQ/1Od+n+KpmEeNotJscs3vPcTVla+9Ext8xpE3SceXFepI/R1YMc95/Z/Tve5Ay5Cfq24DrI/A5YOC+bFnCgL9PGUak1k0nY+Jj70Njgfm99gU76+tG/fMyVO+my/NoJeHOD8SWdCnECCtVbWQJ5De6EziB155yh7LgoXmBuHnzu7824tehAT2YcQzy0c2c2RV9uir+RBHS4MUmjdZm0p27cqXOuVwDdXVkXBYDBYH1dUza1WprAzZSmVrwXfjmvU/Q73fES69fTcOkvM+tlwdty6rwxm3YtlZOG1fczKQ/Fizqz/6Yg7eneHWhgmp9JAQgwnEQaW52bEKP7z6mQpkBr6XFhonLVeM9WALN6km5UKcJU5iyTBSEBQFV3BP/3iMgNuDQfuZP0fPygjNnO1FozjOJQHK19C/gqcO0E22sy1oYxBtOaESY2jhphUWNaq50zNaoGwVkrTPQ35f4iTSLSkl4GzgQeGlPsRuBN4jgZ6DZ/9NqjUK0ZRr5MpbV89BZYA+2fpEgm1oaqrgfaRGRxcc7AqBZMa0aY2DhqhEWtac3epBsVh4gQK+xJ2ULghiASaBT4nqrePMbH6Sacmd4GnKneWwtqtFGVFEFrhpEXeWotH1eeybBYG4ZpzQgVG0eNsKg1rc36SfriZucjMpJS6oMvdiiZoiXwP4p6MRqizs9JGKYv0cDuQeeT4atSH3U+TYPJrL9h0leSvp9JXxb1PNrr3aXctC/ruzM0nKSx3vnhDQwlWDi3IbMt6nmZNGu5eALbe4d49vzmg7ZNxGj/9YPZttv5pSye38yG7d3ElrcBsKi5jsPa3bkn/AYe3efK946kGEkqB/rctr7hFH7gR97dN0w88OGfyVOrVxw6P+MjPxmFpFhQ1U3AMeOsvypnWYF3z7iSGqUUfuGlIt/0cFWZzkN9548+nE19QirwJYvWQbwBqWvKls/x15R4o1uIBP6aaR/iXJ9qVZi3xC3PI+vLWb8furth0bJgnyQ0p30lB50vHqB7O5HDc9rreRD0l/kylT9b6tFt7jSWt6G797h9Vq5A2oOXeQvqYXgAffwB16bde1zbAaJRl9oI0OHhrF9hWysSi8NqpoWs/SD65BemLJeH1qZ05ZmqKeOsm3msDcH5Beem/Ipm4wtQ1wRzA0fa+VHnzzmQ9YPNpL+qrx+trxw/X92+1aX5w/nfJu973C3HInirnb9j8vG9DD9xgEiL85GMrphDNNg/48uYJpkicbs7Rt0p+Z1m7F0/YPIEerjfkPpZn81IFHYG89EFC7K/kaSf9R9ubnLnndk2kk2zBAf7OOeB97wv4N/2b1OXqzatpQ+6NOh3kimoj2avV11Tts9K92HgUjH2D2T1Vd842p83rcF0ikBw/tpzWrL+r+kUf+B0mY6fMKclux5G+6tDtl+N5P895hN/QHd3IguDVJK797h4EHPdb1AWHYIGKbxk5xYXrwHQue0wGPgJ+z6qfvb8cnQ2ndHOO8fdMvk/nfodRlWOo+l+LTdVp3gu3kEy+K5bc/q+fXuy8SCSSaShMRuvALLj3/AQbAmeXyU3w0IXkyL5xwfw5tbjPWMNAEM33I14f3JNOKQNb1UQO2bpEmhuH93WTmfUohs3I2fkd3rRN1zn/k9WKFYPaf/7ZCKTbk4f+issDcbShiakbZFLOQcu1Vq6T8tNMQfoUG82JsQ0yKQivOfjU5atSq3NkFk/STeqDxGIjhNUzzCKjWnNCIuQtGaxNgzTmhEqNo4aYVFrWqudMzWqCs+TCf8Mo5iY1oywmExrRdKbxdowANOaES42jhphUUtam9Vv0lPqs3G/M+NojEcYGHHmlmvmNtLb58xS5jfGOTCUNXTb3T/E8YtcWob+RAciadP3KCl15SKSZEdfhPbAlL2tboh4xJkVLWzKpiRL+sqmLlf/lqEE8xriHBhyx+sbSjI4kmNGFXDK4taD1hXKB09fC8ANG/ayV5W7HtkNwLqV7WwMTNeXzxHagvPpaIyzoDHJtl5nnj+QSJHWfntjjKc73bl2940x/cqT1x6xiNdNsl1EiEVm34+t0ihJSrPgmJWSjm6qc6xKrfkpl46lpztrlrlnD6wIbLSH+5HmeVkzUc0xM25sPThVmBd8Fg9GArPj9sUQCUzWItGs+WhTu4v4EBxbwZnaA3j7XTsgm0YpYFTKlyIRe+f3AUh+83VEjnbmg7pvH7QFbahrQuINEKSmkwU9Lh0dwM6ns6arvp81B+3rRxv9aZmEppG1HwyWPjT+9iJoTUSuB07D+RNvA/4DnKV2KWNt6M5dLq0TwO49SGC+6dKnBWaZQ/0wksi4HnjHPw9NpxTKTX8VpChl6ya36fB10B6YzEdiRE8PNB2vz5jVR4eG6HtgD3WHu7RG/v5BdF9Xpg25V9U79+vUnVuMsx6NLH6Hc2lImxDH49kUWI8/7kzbAXwfaQl0tmQlDPTAju3uc47ptPZnUw2Ncg3JA++0/w6WvjR+W6tVa76fdV1paED37ctqbWQkkwqL3n1ZM+P9B5C1z0SDvgvIai2VgEigp/27oCVI9VffgkTjaGN/tny6XzzQmU0D6HnO5D39OTBnTjPtVI15Ejn/W/jrL3EfOvehGzdDb2/Q1E3I8sDdqKUFOSbw7Ktrgv4DQTtHkGQqY4avg4NZl54Z4L3y/3DB/senKsdREUj/BuMx19+kSeV8zwN9mfFBN27GO+0f3PJA1+h+LXdc3fA40hJodcHCjAajpxzp+olg7Ikd2s6eHznXnI65DXhpfUXjo9MHAnLCp9z/Qs55PKJnwsCP3Dlt3wg57kP6QBBvua0VlvYgi4N7jMZWJH2+iSFnMg8uhZvvZ93wZoA7z09PvL0atVYAs3qSblQnzg2ydn6ERvkwrRlhUQytqeprp9husTYM05oRKjaOGmFRa1qzSbpRcdSaz4lRPkxrRliY1oywMK0ZYWJ6M8Ki1rRmk3SjIqmlJ2VGeTGtGWFhWjPCwrRmhInpzQiLWtLarJ6kJ33lrgdcsNGFHY0smud8Le7evI/lQYqz+57aT1OD8xfpH0ywYkEzTdFOAIQUg0nnAzfst7Az8MFO+sLSllgmm0drfDt+EINvcWMXI76rp2dkMcmg0OJ5jWzq7CcZpF1727HLSnru4/HoUwdYMr+Jkw51/n8HhpL0DTkfua6hBEd0uHPoHalDGKG93vma9o0k2dvvfGXOX7cAVs6dcRsu+flDrFk2ud99reVBLDXVlDYtl0LbnY9ffFVqTX0YGkA3b4EgRaSsXgWdQWrD5hb0kfthbpv73NMHy1e6cnMWZP3tUknnQ5bKSY2W9i/3ky4tzdj1qpAcQVMj2fW9LjUMnXuR4/7T1VPE052Kkcf20/CikwDw2pdkfVP9FKQSSFPgMx1vzJyTLhHYE/gJb96bSTU0U5LffgORE4+atExVas29tnC+ufsDf9fGRvwHH3WbVy6BJze69XNaSD6yg2gwvlDfgnjBLcZwfya1D1s3ocPDyPIV7vNAH9IS7JNKwtJ1bjkxjPbuDcoM0vK8ZSS39ACgwyki53+rRCc9Cb46H2VwvudB6iH1PJeCEJDlS7N+68P9MDKEbnXpAlO7+zOxFGb6G/Fv+zekoWHSMlWpNYBUiuHbngAguriZyNJWNPAHl3nz8O93PrLS0pBJpybLlzof2XRKv6F+d90BenuycTva5mdSpklTO6ifTVOZGHI+xuDiBuTEF6CvP6+0aUVnR9Cfz21Hli7OaGqUf/nyNTCUjvsg2dRXIyPOL71AP+aRL70KgOjKOZOWq0q9CdnfaTplHcDQMDK/Y1RcFe3tcwttc1xcF3AxDYZ6M32A//D9GV9zWbM6c2xpXZiNw7G2w/VrXcF3O5Ji3gvcXCB62AK3HyDLy+RFEo/BgaCf9yQbq6WnFxb76GbX77NgUdYPHWDIXR/peBPSCMxgiqCPf94tjIlnM5aq1FoBzOpJulGd1Jo5i1E+TGtGWJjWjLAwrRlhYnozwqLWtGaTdKMiqSVzFqO8mNaMsDCtGWFhWjPCxPRmhEUtac0m6UbFISI19aTMKB/F0JqInAVcAUSAa1T18jHbJdh+Di5V0VtU9X4RWQ5cCywCfOBqVb2ioMYYFYv1a0ZYmNaMMDG9GWFRa1qb1ZP0ufUxvvSaZx20/q3/8ycebHK+O6eeuIJ1853/UcwTEr4ynHI+ZyN+Mwnf+X51DyeJBk9vnjG3kzqvFxHnw+JrFD/Iof7YgcUsaHSXdVPXMIe0uf37Ez5JX3nVWpfz85r7trIqqPeMFTP38Z4OGzfso7U5TjwQeMwTDvQOAbC8rZ57djpfkJa48kTCZ2DY+f919w3zjhNWFKUNS+Y3cejClknLVGeKhZZxfajLnS9cOHVUG6rFPz2sdhaqNRGJAF8DXgxsA+4RkRtV9ZGcYmcDa4O/k4Arg/9J4P3BhL0FuE9Ebh2z78HULULWfhBZO3q1f+M/uoWOucjKVVk/36U5vuWpRMYvEz8JyUTW97yuyeV9HYv6WR9PL+rysEfTvuspNMhlLcdeiv9TlypZVq7I+KeXGq85lvEH1tZkNm/tUD/EG9CeIG96KpnNHb9zVybPcqH+6IDzR+9YNGmZquzXGhYjx3ziIJ/W1I/e4hb2H0DWBUJsaiKWzmkN7loHfuiaSrp84QDRKN6aIyEe+FV3eJl86Pgp/HtdfyVr1qKbnL+7LF1CpGMIr8V9l5ELvp3JIy2xeGha0+07kPY292Hpimyu7uHAjxXQxzdkYkWweQup3QN4re73kvZHL4j6Ope3eBKqUmsAc1bQcOkvR63qf+8ZAEhsE/VnP8Mtr14J9Y2ugO/DyGD2tz0ymM3T3NCAzHfxOPCimbzhqA8pH933tPscq3f50QE6FrhjgNP3sZfi3/Zvrt6FC5DDP1Lcc56A4b86rdcdCyxelM3R3tMLLe4eSh97EAmWGdrufmcAXd14Z/1PwW2QFnefLEuXTF6OKtRb3aKMzz5k/fb9m/8J3fI0sjK4543HXM75NGmdqYtJocFniUTh2c9yy/EGWBD0DalkJoaL3nE7ctSR6ONPAhA5cjVebxBzoaUFWfkvrtz+7yKxemh5VZFPenx0exBXJJmEZYFffN9+NNCctLSgm59C5s935fbsysbm2NOJnHRZ4W0IfOGldZb2bTNkVk/SjepEBGI19KTMKB9F0NqJwAZV3eSOJ98HzgNyJ9rnAdcGeYXXi0ibiCxW1Z3ATgBV7RWRR4GlY/Y1ZgnWrxlhYVozwsT0ZoRFrWmtds7UqCIEz5v4zzCKx5Ra6xCRe3P+3jHmAEuBrTmftwXrplVGRFYBxwJ/KcJJGRXJ5Fqzvs0oHqY1I0xMa0ZYFK41ETlLRB4XkQ0icpBpjIi8XkQeDP7uEpFjin4aeTKr36Qn/CQ9iSCdhwzTOXQoAP/3T88dVW79LmeG94z5G9k3tIaukeUAzK3bjODMXNrr59M34kzYnu5dyCGtg6jvnnGktI4H9zqT9Tsf3cmSwIy9tSnO8jkuTUE84vHbv3dBYO4ej0XYF6Q1C4tvXPwcLvn5QzxnjTPL27Z/gHmtzuRw074Bdu51aRQOWdbKrn0Dmf0GBovXzn8+ZTWPHhiYtIyL3lhtHXvvuKbtY822y23+HhZjzewrtQ15aK1TVY+ftJqD0emUEZFm4CfAv6pqz2SNAcDvgsEbXbqdtHl6YgjvZf87uoL933XHb56bNVdPjmTNjBNAjKz5e99+SJvIp03GAZIJdDBI89O1x6WeWnSI++xF0I2bXT0rQYcCs8DtO5DjpjyTolD/iV+gD3zSfUglYSBIT1TXhA73o08E6cIaGtF9+7I7plNmnVB4G+Twj0DvTyYvU439WuoA9PzIaSYwFdaeveOmP9MtVyDrjke7d7vP/QeQlnmAMwXNpDiKRNDuPTlmyJ6LyAD49/+ZA9+4G4D2t6eyqcbmtiEjCfwntmfqy5j5RsO7jfFe+GX8W97j6l9+SLYt8+aie525tL+vH2+pux/QhE9k3WJnRlqsNpz8WXTn1ZOWqUqtAST3Ob0BRGNo9x6avvLbg4rpw59Blh3ulrt3oX37M+49QpASD2B4EO10z0dlweqM+wXqowPdGXcKolFnrgwwpy2TctJ/dBORY3Pq3duJHF60s52Uhk/9CoChT76UutUD6PYdQfta0C3unHRwOPu4t6s7k5ZuqjRW+RK76HpXz+YvTVquKvXmd0HiZrcsXiYt2lg3Ad1yBfIsN2fQ/gNonxtDZM5850KRHj+XLcumI5231G0DZ+5+m9Pwzm88yJJLFyKHByJKjiCNro/T3t7MjYJE42hqJLRUpmkXDr3n45m0hOqnkJVuLqSPPhG42QSp+AYGs+4XQarmQvFO/qyrq8R9W54uipuBU1X1gIicDVyNc1EMHXuTblQknkz8ZxjFpECtbQOW53xeBuzIt4yIxHAT9O+q6k9neg5GdTCZ1qxvM4qJac0Ik0K0Vk1vNo3yU2C/lnFRVNURIO2imEFV71LVIGE863H3bGVhVr9JN6oTAaKePT8ySk8RtHYPsFZEVgPbgQuB140pcyPwnsBf/SSgW1V3BlHfvwE8qqr/XUgjjMrH+jUjLExrRpgUordqe7NplJc8tNYhIvfmfL5aVXNfz4/nfjiZlt4O/Hq67SwWNkk3Kg4RF3neMEpNoVpT1aSIvAf4DS4F2zdV9WERuTjYfhVwEy792gZcCra3Brs/F3gj8HcR+Vuw7qOqetOMG2RULNavGWFhWjPCpEC9TRl8VVXvyilf1jebRnnJQ2vFcFEM6pLTcZP05+XfwuIyqyfpMW+QpmjgJ6ZRFjf+HQBlMFPG1xjPmu98QqIyzOLGB9g1eDQAA8l2WmIuDUZTtJM5sbZgf4/1Oxazpt2lANk3mGB7t/P53Nc1yDFr5gXHVjZ3Of/r7uEkHz3jsEy9b3rm5CktSsVnzzuKv3U63/Mnn+7i5KMWAnD/Y/uoizuf+0c3H6B3YITBfufX9JXXF+5c+vutznLkqI4RDpmzdYrShZnj5ZN/WkROA36Oe0IL8FNV/eTMax2fcvll5/rClyvtWrre6VyDYrR1ute80HvZYFJ905h1V+UsK/Ducfa7k/EHjMnxImhDK6J+1ne8rml0qj31kdacdFj16TQ9vdkUMrE6oM6lZQNIjqBbH3L7L1idbefeLdAf+LTX18HAILp/m/u8/wDeC7+cKRt53bXTPp1iIMd8Agj88ANfc+INsH9Pxk9Tt24jsdH1QzqUov5jPy+4Xt11jau/dQE0tU1ZvurmTZEoOmcB4mdT20nbotFaS6fgW3o4iCBzg/vnnj2QcCk+qWtyKYXArUsl0c1Oa8xfAhsfd8doaqL1H4IUQEsXQzr10dAweB7Rt30vW++RHy3FGU+Jd+ZXAdB915G6868ARJ53LPS5cdWb35yNd9DeAslkZp9C0e1XIq0LR/0+J2xntWkNXJyN9O/ITyHzV42vtUOflYmRIB0r0c4t6KCLRSHN85DGII3TUH8mvZ/+7U+w9ohgfS/61GbY4+4PZfkyl8oNoHMPGqTFSvdn3mnlM3RKx9xIbnNtij6jieE/u3uo6LIWZNh5V/l7B0jtd7+3tD97Ifh//ABy+FEAGf//yShAb+V5s+lFIBKkH/VTSJtLoZnW29h+DUDmLHBjKDhf9Gjc+aYDNLZmYsTo/m2Z2C96319cykBg0ZtSsHQ51Du/b7r3wEI3F/COflu2bXPOD80fPRc54VPQF3jd7Xgalq9xy/5jEI9Dj+vjaG7KxNlIj72FoHu/lY0pUfq+LR8XRUTkmcA1wNmqum/s9rCY1ZN0ozoRpFBTvXzzT9+hqucWUpFR3RRBa4aRF8XQmoicBVyBs9q4RlUvH7P9NEJ4+GhUNqY1I0zy0NtkJshV9WbTKC9F6NumdFEUkRXAT4E3quoThVRWKDZJNyoOKTCwjeWfNvKlUK0ZRr4UqrU8fTfBHj7WPKY1I0zy0NtkJshV9WbTKC9FmB/k46L4CWAe8D8udBDJKUzoS8asn6R7khj1f7ztseChTDrd2sIGNw4NJNvxxJl0JPwWRnxnopLSGMcsGGZ7XxyAnuEkbY3ObGZ4MMET27oAWDSvie7A1LKYacwKpb3etXXv7j5u7XHmUQvmN9Pa7M7nX553CK/53B9oaokXrc7TlgVmtOJPUdIRnfxXOFVgiAxT5J9+jog8gBsQPqCqD+fVOKNoVEKqtim0VrGoeNkUbONsE2+c7r2+JWveLp5bTpt5etFMWiw9sAN2u5Q0B674HU1HO5O++BnPgqFhdKszd9f+oVEpisqNxOrRHmeOqAcOIE1NyOrAfPoF/0Xs5n9yBYtkPSELnTmgTvA9jKVArU3pu1kqdDwtjdkmMFqPLR1Z1wrxwA90lxhGB7phQZA7aqAHFjnXDN25Cy9IW6obNyMLA5eNaLRoaaWKhUTjjDzq5gp19Q8603aAOS2ZdEL+T98Kc1qKV+eSZ8x+rUWC+47IONvSWouNXi8dK7OpF0Ug4bSiqZFs/3boM2CrS7mm3T2w/wBDd7s+Lt6bwFvc5sp1d2ddZiqFtlaSW1x2zuSWHogEGvCE6BuuA2DPa55D44LGolXpPe/szPUe97X2GArQW9nebGb6tXH6t3H7NfWzrmOJYWcy76cyn7V3r1uuawJ1V8076fmZlH5ecxPs3AaLA5eghpZsCrdKIXAj8R/bmE3/1TEXRhLIcf/ptt34j5l+rRh3TzJv+aRjzFgKvWfLw0XxIuCigiopErN+km5UHwJ4UlBgCHecyfNP3w+sVNU+ETkH+BmwdmYtNqqVPLRmGEWhCFrL13fTHj7WOKY1I0wK0Vu1vdk0ykut3bPZJN2oOESk4CdlU+Wfzp20q+pNIvI/ItKhqp0FVWxUFcXQmmHkQ55aK9R30x4+GqY1I1QKHUer6c2mUV5q7Z7NJulGRVLIk7J88k+LyCJgt6qqiJwIeID5OdUgtfRU1igveWitIN9Ne/hopDGtGWFi46gRFrWkNZukk/VXH0k1EY/0IzgfpubYHnx1zk+N0aPZPej8t6Neig3dMQh82KOe8NdNLrXP2tVzaahzl7W3f4ThhCvzz6dMnVYgLFY2O/+Ya95xMv/wYffw0num4Ac+NFfcuYkffvh0Lv6/uwE49xO/QVNu268uO2tGdebriw7uEX6BT8rGzT8NrIDME9pXA+8SkSQwCFwYpMoqO4X6aZcr5dpETJaKTbl91PZR6XZCOI8iaK3y8ZNZP0+AqPv9i/oQPRMGf5LZpH3BcyrVjN9207p57Puj80Ff0NGIt3Zppnzk/G+Vtu3TpeVVyEmvAiD17TfgrVwA+/YDsOm1R7PmTpeGM/WjtzB02XkAxI9ZhHfu12dUXb7+wVAUreXju1m+h4/ijdaaeBCMheInIebGDt13jYuFsCUICt7Y4FL7Af6GbRmfdJqbnO8wIA0NyEmXhXIaedN6AY2XXwDA9peewMJXuJfI3iFxkt95IwDRN1yH/7O3k7jSlSPmEbvo+hlXma/eakJrI85vXOuCdFbNLvWt+EloeJlbt//KbJqt7VvRwFcd3yex8QCRVqc7HUjg73E+7dqfIPbO74dyGvkiK/+Fxi/+C+C0NmdZ4A+8sw//i68EYMEP/0zXRacBsOVFz0I8YcWtf51xndPxEZ7V46h4mfSTo65JXdRpLXqm29Z/TXbbnu2ZPk1b5sGOoK+btwAammB74EkypxlZ+8GSn8K0CH47kQtexuClLiZk3SmrkPZ2dPuVAHgv+1/82/4NcP7pqZ0uDsxMfzemtYmxSbpRkUQKi944Zf5pVf0qUJzktUZVU4jWDGM6FNiv5eO7WbEPH41wMa0ZYWLjqBEWtaQ1m6QbFYcIlrvaCAXTmhEWxdBaHr6b9vDRMK0ZoWLjqBEWtaY1m6QbFYdQW4EhjPJhWjPCwrRmhIVpzQgT05sRFrWmtVk9Sfc1Sm9iMQBN0c4Jc6Wn/c57E4tpk60Z/+mkHyelzq+kMQqrW5yv3JPdgwwkUjy+3fkwveeUp3lgywp3LF+pD/zw7v37Tr7y+uMA+NIdG9mzf5DPnndUKU51xrR3uLyaO7Z0s2Sx83NatrCZ09/xE/5wtfPtfM3n/sCc9oaC6tk9eCQAEUnQEN0/eWGBGvoNjstkftzT2afS/NPHI93esuRMr0qtKZIacX7jgb/lpL6qiWEkvT3Hvw71nSFri/uda+e1mbzWumMHcrLzIfbWP0LrIa0ApHb3A9uJvvk7gPOP/Ovtzm/43J7Hi3iOhTPy6D7qYh7S6K5RtC7Czle4LFKLb/gLwx9y55d8spP4hEeZHBnudwue53LmTlq4CrWmiiQGXS7fuBsDJvQfVB+G+5F6b/Q6gGQC3FCKLLoI3Xl1JuaB7tyFnHm+2/a3hyEZ5A2ORtGdLu+wd/638G95D9rptBZ53bVFPMnC0ZTSedMmABZc1Ia3bD4AQ598KfWf+AXJr74GgMjcmSotoGsH4kUz38WEVKPWANRH0nExGlsn1Vo6foZEA5/zdL7q5AgEl0eWvgt98gtul95ekg8+DUDsvf+MPPQ18IJ9Yh6Df9oOQMuVv2foky8FYGR7H3O+/ocinmDhNM5vZKTP+dbHD20jurgZgA3POYpD//wQAAPnnUh9e11hFe17GokGek37/U9ENepNfWTQ3cNT1zRlvwYg9S3ZPs1POa0FITRk0UXo3m9l9+sKjr362bDT6Y7BXldXvzued9x/onu+GRzAQ+a/pTjnViRiq9sAGPrtBhpefwo0zAHAv/mf8M76H7f82/cSOby1sIr2b8ssSkPL5GWrUWsFMKsn6UZ1IigRMdc2o/SY1oywMK0ZYWFaM8LE9GaERa1pzSbpRkUynWjwhlEIpjUjLExrRliY1owwMb0ZYVFLWpvVk/TekRg7+12qz4bocnb1OzO6vz19gEMXOZOKOXVRHtvTB8Ah8xpZ274ys//8+sXjHvehvX2sbG3gzExatdU88NB6AE4+bik7Ot3x1qxsz+zj+8qieY3FO7ki8f0PnnbQukt+/hDnvPaZmc8//PDpBdfzxV+7FKudu3p55tGLJi3rnpSN75owW8nHLH0mJvCVxHjnOPZcwjbPr0qtpVLQ3wWxOmduB0hyBA1SEkk0Dl4EHQzSGMfqsqkOxIO6c8Y/7vanYPkaALyT/zmz+sDvPkL7i1y/qAMJem/fSvub3bamhU0cc0qqiCdXPBov//Woz/PvOgupy5qkN37+5oLr0F1PugXfh+b2SctWpdb6uvHvuBk5dA2kzYq3biXxF+faEHvRs6HZmcImbl1P9PnHIksPze7f7NJDMdYTYH8nLFwAgHfCpzKrk09fQew5LpUZezqRhtEmu9IxpzjnVWSW3XTvqM+pH7gfSPxEd/8Rf88Pi1LPgX/9Hx6/fS/PfsczJi1XlVoDGBpAe/a45cEeGOhGt7h0VdLe5tL1Af7OXUirM7FVVRBB5rm0d8RGH1L//ojbf+0a4u/978z63r98jDmnuHSS/t5B4oe2ZXeKOFeMulUFmvGWgPZvjh4zBz5yNgDLX31YZt2Sn99dcD3JH/8KHXb3zNFDOyYtW5V66zqAPv2YW66vQze6NGlDNz9Gw/knwBw3Rxi56S/Ezj0ZAFm2zrnugHMTGzuDGgrcn5qakMM/klmtQ791C23tcKATWZ2TkjlwMSNWoHtCCUi7taVPUx/+DACybm2mjHfGVwquZ8ebv8w9v3P3K2e8bdmkZatSawUwqyfpRrWimVz1hlFaTGtGWJjWjLAwrRlhYnozwqK2tGaTdKPiqLUnZUb5MK0ZYWFaM8LCtGaEienNCIta01rtJJszqgdxPicT/VUSIvIBEVle7nYYM6SKtGZUOVNordL0JiIfKHcbjBlShVqzcbSKqaJx1LRW5dSY1mb1m/Su3mGuvcOlRVm3sp2/b+gE4L5bNtCx2vkPRqIe6rtIgSedvJzoYQtYMWd40uM+tbOH3oEEx86/D3B+tNe8w/msXHHnJjpand/U41sOZPZ5/6mH8pnfPlHEsysdnzlvH5/97WI+9ouHAXjykT14Qc6DrXdv59Xvdef6vuevyfuYD93j0psM7Ohh++YDU5RWPElOv+HlYSlwVxgVKbcjnDqlb3pZUpkVgcnaXDpf9arSmiMxjG7fCNEItLlUTwz2ok8HaV5aWyEeRw+435ksX4EGfnTSPHfCww584480vtMNCTr39sw1X/DDP7Pvjc8DoP38w2n0s5FV2665De+dhcesCIOGz1/CwPs+DUDn65/LnJNczBGJRUjudr6Ed//vBk7d/ljex0zddk9m2Vs9eayNKtTa0mRnPwf+716a1m4kekgbAJ0/e5Lf/8Rpa+2hDzHiwiIQjcJxnhA51/mvSsPE/ry6bz8SpFrTFVmt1b3/p/g3/5Pbf/Ei/Ke2Zvbxzvwq/m3/VtQTLBXeBW8DQH92LakfvYWRh929R6S1jr4HnM9169mHELng29M7bjTCsnWN7L975xQlq09rwF3a1U/ix85/N3rUMvyn9tB3l4tnU7e4CS9Ip6iJFLFD3T2cNzQMqya+Fxl51KV8jQ4kiRydTfc577o7GfnKq90x5taT2Nyd2af+Yz8HYPDSc4t4iqWh4XLn+zzyxSsY/JiLN5LoHGSkb4SdD7g0dYe9/hnUXfKzaR238+bNDHUNAVDftnWK0lWlt6XAXYn9Qwx9x+khMree7TduAODPtw2x+Lqn6O5249zaQ4W1MRdUI/6mVS6uy0Sk/cr37RmVWlaCuBu682poaoIdTtMsd2kCAXTHVUU8xRJx5HPd/y1/Qzd/CQB94CHX+QMjD+yi7h/PQxa8bVqH7ThlKS9c4lIJ9m7vm6J09WlNRDYD1wM/UtXO6RzA3qQbFYmQmvCvklDV9wEryt0OY+ZUi9aM6mcyrVWa3oK+zahSqlBrNo5WMaY1IyyqUGsfB54JPCgivxaRN4nIFAnhHTZJNyoO53OSnPCv0lDV2knaOMuoNq0Z1ctUWjO9GcWiGrVm42j1Um3jqGmteqlGranq7ar6LmA58GXgfcDufPaf1ebu8Xg278vdD+zgiQd3ARBpjNG936UrGtzeQ8NSl9bl/vt3EI9FiK5x5nqLGsY/7vuev4Yv3r5h1LrvPOTMz5bMb+b8dS61DMct5+cb9wLw1yc6OfKQecU5sRIjnMpHz4AP/vRBABYtm8Omx52FxoXvO4WmBmdy9qvN+3jJ6vzOafiAu96veddJDA0nufW/Jqtf8WooMMRkjGe6nvs51wy8Gk3c821/2tS/+PVXodZSPvT1ozt3kdzoUj+muoeRwCQvubOPxnPWQtosXTxY5PokjcaQ+vEP2/SV3zL0yZcCUJc2awOefvGxzDvc/c69l/0vdcCfVroUUAsWRWhbXXlpisZDOJWmLzkNDb/l+SR3OBP36JImNv3U9edz5sCP69bx6uHH8zqmJtyT+/71O5mzZvyUndn6q09r0bZ62l52KPiK3+vs2uPNMU57mfvOxROe+pszEz78jMUkNncT2e7cLnTZKiZ6V+C94L/wf/ted4yc9f4fP4C0OzNmOeFTRE7IrqevD5k/v8hnWBrSfZW8/FT8G/+RePD78fcP0Xbh0a5QNJox7ffO+p+8jhufW8/SVz4DRgId/Wz8VFvVqDUAIh5+l3M3HPjp3+na1I0Xc++SBvcNZoqprzQ+3QtAc8InUl8HE0gjbbo+8qVXjcoEmPz2G4gsdia2kfO/lcnclvremxj+m3NJqHvWgiKdWOnIuoqcSv97zwAg2hxj3xP7Oez1rp+WpijJ77gUddE3XJfXcRN9Iyx7/REAeK11E2rNtaH69BZb0ETdP7jzk1ic5a3OVH3pq5J4LXEe/YJLq7j6rFWZfTQx5FKcToAsusiVG/zSqPXadb1biDcgi9+RfY8/eCPa7bQmzZU/P8jcg608Fd1yhVu3eiW6eQsAde94BRJvgMEbXbmGl+V33KYoLZe+FoCWHdtnndYARORo4ELgAmAf8NF89rM36UYFotUUGGKtiHyi3O0wZkr1aM2odibXWqXpTUTWTl3KqEyqT2s2jlYz1TOOmtaqnerTmog8AnwPGADOVNWTVPXL+RxjVr9JN6qXCJVntjIBv8EFhDCqlCrSmlHlVJnWflPuBhgzpwq1ZuNoFVNFejOtVTlVqLULVPXvMzmATdKNikNEK+6J2ESo6iEiEiVP0xWjsqgmrRnVTbVpTVUPOX5Nh/luViHVqDUbR6uXatKbaa26qVKtpQCCdGwnARtV9a/5HGNWT9IXz6nnspceCcDX1j/FS56/GoCICHPq3Knf8ehuuvqcr10y5XP3vds496jJfQvBpVSDQzOfYxHnObB0Tl1m3R+3d9Fa5zydVixq4eldPbCu8n2c0viBT+uale28+jSX4iTqCU/scSkSWuIRrrnPpea46LjJUwH+/qpXjvo8eQJeJVKgz4mInAVcAUSAa1T18jHbJdh+Ds4E5S2qev8M6rkI+Dy0TJkababk44tdjf7o0yU3pclkTM93vbxam2rfcWlagpzwKQTY94qTANhwbzeNjW7z0BAc2xij4fWnuBWNDdDl/IZlwepJD13/iV8ctC4x6Hz00vS/78V4gaPUnl0pdmxzKY5KlSSvFKSGUuiA+94f+H8PsXu36+vmzxdGRuDvRzlfzqMfmjwdW+wi90Km7aLctRMF3Kiefi041kXHHXcckfO/5T7fdDEAbe9YQVoAEomycPeezD7aP8TwL1xq0rp3rZr0+N4ZXxlnpUBzU/Z4D3zS1dPUhA4MoEFdcvCelYvvIwudv2n00Bbw3Q2mdneT/tH6P3s73su/MeWhGj9/85g135ygZPVpDfi8LDgk0wcNf/4VLD5lKVIfeJI3NpB8wn3/ftcwUu/u4Qbu2k7LmS+Yso74+34yekVEkMVZR/Z0ej9pjBEL4mwkt/SM8mOvdBID7g1jw+FzWXn66ozWkk93I3XuTEa++hri7/nhlMdacevYOcRk6QIL01s5tEbLcrznfcGt7P4B0RNe6JZHBiES5ajT3diqjz3uxlAg8d2fE3u18/uXSUKxyOrRiTEkEoyf0WB+0PdT97+hBWlwgTs0OVJd/VraN3/+ArwjTnTLkRjaswepc324dl6LdLxpykPF3/vj7IfFAJ+cpHT19G3Z+QF9IvIp4IPA/cCxIvJNVf3cVMcwn3SjIhH8Cf+m3FckAnwNOBs4AnitiBwxptjZwNrg7x3AlTNs6vuA/BPGGxVHubSW577GLGIyrU2lt5D7NXB9m1GlVKHWbBytYkxrRlhU4fzgebio7qeo6oXAscDUTy+wSbpRgaSjN070lwcnAhtUdZOqjgDfB84bU+Y84NogPcJ6oE1EpjahOJgRVT0wg/2MCqDMWstnX2OWMJXW8tBbmP0awMgM9zPKTDVqzcbR6qXAcdS0ZuRNNc4PVPXpoM5OAFUdIM/x1SbpRgVScPTGpcDWnM/bgnXTLZMPDSJy7Az2MyqCsmqtWBo0qoKCI26H2a8BTJCE1Kh8qk9rNo5WMwWNo6Y1YxpU3/xARI4D4sHys4PPEyTDHc2s9knPZdvuPp7a0QPAi49bxkjKfZmeJzQE/umPP7oH31dWNtdNeJyJuODwhQD8YlMnv9jkcooPJXwag1zt8ViE4YSfya++YtEcWgOfql/dtYUrXlu5fcZzD5uPJ85bxhN45hLnjNM5MEJLo/NLueTnD3H7/93PXT/Ly4JjSsSfNHpjh4jcm/P5alW9Onf3cfYZGwApnzL5sBP47xnsl9OQ6Xnz5vq+T+WLPt72UuQbD5OJ8sTPlDJqrWANpoZdnu4jXzSfzX/eCzg31/gz52d9e3t6M76v+eYtzWXNnX9n2znHA7DgS6/iwOMHWH1cGwC7H+li6zbX5J81rmPOnOx+ixcJh/9tcp/uctF26nIe/PIDgHOvXrzYfRWNDbByhdDY5mKJDHzkbKLLnM9gPn6cUzGF1mByvYXZr4Hr29ZlDtIb5KnuHcRbtcwtex7MbXPLu/Yw8ug+SLnqZP5bpl2h97wv4K+/xH245+PooKtT6uogHocBF1vBv+liaAtytcfi6PYdbv88/LpDx/eR9ja37HkZP2GZNxc90OXW19eR+PqFbLjybwBF+d1UodZGjaOJp3tI7e6n/rnBvXEyhfa7c/LmNjAQ5DKPNUZd7ulpEn3Ddfg/fSsA/s3/hHb3AyBN9Rn/7dSBIQY+cnbGR91rq6P715sAmPutO6ZdZ6mJNbp7ytgxy5zWgtgR0SOaMnFJvLY6hj/7cgCe/tmTrP3Lw0Wpu4BxtOxa0+F+2OVyfcuqo4KV7nfq7+km8fhmAJKdg8SXXDz9Glte5f73/RTdd1021/pAD3jBNCwxDD0/cst1TRCNoXtcvTPRd8nZtQsAOfYFIMH7XvVdvvehXvdZBL3n4wBs/49fs+yme8c70rSp0vnBLkbrblc+B6iZSbpRTWimg5yATlU9fpLt24DcSHbLgB0zKDMlqno6wPHHH29RkKuSsmotnse+xqxhSq3B5HoLrV8D17dZv1atVJ/WwMbR6qWgcdS0ZkyD6psfjIeIxPI5hpm7G5WHAn5q4r+puQdYKyKrRSQOXAjcOKbMjcCbxHEy0K2qO4t6HkblU16t5bOvMVuYSmtT6836NSM/TGtGmBQ2jprWjPyp4vlBcLwXisg1uAcBU1Izb9Lvv+tp5i5w5p/Xbe1m/x5n2tSxuJmtDwVpPRI+t33j1QXV89u/bOXYI1yataHhJD/47UYAYnURrn9/1jT38t8/wboV7QCc8qwl3LLFpTE6c+XcguovJoP9Lq6BrxDNeZzjBYYgcxti3PukM+3/2/qtxFrr+IcP3wTAbz53TgE1K6SmNNWbeG/VpIi8B/gNLsXCN1X1YRG5ONh+FXATLr3CBlyKhbcW0OAZUUqz89xjjzV5zzeVWTWg3F7geZRPaxPtO5365z7TpRCKHz6PZ7Q7FyevMYZ4gj7p+h6Ghgs2A44GZpTqK4vffCT+/iEAmuY3csyVv8+Uu2+dS10WjznryjuWu8/P31phZu+eZNLIDQ1lLJAZGoLhYaUtMG+V+giRhUGarN//K94Lv1xApdXdr+390eMAzDmkjcg2Z87o947gNboXAjt+vYn2Ne20XXNbYRV1urGQ+R0QdWbHib88DikdlUbL/+U7AdCOudDhxk1//SV4J3+2sPqLjD+QJJIMbh493w2oaYLUTrprP8mne0gG8tj/lucXaE5d3VoD6N7SQ9PCJgZveBKAgb0DNC1y93D9u/oZ6XNBotbc+fcZ13EgOHbrP6xGe939zu5vP0y82Wl6wQ//7Or+0FkAxI/soOU5zvw+9YM3E7lgsrRk4ZO+Jg2+P8q1Asi4P6Ue30bnXdsBiDfH2P7SE1j6i3sKrHnmeqsErQ1fdQORJc0ARPbtc4NXMEDs+PZDzDvcpVBsyRnrZoIe2AmxOrTP9XH61wdhjnOnyh1btOt6pKEVaV/iViRuhthZBdVddPwJ3mZ7Eah358T2J/E3PQ3A4L5BOl//XAA6vvunAiquvr5NRE4CXge8ApgLvBuXjm1KamaSblQRmpep3hSH0JtwP7TcdVflLCvuh1IQInIZ8Jrjjjuu0EMZ5aDMWhtvX2OWUkX9Gri+zfq1KqUKtYaNo9VLgXozrRl5U0V9W1prwNPA9bgE8Peqat5P92ySblQmBTwpC5l3AI8Dh5a7IcYMqR6tGdVOdWmtAqMVGXlTfVqzcbSaqR69mdaqnerT2pXAL1V1SESmFQvBfNKNCkSDp2UT/FUWi4DLyt0IY6ZUldaMqmYKrVWe3haVuwHGTKlKrdk4WrWY1oywqEqtvQzYICLX4dKy5f2CvGbepN/8uSZedPE+AJJ9I0jEOVYP7htg4Vrnb9K5vafgenJTqV38f3dzxDHuPufB+7aPKveRFx7GuZ/4DQDzFzWz7hnOt7SSfNJfdMpKAB7b3cszl7jcSj3DSfoTzr/OV7h3vfM36d/aTdPyVgYDX/+CUGDq9DEVgaqmgF8ff/xkwSRLw2R+52PLTZWqrWapIq2NR8PlHwHA/8E38ZpdWheJeaivyNCwKzSR79g0WPTj9ZnlwY+/hB1/cL/7xaeMTh163OPO93zj845mYDCR8fuuNKKvOJO1f3cp6x74xXbqg4yl8RiM1Av1Hc5XOLqsBWkP8sr1Fdi3VZnWVDWV268t/PHnANj1ig/REMQkGNw3SF2r092iU5fz9I0baSuwXu/cr2eW/R+82a1rrWfk4U7i45RLXHlBJlBKpILGzzSRo9dC+rfoeWjC+T4zkoARt5zY3E3fxi7WnLMKAH8gUVilVag1xoyjS37xX2x98b/SvdOl4atvijDc7a5X68o5NMxrKLjeedfdmVlO+8vOPaqD7icPjCrX+PmbAdjwnKMyfvGt6+bSeEHBTSgqrRceDUBqcyeRtYtckA2AoWE0SI24/+6ddG1xMSWa59cz2DlYeMVVpLfxtFb3iQ8w8L5Pu+VYkH5vt+vvl7z2cPb+wsV3aSqwblnuLKj1r5e6z0cfQerOvwKj35hK22tdmSDNJO2LkLYCKy82QbwQPbAj6zs/3A/JBJpyv1N9+DGG/uTmPsvOXIXfPVx4vVWoNeDXIlIPnAs0AttE5Peq+rqpjlGht1BGbaOo+hP+VRIicoKI2BunqqV6tGZUO5NrrdL0JiInlLsNxkypPq3ZOFrNVM84alqrdqpTa6o6hJugx4BfAXkljbdJulF5aBC9caK/yuLrwEi5G2HMkOrSmlHNTKW1ytPb16cuYlQk1ak1G0erleoaR01r1UyVak1EXgBcDnwbl3P9lHwOUDPm7rsHjyTRcysAyd4RNEiDUtcBTS11APQ0uLQbL/+kK/ezT7y4oDqveuuJ2Q8vOYLnv+56IkEdyb4RBp7qAmBXzOP/7ry4oLpKwSvXPgrA1+9exR1PONPQoeEk0SAf28anDtC735lKxTsaqWuI8usCU9hlqDzfkomIqOr+QszdC08jdnA6tanM32cLRTmX6tHaQchgt/tfF4XAhQdAPMmkpWIkazo7/NmXU3fJzwqqs+FTv2JNzmf/xn8MFnz8Pnfvs/TsQ1jUOUDTl24tqK6SsWANTf/otPPs1vUceMilkvRiHq1HdRA71KXH9Jrj+E+7bdG3fa/weqtLa5HcD9LrrkOsMUpdkJZupGeY3q3OdLZ+UfOonYcuO4/6j/28sAbkpLiKAgMfOdt9SKSQFmf8ntjZT7TVjeGxd36/oPpKwjGnonf+0i0nU9DTm9mUeMxdUz8YR6PL3DWMv/fHhddbZVo7aBzds5He3YNs3xHcq9WlWL7K3bI2dDSQHMrmRN75ipNYfMNfCmpAblqoxuD/n1c/g8YG2B9Yv+/cpdTXdwHwygLrKwVy5vnu/ze/TuKvT8NI8GYxIiR39gEw1DVEy0LnKhCpj7Lyd38rTuXVo7eDtCYDB/DTekr5+N3DDD7hvvSGiDDSkzXTTgUuOIWk35NjL80sR4PBdPBj2bTFXnMcv2+EyOKgP3jPD2dcV8k49nT3/57foguCtJnigfrow27uMPLgnkxawDnPX0bk/G8Vp+4q01qwfAFwtar+BPiJiPwtnwPYm3SjAlHnczLRX2URmU4QCKPSqCqtGVXNFFqrPL1Fpi5iVCbVpzUbR6uZqhpHTWtVTdVq7UXA73O25aVBE6pReShFCXYVEteDRWWrWqpLa0Y1U31aux74dLkbYcyA6tSajaPVSnXpzbRWzVSh1kSkExgE7gAQkUOB7nwOYJN0owLRSnwiNi6qepmI/A74c7nbYsyE6tGaUe1Ul9ZU9bLjjz/eJulVSfVpzcbRaqZ69GZaq3aqUmuLgVtUM3b6HvDP+RyjZibpMW+Qw16wCoANf9mGF3OW/u0rWtnymPO3vvW/X8rp7/gJ81a1F73+i65ezzFnryUSpC1IJVMc6BwAYMv6bZz4omsAuPt3FxW97pmS9vd9/bGPsrF7OQBX/eIREsPOd2ffnj6OOtmtf+yvO5m3oHn8A00XVUilpi5XIajq+un6pJcyLdpUx01vrzTf9LKkiqsyrR1ENEi7tnQJdfXOLxfPg+Ym2BP4Wb/8G/i/fa8rV19cC2Z//SXI4iBQbjRCJOqGlMi6YRJ/fpThz78CgLoP3VDUegtFOBWOdH6GDR9ah1zxHcD5N8cObSeybhUAunUb3tzCUz25g1W51sTFPGh9wXK6/7gVgKEDQzTOdx68XY/uY939j2ZSWc15ztLxjzND/FveQ/0LAwfOeDyTEi+6q4fkZvdSov+9Z9D0ld8Wtd5CEU5Fnu38W7WnE//3f3TLQ0kkuA+Jrm6juSWeSaNYMFWotYPG0XgDi589n3iDc+mMNkaZs6wFgJ6tvSz5+d2AS4s2Z3lLUduS1vDhL1pErDF7mzy4b5B7f+361Vs61nFm5+NFrbdQ0mN69DX7iGzfwP5P3wjASF+CVHDftuiUpey6y6XFapnfOP6BpkuV6e0graVSNL3iCAD2XH0vg/sGqW9zeTm9Jw5k/PZ3nHcii9757OK25ckvAFD/hhdAMIbr5i34WztJ7XBxBAY//hIaPvWrotZbKJn7x2d0okNBnI1d26BjAf5e1+7I/EYa693vR+pixam4CrU2zron8t2/ZibpRpVRYakUjFmMac0IC9OaERamNSNMTG9GWNSQ1mySblQe6RQLhlFqTGtGWJjWjLAwrRlhYnozwqLGtGaTdKMyqZ7AEEa1Y1ozwsK0ZoSFac0IE9ObERY1pLWamaTPrdvEWacfDsB1u3pJJdyX7HkefmL0Fx6NFS8z3Xce2gnAC05eQVNDlMHAL2hoOElLo/M/+9OCJh5/cHfR6iw2LbHDWTVnEwDzOpr423rnj7j6GR0smd8EQOKI+Rkf+4JRdflkjWkRuj93CUj7OYV2LlWuNY0F/tLLlsOgy7VMPAbJMU+aR1z+ch0qzrnq0/8PAFm6zPnAgxs40wFdOhYQO72O1AOV5bM5iuiZ7n/jzcSP6gDA70vgLWrP+AYSL5KPMFS/1prnARB9wbOYE4yZjU/3IHUuzsHwTucjCaq+6wAAGvdJREFUno73ogOJ4tW94yrkyCMhHug9MQRJd/zokUkijz8JQHJDZ9HqLCqNLwdA+BnSHPidDiXxgvzuXkcTkbn16FCR3hBVudYAaFtC22uOpP8rzvc82hDL3Kv17+rPFPOTPtHG4t3Kpr73JtpfdigAUhdFh5Nov9Naw6I5PH/BRgA2/GZr0eosOs2vRBb/iIYgz/amG57iiHNd/KDIwkY6nuF+y4P7BotTX5XrTVs6kGOdj/rCj3Uw9OO7IejHUp3Za9Qwr0jxSdL0/gRZdIhbjkQyk0+Ztww5opvIls2ufTt3FbfeYtLyKkR+CoAuXAKJYbyWwP98XhMRz8Uy0f6h4tRX5VqbLjUzSTeqjBp6UmaUGdOaERamNSMsTGtGmJjejLCoIa3ZJN2oPFQPfhNoGKXAtGaERYm1JiJzgR8Aq4CngNeo6oFxyj0F9AIpIKmq00tNYVQ+pjUjTGwcNcKixrRWM5N04VSevdiZW0TfcCx3/m0HAMODCfZv78mW84TrPyhFqzcWcSYzjY3OJDDa4I69oKWOtnpnErJjRRtPPbmvaHWWAsE9uUqmfHzfpfpraqmjNTDdO/XEFZy/bkHxKizRkzIR+QLwUmAE2Ai8VVW7xin3FDO8uQjdZLsGKWr6uCp+Kpu5Ds2dsPYwt9y1H5JJtCvbrxGkRotf8r7iVBwJhg4vJ6WbCMTSZuINmTorHvFgjkvhFOnoQvd1M3ync+958LoNnLTxseLVVVqtfQT4napeLiIfCT5/eIKyp6vqtGzDM/3a4h3Ezguu1x1/IbHBzc3iHc4UtG6O00D8Q/863fZPjBd12srVXX3azSKFrHE3bZH9fcWrs0T4Pe4+xO8eRloCd4poBFk0l8gLv1zEiqpXa5BOk/g3lv6r+56H73gqs60rSLkHoCml/Vufnu7hJ663PgKNWbNmiUaR+S4tr8ybS3Sxc02seItbL4ImXCPjMTKuFRKLUP8sd6/W8s7vF6++ah9H6wOJrjmSupcMMnzLwwBEgusGEK2LIOe8togVS7ZPEw8kuIaRKNI8F13XFLSvwkmn/+7eh+7e41LAArJ2DTJ/pdvW/Mri1VfFWpsuxXO+NoxikfY5meivMG4FjlLVZwJPAJdMUvZ0VX2WPf2fxZRWa4aRZSqtFa6384BvB8vfBl5e6AGNKsW0ZoSJjaNGWNSY1qrkVYdRU5TQnEVVb8n5uB54dUkqMqqDGjOdMspIflrrEJF7cz5frapX51nDQlXd6arSnSIykWmTAreIiAJfn8bxjWrBtGaEiY2jRljUmNZskm5UJKqhmLO8DedXN24TsJuLmiAkrRlGPlrrnMxyR0R+CywaZ9PHptGM56rqjmBidauIPKaqf5zG/kYVYFozwqRU42g+8Q9EZDlwLU6vPu6B0xUlaZBRdmrpnq2mJundw+7py7yGGMsWutQU23b3ZVLGAPz+qiL6TQBLW+sB2Nk7DEA86rxL6qMefuDH0VAXZcnKtqLWW2x29C8JljayfM1ct25LVyaN3DtOWFG8yqZ+UjbpG4DJbi5U9edBmY8BSeC7E9RR8puLovpV1xBFvW6z5KmspkYg5voa6usgGSH5VOArDHhnfrW4FdY5nzMGup0vHbgUMtHAx1Z9iEbw5tQXt95S0H8AWeheBMZPbUF7e4kd6m4CiuqPXgStqeoZE20Tkd0isjh4s7kY2DPBMXYE//eIyA3AiUD+fZvvQ4PzSffWLEe29QIQaXIxVpq+8tu8D5U33fthTluOT3oUIjneenVOZ9IYK37dRUSH+pH0/UYsgr/XpXfyWuJEzrmqiBXNEq319EJbKwDR1a2Z6zXUnzVrXXf/o3kfLh9k5Qr8TVuynxvqsj7qyVRGYwvXNBe13mKjuzcjde73csipSxh8yvnxN8Yi1H/s50WurKTjaD7xD5LA+1X1fhFpAe4TkVtV9ZFp1xaNIUuXoEMPAhA/rD2zqeXK38/wFMZH925BOoJ750gkO5aC80v3nc610uO7RFxsGt2yleQjOyDl5jbRxgZkdZHi4KSZJfds+WI+6UZl4uvEf8EbgJy/UW+5VfUMVT1qnL/0BP3NwLnA61XTES9Gk3tzAaRvLozZyORaM4ziMZnWCtfbjcCbg+U3AwfdiYtIU3ATi4g0AWcCDxVasVGBmNaMMCmd1qaMf6CqO1X1/mC5F3gUWFpoxUaFUiKtichcEblVRJ4M/rePU2a5iPxBRB4VkYdF5F8KqnQKbJJuVB7pJ2UT/RWAiJyFewr7MlUdmKCM3VzUCiXUmmGMYiqtFa63y4EXi8iTwIuDz4jIEhG5KSizELhTRB4A7gZ+pao3F1qxUWGY1owwmXoc7RCRe3P+3jGNo4+KfwBMmkZIRFYBxwJ/meHZGJVMae/Z0lYba4HfBZ/HkrbaOBw4GXi3iBxRaMUTUeE2FMXl2fOdedKPHt9D/6D7MocHE/z2yy8rWZ13PubSdaxcNIdHN+9nXmD+fqCljvZmZxo6v72BBQsq23RqU5czM1u2oJnVS+YAcO/fdvLvZ64rfmVKKVMsfBWow5mwA6xX1YtFZAlwjaqeg7u5uCHYHgW+N5ObC+HUg9KwmYn7zCnJtSut1kJD2l6Lbv2a+7C/C+3vJ/6eH5asvtTNtwIQee6zXcoVQFpbodG59RCrg6YWtG+4ZG0oFtrTmUkZQ2MDpJJE3/CVElRESbWmqvuAF42zfgdwTrC8CTimkHpk7uvRjV90H+KxjPlvKfWmGzch8+ZlTJ+Jx9DtLo2qzJvnzKKh8tP+DfcjTe4eIOIJfsS5v0Uu+PZke02f2aK1o/8d/0dvASDxxAH8gQQARz9URDeUMQz+4C/UBSnKum/ZTOPauURXuuf53oJWood2ANC6ctpZ5UJFt+8kfvg8ACTm0X/7VoDim7pDPnoLI/4BItIM/AT4V1Xtmar8KFpeBYDuuAqSSWKrAzeLt31vWoeZFj29aI9L9caCnNPfthUWLoBBd99d8fcoaTP9eJzIwib8Ljfue8/7QvHrKm3fdh5wWrD8beA2xrhWBA+K0g+NekUkbbUxfdeKPKjwEc2oTUoa3f3QCdYX9ebCqBZKp7V8At4E5c4CrgAiuAdF6bdSXwBeCowAG4G3qmpXSRprhEBt+dIZ5cS0ZoRJYXorRvwDEYnhJujfVdWfzrgxRoVT0r4t36wVQDhWG2bublQequ5J2UR/hlEsSqu1KU2nRCQCfA04GzgCeG2O6dStwFGq+kzgCeCSQhtklJGptGZ9m1EsTGtGmJR2HM0n/oEA3wAeVdX/LrRCo4KZWmuTulaIyG9F5KFx/s6bTjMKstqYBvYm3ag8FEimpixmGAVTWq1NaTqFC0i4IbDeQES+H+z3iKreklNuPfDqUjXUCAHr14ywMK0ZYVJavV0O/FBE3g48DZwPLv4BWRfF5wJvBP4uIn8L9vuoqt40zvGMamZqrU3qWlFtVhs1OUk/f90CWDepFUPR+MgLD8t+OGK0y82vNu8DYGgkSWqSqITXP7ILgNceMZ7LTun52vqn6Gh1KUga6qJEo84AY/7CUvnR66x50h+mD/pkdY31jZ+qXLl85/NtZzFrLKHW8jGdWgpszfm8DThpnHJvw5nOT4gsf7dbWA4yk9ZOg+gbrsvWu/rg7brxi+jW7ez96RMALHrd+McZ+NBZNH6+PLGkOl//XADmffQlLm0dQH0jUleqtHGzqF9b8/7McvzY0tfnjZOeLK07/5fvBC9QvDex8v1b3lP8VIR54v/s7QDIurXI4cE9wdbteIlS+TXPHq1Fzv8WAI3nh1Nfbn80d0y/5f/2vegBF/9guGeYlgmOkfzOG0f1kWEz9MmXEls3Fx1yZsHSWE+0vZTpMEuntzzjH9xJkYY9WXIxALE1xTjaFHUd84nxNyx2WpP2ILj40okD1etOl9xIFk8nFl/x0O1XQtzND+Two2DoXrxUKTPjlLRvS1ttXE6FWG3U5CTdqHAUNGFvAYwQmFprHSJyb87nq3NT/hUh4M14NxajRjgR+Rguouh38zymUYlYv2aEhWnNCBPTmxEWpdVaxVlt2CTdqDxUITE73gIYFc7UWiu16dQ2YHnO52XAjpxjvBk4F3iRqlri9mrG+jUjLExrRpiY3oywKKHWwrbayAebpBsVhwI6ifm/YRSLEmttStMp4B5grYisBrYDFwKvg0zU9w8Dp6rqQKkaaYSD9WtGWJjWjDAxvRlhUWtas0l6GXnJapfD8ou3b2BgMDFuma+tf4regRH3oUw+6cvmNzGvweV0b+xoyuSb55iJ/WQKwgdGzHSqmKR9zCfz+Q7fH3xqSu4bX1qtTWk6papJEXkP8BtcCrZvqmqQOJWvAnXArc4NivWqenGpGltMZM376brsVOLNsXG3J655LQDRxU1hNmsUjUsDj9K2dqh3fZrMe6OLElAKrF8rCd65X8e/K4jH2Nd/0PbJtoWFLA7G7uYWaJkLgJfj1190TGslwTvjK/S883QA+nf10zFme+LKCwBI7R8q68117NB2vENW4AWxNuTofy+tT7/preh4Z3wFul0YGu3bP24Z3X4ldO51HxaH1bLRyNylkApSokXjSKnjftSY1mySblQgWlNPyoxyUjqt5WM6FXy+CTjIn0lVDy1Jw4wyYf2aERamNSNMTG9GWNSW1mySblQeivk3GeFgWjPCwrRmhIVpzQgT05sRFjWmNZukVwDvP/XgF2bXPuhiR/m+8uEX7gzWHnZQuTAYGvHBZVigM216X0oUtKQpHGqXiczHK9HUPRRMayWj/Zvja2r4i68kdsIhAMgLXhpmk0ZRf9oqt9AwBzyv9BWa1kqGd8rnxl2vD38GRpwrmbzyLSG2aAKSI/DkI275hBLWY1orGXO+/gf3f8z61A/enEkBWPexfwu5VePQ3BROvwamt1LR6twnpHXM+uHA8K5zLxxTnnS5GdRHk8NuuW8/Umqv3BrTmk3SjcpDFSydhxEGpjUjLExrRliY1owwMb0ZYVFjWrNJulGR1JLPiVFeTGtGWJjWjLAwrRlhYnozwqKWtGaTdKPyUIWR2vE5McqIac0IC9OaERamNSNMTG9GWNSY1mySXqG86ZlLcj6tLls7ANbMayTUB1daW0/KKoGSpzqrVExroVP3/p+WuwkAyAknu//ROHiR0ldYYq2JyPnApcDhwImqeu8E5c4CrsCl/LtGVS8vWaPKjBz5UaTcjQBIp2AbHkKHhwBK2y7TWuhELvg2IfQieeEd8wxobIBYXTgV2jgaLnUuOYwcc84UBUuPjgxCT6f7kAgpZlUNac0m6UbFoQpaQz4nRvkwrRlhEYLWHgJeCXx9ogIiEgG+BrwY2AbcIyI3quojpWyYES6mNSNMbBw1wqLWtGaTdKPyUK2pFAtGGTGtGWFRYq2p6qMAIpO+oz0R2KCqm4Ky3wfOA2ziNJswrRlhYuOoERY1pjWbpBtTsrNvmIaoS+Xx9y0HeN6Ssfkgik8tpVgwyotprUYZ7AVAkyPols0AeCe/sqRVVoDWlgJbcz5vA04qU1tqh7QZ6EiC1GPbAPCeV9oqTWu1i+7cBc1N6BaXyjdywcWlr7P8ejPKwVA/SJDqLxrOlLKWtGaTdKPyKGGKBRG5FPhHYG+w6qOqetM45WrGl66mqbF0HkYZyU9rHSKS6997tapenf4gIr8FxstE+zFV/XkerRjv1Wft3PHUCqY1I0xsHDXCosa0ZpN0o/IofWCIL6nqf0200XzpaogaC0JilJH8tNapqsdPeAjVMwpsxTZgec7nZcCOAo9pVBqmNSNMbBw1wqLGtGaTdKPyUNDy+pyYL12tUH6tGbVCZWjtHmCtiKwGtgMXAq8rb5OMomNaM8KkMvRm1AI1pjWbpBtT8tJDOjLLZ6yYG0qdU/icTGqmlwfvEZE3AfcC71fVA2O2my9dmShHKrha8m8yssiKf84uLw6nzlJqTUReAfw/YD7wKxH5m6r+g4gswbnsnKOqSRF5D/AbnCvPN1X14ZI1ygBA1rw/sxw7Mpw6TWu1i3fGV9zCyeHVaeNobSKLLgq9zlrSmk3SjYpDVUlN/qRsUjO9yXzpgCuBT+F84z4FfBF429hDjNesyRpkVCd5aM0wikKptaaqNwA3jLN+B3BOzuebgIPicBizB9OaESal1JuIzAV+AKwCngJeM86LlXTZCO7ly3ZVPbckDTLKSq3ds9kk3ag8CvQ5ydeXTkT+F/jlOJvMl65WqDH/JqOMmNaMsDCtGWFSWr19BPidql4uIh8JPn94grL/AjwKzClVY4wyU2N9m03SjYpDVfFLF919saruDD6+AnhonGLmS1cjlFJrhpGLac0IC9OaESYl1tt5wGnB8reB2xhnki4iy4CXAJcB/1aqxhjlpdb6NpukG9NGuT2zXCof4hI+Kfu8iDwLZ77+FPBOAPOlq0yqXGtGtaF/cP/l9NIc3rRmpElrDUqiN9OakaHEWoOS6m1h+sWKqu4UkQUTlPsy8CGgpVQNMfKgurVWcdgk3ag8FPwS+Zyo6hsnWG++dLVICbVmGKMwrRlhYVozwmRqvU0a7HeKOEJTIiLnAntU9T4ROS2ffYwqpcb6NpukGxVHrQWGMMqHac0IC9OaERamNSNMCg32O1kcIRHZnXZTFJHFwJ5xij0XeJmInAPUA3NE5Duq+oY8T8GoEmotSKFN0sch18Q2zXimtuOVmynlSD01E3LPOeXXEfVKUklNmbOM1dFEWiiW3qpRayWsxLSWR7mZUnVaEw/xk+Pndyi8EtNaHuUKoRr0dpDWoPh6M63lVa4Qqk5rqRG3HClJRaXU243Am4HLg/8/P6h61UuASwCCN+kfKNUE3bQ2Mcrtpe3XXCU1FaTQJulGxaE1Zs5ilA/TmhEWpjUjLExrRpiUWG+XAz8UkbcDTwPnw+g4QqWq2Kg8Sqy1igtSaJN0owJR1LcbDCMMTGtGWJjWjLAwrRlhUjq9qeo+4EXjrB8VRyhn/W24yZUxKylp31ZxQQptkm5UHvYWwAgL05oRFqY1IyxMa0aYmN6MsKixIIWzfJLeWzS/kFL7x052/ErwRxmvfVHv5KIc56AyCn7V+dOZ1opJvn5f0znGuGVMa0U5zkyPXwl6O6iN3kEvbaZ/jPHKmNaKcpyZ1mFaqwaKozfT2jjti7y48GNMVK4q9WZaKxZh9WuQl9ZmVZDCUoT9MozCUMVP+BP+GUbRKKHWRGSuiNwqIk8G/9snKHeWiDwuIhuCYCVjt39ARFREOgpqkFFeptCa9W1G0TCtGWFi92xGWJRWa+kghTBJkEJVXaaqq4ALgd+XMouATdKNikRTOuGfYRSTEmotHSl0LfC74PMogjQeXwPOBo4AXisiR+RsXw68GBcwx6hyJtOa9W1GMTGtGWFiWjPCooRauxx4sYg8ibvvuhxckEIRuanQg8+EWW7uXpuEkrqqhG1QBT9pT1+rAdPapOQTKfREYIOqbgIQke8H+z0SbP8SLkDJQU90aw3TmhEa+gf3T8r3HsO0VhtUe78GpreqQv9Q1n4NKrdvq8QghTZJNyoPVVJmImWEQWm1lk+k0KXA1pzP24CTAETkZcB2VX1ApBQJR41QsX7NCAvTmhEmpjcjLGpMazZJNyoOBSx7jBEGeWitpJFCgfFm3yoijcExzszzOEaFY/2aERamNSNMTG9GWNSa1mySblQeCslkuRth1ARTa63UkUK3ActzPi8DdgBrgNVA+i36MuB+ETnxuOMOm7TBRoVS4n5NRM4HLgUOB05U1XsnKPcU0AukgORk+jaqFNOaESZ2z2aERY1pzSbpVUAl+CyNR6napUDVZfOYJZjWiko6UujlTBApFLgHWCsiq4HtuGihr1PVh4GMeXxws3u8qnYef/y6kjU4bCpRb1WqNYCHgFcCX8+j7Omq2lnS1lQY0/peQ/LZNK3NTmqpX3PHtnu2cjHt7zWEvs20Vjxskm5UHFpjT8qM8lFirV0O/FBE3o6Lzn4+uEihwDWqeo6qJkXkPcBvgAjwzWCCbswySt2vqeqjABa/wDCtGWFi92xGWNSa1mySblQeWls+J0YZKaHW8o0Uqqo3AZOm9whychrVTOX0awrcIiIKfD03xoIxSzCtGWFSOXozZjs1pjWbpBsVh1JbT8qM8mFaM8IiT63NOFChquabpu+5qrojyDZwq4g8pqp/zHNfowowrRlhYuOoERa1pjWbpBuVRwmflInID4C0U28b0KWqzxqn3FNYwJvZT409lTXKSH5am3Ggwryb4Sw5UNU9InIDcCJgE6fZhGnNCBMbR42wqDGt2STdqDhK6XOiqhekl0Xki0D3JMVrLuBNrVFr/k1G+agErYlIE+Cpam+wfCbwyfK2yig2pjUjTCpBb0ZtUGtaCyeEqWFME1Wd8K8YiIt48xrg+qIc0KhaSq01w0gzmdYK1ZuIvEJEtgHPAX4lIr8J1i8RkXTMg4XAnSLyAHA38CtVvbmgio2KxLRmhImNo0ZY1JLW7E26UXHk8aRsUl+6PHk+sFtVn5yoGVjAm1lPrT2VNcpHCBG3bwBuGGd9JlChqm4CjildK4xKwLRmhImNo0ZY1JrWbJJuVBx5BIaY1Jcuz4A3r2Xyt+gW8KYGqLUgJEb5MK0ZYWFaM8LE9GaERa1pzSbpRuVRYGCIqQLeiEgUeCVw3CTHsIA3tUCNBSExyohpzQgL05oRJqY3IyxqTGs2STcqjhDMWc4AHlPVbeNttIA3tUOtmU4Z5cO0ZoSFac0IE9ObERa1pjWbpBsViV/a+A8XMsbUXUSWANeo6jm4gDc3uNhyRIHvWcCb2UuJtWYYGUxrRliY1owwMb0ZYVFLWrNJulFxhBD05i3jrLOANzVIrT2VNcqHac0IC9OaESamNyMsak1rNkk3Kg6ltnxOjPJhWjPCwrRmhIVpzQgT05sRFrWmNZmNeeXSiMheYEu522GMy0pVnT/eBhG5GeiYZN9OVT2rNM2aGaa1imdcvZnWjBIwU61BhenNtFbxzBqtgemtwrF7NiMsZpXWCmFWT9INwzAMwzAMwzAMo5rwyt0AwzAMwzAMwzAMwzAcNkk3DMMwDMMwDMMwjArBJumGYRiGYRiGYRiGUSHYJN0wDMMwDMMwDMMwKgSbpBuGYRiGYRiGYRhGhWCTdMMwDMMwDMMwDMOoEGySbhiGYRiGYRiGYRgVgk3SDcMwDMMwDMMwDKNCsEm6YRiGYRiGYRiGYVQI/x8+fkAj8yql7AAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 1368x504 with 24 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import time\n",
     "rel=0\n",
@@ -2900,40 +1128,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 1 0 1 0\n",
-      "8 2 1 1 0\n",
-      "2 3 0 2 1\n",
-      "9 4 1 2 1\n",
-      "3 5 0 3 2\n",
-      "10 6 1 3 2\n",
-      "4 7 0 4 3\n",
-      "11 8 1 4 3\n",
-      "5 9 0 5 4\n",
-      "12 10 1 5 4\n",
-      "6 11 0 6 5\n",
-      "13 12 1 6 5\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+kAAAGeCAYAAADohUAvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAEAAElEQVR4nOydd5wkR3m/n7dnZuPtXj5d0Ol0yiJJgBJBCUkgHSIjMohkE0z8gYk2lrGxhU0wGJtgWZbJYAOSLMtCQkggIQQKKCKE4ulyDpt3Zvr9/VHV0z17G2Z3Znpndt7n89m7DtVV1T3fru6qft96RVUxDMMwDMMwDMMwDGP2CWa7AoZhGIZhGIZhGIZhOKyTbhiGYRiGYRiGYRgNgnXSDcMwDMMwDMMwDKNBsE66YRiGYRiGYRiGYTQI1kk3DMMwDMMwDMMwjAbBOumGYRiGYRiGYRiG0SBM2UkXkaNF5Hci0ici70ujUvVGRB4XkbOnSHORiHy7RuW9S0S2iUi/iCyewfE1q8s0yz3E1zlTxzI+ISKXzPDYM0RkY63rZBiGYRiGYRiGMVtU8iX9I8CNqtqjql+eLKGIHCoiKiLZ2lSv+RGRHPAF4PmqOk9Vd812nSpFVZ/wdS7WsYy/U9W31yv/emADVzUpr6qBK5/HlHVuJEw3NSlvRrqp14CeiJwqIg/WOt+Z0Kr6agbqNdBezSB3jevRktprhLatnvi6HDbLdWhJbbUyjfRcnW0q6UyvAb5f74rMFBHJ1LMTWQMOAjqA+2e7Isb0EZE3A2eo6psTm6OBq6dXcPyhwGNATlUL9ahjs5EYuDpFVe+e7fqkiOmmChpRN6p6E3D0bNfDY/pK0ArnqKp/N9t18Jj2qmA6bZuIKHCkqj5c73qp6rx6l1EBpq0Es3WOInIG8G1VPbjeZTXYc3VWmfRLuoj8HDgT+IofUTtKRF7oR7X2i8gGEbkoccgv/f97ffpn+XzeKiIPiMgeEfmpiKzx20VEvigi20Vkn4jcIyJPmaJOl4nIV0XkahEZAM6cok6IyBtFZL2I7BKRT07rCsV5nCIit4jIXhG52ws22vcWf359IvKoiLzDbz8KiEaD9vrrOVkZTxaR60Rktx9R/cQ4aQ74IpQclfMju/8lIt/29bnX/24f99d5g4g8P3HsjSLy9yLyW/8bXCEii/y+MssIn/ZvRORXPu9rRWRJIq83Ja7zX053JDpR3oUi8oSI7Ez+XiLS6X//PSLye+DEMXmtFJEficgOEXlM/KiriCwSkY0i8iK/Pk9EHhaRN01Wt0lYQwMPukgd3RNqRKoDV/6euTGNsqbAdFMdM9KNNLhlVw31afpqQJpAfxeNfWeaAaa96pizH3PEDSpUg2nLmDYN9N5XFZN20lX1ecBNwHu82fMfgQHgTcAC4IXAu0Tkpf6Q0/z/C3z6X/t9nwBeDiz1+X3Pp3u+P+Yon9+rgUrMwV8HfAboAW6erE4i8iTgq8AbgZXAYmBaI0Eisgr4X+BvgUXAh4EfichSn2Q7cD7QC7wF+KKIPMNfryf7NAv89ZyojB7gZ8A1vp5HANdPp54JXgR8C1gI/A74Ke63XgV8Gvj6mPRvAt7qyy0Ak7k1vA53jsuANty1iK7zvwKvB1YA8315M+G5uFG0s4BPicixfvtfAYf7vxcAF0YHiEgA/A9wty/3LOADIvICVd3tz+/fRGQZ8EXgLlX95nQrJjZwlcyjrgNXIvJsP1Cz2q8f58s6Zib1nU1MN2V5pDHgqSLyZyLyEPBQYvuH/DXaIiJvSWyfLyLfFDfAt15E/kJEAhFp9/V8SiLtUhEZEpFlMmbQVEQ+KiKbfP0fFJGzZnKNpksr60tEThKR232e20TkCzM5R79PReTdIvKQ/w3/RkQOF5Ff+/x/KCJtU9TnDHGDwh8Vka3Af/hdbV5jfSJyv4ickDjmWHGD4Hv9vhf77aeIyFZJdARE5GUico9fTg5yd4gbnN/l87lNRA6q5BpWQytrb5xy6/1MjK7d3f7avVpEForIVeLarj1++eDEMWUfS8Zo5hoRec+YMu4WkZf7ZRWRI/zyOhH5va//JhH58Eyu0XRoZW1JA7VrItIN/B+w0pfZL+6j2Ek+j73inqlfifKRcdyfxbVxb5cmea42BKo66R9wI/D2Sfb/E/BFv3wooEA2sf//gLcl1gNgEDc69jzgj8ApQDBVXfzxlwHfnCJNsk6fAr6f2NcNjAJnT5HHRTjTDoCPAt8as/+nwIUTHHs58P6JrskEx7wW+F0FdTkD2Dhm/+PR+fi01yX2vQjoBzJ+vcfXZ0Hi9704kf5J/vpkxtbdp/2LRNp3A9ckrvP3Evu6ZnCdo/IOTuz/LfAav/wocG5i359G1wI4GXhiTN4fB/4jsf7PwL3AZmBxhXp7M3DZZPeE/02eitP204BtwEsnuSdeCjwMHItzOfkL4Ba/7wXAHbgBJ/FpVlRwT+wDnuPr0DFFnZ7kNXEa0I4zsytM87dahRtQW+fLOMevL/X7X4gbTBHgdNw9/4zp3BM+7WeAnwOdwD24AcMDdD9FHmfgzOWm/L3r+We6SVU3ClyHG1Tt9OdVwA1S5nz5g8BCn/6bwBW49vFQ3HPpbX7fpcBnEnn/GXG7dwZxG3Q0sAFYmajv4Wnps4X19WvgjX55Hs5keNrnmNDNlbgB9ycDI7jB8sNwA8+/Z4Ln/pjrXgA+68+jE3cPDHvdZYC/B2716XO+Tp/ADXw/D+gDjvb7HwHOSeT/X8DHxrm33oEbqO7yZTwT6K1ANxcBF5n2mqptOyKxvhh4hf/de7w+Lk/sfzx5HmPq/CbgV4l9TwL2Au1jywK2AKf65YVR3Supr2lrzrRrY/sez8T137K+Xg8AH5iknqXfkiZ5rs7237RDsInIySJygx+12we8E1gyySFrgC/5UZO9wG7czbBKVX8OfAX4F2CbiHxDRHorqMaGadRpZTK9qg5Q2df6sedwQXQO/jyei/tijIicJyK3ijNT34trpCe7JuOxGvcwrgXbEstDwE6N/faH/P9JX6Pk9VyPe2mYqP5bE8uDiXzGXudBpn+dp1WGr2vEGtwoX/I3+gTOjCziG8BTcB33CesmIv+ayONfgdcl8r1nbHpVvVFV71XVUFXvwVmKnD7J+b0D+HtVfUCdT9HfAcf7kc887kF7DCA+zZZJ8oq4QlV/5eswPEWdXglcpaq/VNUR4C+BsIIykrwBuFpVr/ZlXAfcjtM+qvq/qvqIOn4BXAucOs0ywL1QzMcN1mzGtRVzAtNNXXUD7lrtVtWozcsDn1bVvKpejXtxOlrcV8pXAx9X1T5VfRz4PM76CuC7uEHUiNf5bWMp4l7CniQiOVV9XFVr1aZPmxbSVx44QkSWqGq/qt46w3OM+Kyq7lfV+4H7gGtV9VFV3Yf76DClb6yv91+p6khCfzd73Rdxlm7H+e2n4J5xF6vqqH8vuopYc9+LlsVZ3K0jtkYcex0W4zpVRVW9Q1X3V1DXmtNC2kuSZttWQlV3qeqPVHVQVftwA9uTXeskP6Fc/68HfuyvwVjyuLatV1X3qOqd1dZ9JrSQthqxXSvDtzG3qmrBPze/TuXaa8rnatrMJE76d3EjMqtVdT7wNVynG9yoyVg2AO9Q1QWJv05VvQVAVb+sqs/Eje4cBfx5BXUYW85kddqC6wADICJduAfZdNiA+5KePIduVb1YRNqBHwGfAw5S1QXA1Ynyp1PG4RWkG8CNmAIlf5ilEyeviNWJ5UNwjcPOaeaxhYQbgYh0Mv3rXEkZY+sasQF4bMxv1KOq63x9MrgG5Js4d4gjJipEVd8d5YGzFvhuIs+njU1vA1d1G7hCVfO4keunAJ9X1fHamAMQkY8l6nUV8NwxdZ11TDf1041nw5j1XVo+0U40ALgE9wUzOei3nthd5+dAp782a4DjcS+3ZaibyOkDuIGl7SLyfRFZOV7F0tBnC+nrbbh3hz+IM/E+fybnmEgzdpB77Holk2ntUNXhMdvGDj53iDMFXQlsUNXki3tSf98FXu7fNV4O3KmqSa1GfAtn4fd9EdksIv8gbkKyAxBnEh1dg48BH0vo76oKzm9SWkh7Y88hrbathIh0icjXxZlT78eZQy+QCnylfaf+f4HX+E2vAb4zQfJX+DqvF5FfiDezHqc+B7RlyXURee70zvCA/FtFW43YrpUhzv3gKnEuOftxgwOVaropn6tpM5NOeg+wW1WHReQk3OhHxA7cCFEyZMPXgI+LyJOh5Pt3gV8+0f9AOVzncxg3alLLOv03cL5vONpw5o7TPe9vAy8SkReISEac79cZ4vx+2nCjPDuAgoich/O1ny5XActF5APi/DV6ROTkcdL9Efdwf6G/bn/hy6+GN4jIk8QNYHwa+G+d/oz5/427Rs/21/mvmf5AxVT8EKelhf7avzex77fAfnG+K53+d3qKiESTy0WT8L0VN6DyzUoeYhViA1f1GbhC3HwQf4Xz6/y8z3tKVPXixEDL+bivWAsS2xoB002ddOOpaEAHNyCZx73oRBwCbALwnacf4kb9X4f7KtI3boGq31XV5/q8FGfyPF66NPTZEvpS1YdU9bW4eVI+C/y3OB/KaZ9jDalUe+AshFaLm1clIqm/3+M67ecx8dcm1FmI/LWqPgl4Nk5X406OqqrnJ7R2Me4rfnQ9JusMVEpLaG+cc0irbUvyIZxJ8Mmq2ks8N1SUd9mHHWD5mOO/B7zWd7o7gRvGK0RVb1PVl+Dus8txbeJ46Q5oy8Zck5une4JjaAltNWC7Nl65XwX+gIs20It7z07qDibQXhM/V1NlJp30dwOfFpE+nB9y6UZVZ+L8GeBXfuTiFFX9Ce6Cft+PtNyHe9iA84/4N2AP7iG0C9eI1bJO9+N8Hb6Lu1n2ANOKl6uqG4CX4AS4A3dD/DnOj74PeJ8vcw9ObFdO9wR8PufgfMi34iY7OnOcdPtw53sJ7iE+MN3zGYdv4b5WbsX510w7FqW/zu/FhevbgvOp247zfakVf43TyWM4U7FvJcov4q7d8X7/Ttw1mi8izwT+H/Amn+6zuBv9YzWqlw1c1WHgSkQEp8t/x40qbwH+Zrr5NDCmm/oMeE4L3yb8EPiMHxxdg2svkvGPv4sziX89E3SSxMXzfZ5/IR/GfZ2YzfCgLaEvEXmDiCz1L317/ebidM9xFvkN7pp+RERy4iYbexHloW+/i3sun4bzOT4AETlTRJ7qB5/34waeZkt/LaG9MaTVtm2j/Nr14NqaveIi8/zVmPR3Aa/x2joBZ36d5Gpc5+fTwA+03KIDABFpE5HXi8h8ddZt+zFtVVqnudKubQMWi8j8xLYenBb6xU3o+65oh6ruwPVR3uDvh7dyoLVwMz5X00UbwDHe/mbvjykmBqwi33m4yTHWzvY51vua4R5663EDE1fhzKe+ndj/aVzDupd48o834iax248b9LnUbz8LN0FaP26g4TvAvCnqcxnwt2O2TVWnC4EncANjn6SCSdhITDjj108GfoEzrdqBM5s7xO/7M1yjvhc3mPL9qI5UPpni+/21aPPrK3050eQ1U9bZpzuDBphAxHSTjm58WqV8cqUzmHzCzYW4l+xoEPZTjJnMFDcxz+5Ij2PzxU0Y9Ft/7Xb767cyLX22sL6+jRsQ7seFanrpTM5xAt3cDLw5sf63wCUV/J5jtXbRmPMs0zLuK94vcBNS/R542ZjjD8G9mP/vRPnivkg9iOtsbMNFaankXrmI2k8c1yraG/u7ptG2vRM3YL0XeBXuuXijvz5/xPknJ7V1GG4gqN/X58vJOvs0/+6POXHMdsVFGmrDRR7a43+f24DnVqgNNW01f7vm013qz2Gv191puC/p/bjIXZ/Gfb2O0p+H+2i2FzfPyy8Y09+gwZ+rs/0n/mSMFkVcHMFvq+olNcjrRbgZIwV3Q56MmwHURGYYhmEYhmEYhlEBMzF3rzvi4oT2j/P3+hqX838TlPOJqY+eUXmnTlBefz3KmwVegvOv2wwciQudpmlfZ8MwDMMwDMMwjGbFvqQbRhMgIvdTPrFVxDtUdaLZWGdSzv8xfliYv1PVv6tVOYnyTsWF/zgAVZ32bKNGOaYbo57MVX1VUJ9PEE9GmuQmVT1vnO1GjZmr2rO2bfaZq9qqoD5zvl0TkUtxk8ptV9WnjLNfgC/hIhkM4twCZiXcIFgn3TAMwzAMwzAMw5jDiMhpOB/6b07QSV+HmwR7Hc5l90uqOl6krVRoSHN3wzAMwzAMwzAMw6gFqvpL3AR0E/ESXAdeVfVWYIGIrEindgeSna2C02DJkiV66KGHznY1jHG44447dqrq0vH2zV/wZC0UJnbTHxx44qeqem7dKjcDTGuNzUR6M60ZtWamWoPG05tprbGZS1oD01sjY+9sRlrMstZW4WbHj9jot22pIs8ZM6c76Yceeii33377bFfDGAcRWT/RvkKhn2OP//iEx97xq3ctqUulqsC01thMpDfTmlFrZqo1aDy9mdYam3pqrQLfzTOAK3AhlgB+rKqfnrrWE2N6a1zsnc1Iiyq1doyIJH/Yb6jqN6ZT/DjbZs0vfE530o0mRQTJZWa7FkYrYFoz0sK0ZqRFbbR2GS7e8zcnSXOTqp5fbUFGk2Ntm5EWU2ttp6qeUEUJG4HVifWDcRGrZgXrpBuNh4AE4w1mGUaNMa0ZaWFaM9KiBlpT1V+KyKG1qZAxp7G2zUiL+mvtSuA9IvJ93MRx+1R1VkzdwTrpRiMi2KiskQ5Vak1EVuO+NC0HQpxp1ZdqVDtjLmHtmpEWlWltSZVmoQDPEpG7cV+aPqyq90/zeGMuYG2bkRbVv7N9DzgD1/5tBP4KyAGo6teAq3Ezuz+MC8H2liprXBXWSTcaDkGQjI3KGvWnBlorAB9S1TtFpAe4Q0SuU9Xf16aGxlzB2jUjLSrUWrVmoXcCa1S134ctuhw4sor8jCbF2jYjLarVmqq+dor9CvzZjAuoMdZJNxoPgSBn0QGNFKhSa94Maotf7hORB3AzgVon3SinBu3abEzmZTQhKTxDVXV/YvlqEflXEVmiqjvrWrDReNg7m5EWLaa11uykh9eDhm45c05t8tQb3P9yZm3ymw2icwBUym8C8ddrou3j7VN16wGFsn3C6ZPXYy75N4XXQzHvlnM1ikAyx7RWttnrZKzeRMNxl0tpw4JLn2kryy9NrXn/zacDv6lJhtMleU1rqQ29YW5oTUNI6Kakp7BQ2q4SIBpSpB2AQPLjZikjA2h7d5lOU9LaZTTCZF7RNQ0LtXuGRvk2s9bAnYNvjwjcK1akNdWAoDjklrPtJf2EZA94TkbI0D7o6ImzT09rkxchshzYpqoqIicBAbCr5gVFWhsdgvZ1tc232bWWfJcN4tf5sc/RvHaTDZzupDh6gC5L7dijdyJrj3fLifwaQW9pofzCXY9aP0OhufUWXh8vj3mOJvsBIVlE3PrYd7UkMjIAOfecbVWtVUJrdtKNxqYGM4WKyALgEuApuPAJb1XVX1dfOWNOMbXWKvLbFJF5wI+ADyS/MBlGiRq0azaZl1ERtXmGTuW7+UrgXSJSAIaA13hTUaPVsNndjbRoMa1ZJ91oOKQ25ixfAq5R1VeKSBvQVX3NjLlGBVqb0m9TRHK4Dvp3VPXHtayfMXeoUbtWCTaZV4tTC61V4Lv5FZxVh9HipNi2GS1Oq2mtdc7UaB7ETQwx0d/Uh0svcBrw7wCqOqqqe+tbaaMpqV5rgtPZA6r6hbrX12heptCa19sSEbk98fen0ywlmszrOOCfcZN5Ga1GZVozjNpQ/XP0XBF5UEQeFpGPTZLuRBEpisgra1p/o3moUmvNRst8SS+Et5IJRtxKkC3zoagW3f0dRucfDUBb5hcMFRYB0DX4B+i9oGbl1AzvH6MSIHnnp1TM9qLaCUAmGHG+cxTiQybwK5loO1B2/JR+JmOQbFXmLIcBO4D/EJHjgDuA96vqQDWZVkyZb3AA2fbaZb3pq8jKYw4sp5iH7PNrVk5N0Rsm9gceM6fBRHMcTLRcOs77NM3El6xKrT0HeCNwr4jc5bd9QlWvribTipnAt78mWe/9HgAyf3m5DzLU1g+5loyZV6OsnR87n0Zx1C0E2QP0FTC+L3opTeSP7rVW6atBBVqrasbtuk7mVbzO/Z/wHyxbroYRf7vk2kG972NYjP1tazWfRy1J+p7nRxjMrgGgKwjj6+LbvUiHQogmngeldpAQneCbiXbOj3UsZ9ZSa43N2LatrbNmWV+z6GjO3fEVCBL+7hn/mzXic1RvIK/dACXfcnDtTjQPi4SJ963CCGTbS/rKSnzM2HlbIKHDw56RyDuddzYRyQD/ApwDbARuE5Erx0ZI8ek+C/x0RgVNRkJrte7m6f1/hxx7sl/zbUb0vAnOqnFpNcBfi5AswcAOt6174QHPzwl9zWXiearKjk/M6ZJy/6CpaJlOutFECFONiE3lJ5wFngG8V1V/IyJfAj4G/GXtK2s0NVNrbVJU9WZq/1w35iJVaq2iItKazMtobFLQmmGUqE5vJwEPq+qjACLyfeAlHBgh5b04t7ITZ1qQMQdosbbNOulGwyFTTwwx1demjcBGVY1m2f5vXCfdMMqoQGuGURNqoTWbzMuoBGvXjDSpUm+rgA2J9Y3AyckEIrIKeBnwPKyT3tK0WtvWMp30bHBK+YYKBmKGCnfTmdldWtfdG92h8xZDcRTtWujWu+bTPrjeF5SjS/rccq69ZManezYjXfMhiMWlBW9+XywgbX5es55XTPPMpkH+GvpYQ3fW/exBcRjNORMy0SJBEJt4ipSb35XMUcaYoE1mzhInCqf9rbGaEAuqulVENojI0ar6IHAWacatnkmYjbGmfZF54+A+hjvXApAPO8gvOY8g7/YFUkAoApALhhkefRSAvvxBLGl/GIDOYCfkRwjbXAifUHOlsFKBnDr9elbKyNWl8BpIMKGpsWbaYpOnZJg1TkfC6+PjNCwL03EA0fXSEKbZfjd1OI+ZaC0KpRJd21FvChkEkB/2aUIkMi8d7jswD73c/V8sxmaomcTvoyGEYTompPlr4nPJ5MYNrXYAGsZmopyOJF2AJgkbE1EylU9Za7M6mddMXBwiM/akqXLfTsjmID8Sb4uu98hAvBwW0KIz4ZXMD1ANkchUN5Nx+gJIjkG0ddY2TNdY+n8MWV+HXHts1t6epVP8u0KYNGN351FKJ2ci+Wvc8jhm7+ORDDE5Hb01dbsG02/bxtzDgHMDS7q8eD2du+1L8X5wbZ/46zV8Vfwbi5Q/vzR0bhgR9WzXhq70ZbRBJkdOnLeeEsTtD1AI3b2Vk4FSWx12LCSQU8vbNe/aGL3zjUdIlqB/u1vpmTDZuEyht8msH8c7cOzA4j8BH1XVokgddD3D56gmXWcncKGVJz2rfEOQjdMWryt3jRmDVuHGNy0K18Z1yORcmUHozNwrIaqb11vkejHZO5v074JOL7JWemebJi3TSTeaCJFazN74XuA7fmb3R4G3VF0vY+5RG60ZxtSY1oy0MK0ZaTK13iazftwIrE6sH4yLTJHkBOD7voO+BFgnIgXVaLTYaBlarG2zTrrReNTA50RV78I17IYxMS3m32TMIqY1Iy1Ma0aaVKe324AjRWQtsAl4DfC6ZAJVXVsqSuQy4CrroLcoLda2WSfdaDhEINNCszcas4dpzUgL05qRFqY1I02q0ZuqFkTkPbhZ2zPApap6v4i80+//Wu1qajQ7rda2tVQnPfzlhwGQI4+K/TCzbWX+crL0zSWfzc6BnbFPXFsnDProNp09UMjDricA0KSP0t4d0DXPLbd1xn6dgD54D/R6H4ye3tgnr7MH7XOhDiTr/JDC39zo1g9aBgtcSDe2b4UlS932Ve+Ky9QbYGAPuv4PbrWvD0a9r1U2Q3CK85vSPZvpWdrOSBg5G3WSVefbFEieUHOl5WQ4j1DaKOqtLrviSCkcTqg3IUwcyq7kZyfBNF3ShWAO+Jwov2C4sICCOv+2tmCAwIenyI1uh47zARgu/o5c0E5/fpk/LqDof4u29n5GC05PQpGOTB9hYq6AyB9NNCzNn9Ae9DFQWAJAPtNJkMkTFnKlPIra7utzLzkfzmXH8FG0BQN0ZPe6OmhAZ2YfUD6fw1Dh7pJP+0jYSyB5+kZXANCV3V0Kv9GVWxSHPPT1iy9MHKIoqTNXP59EfuGWS75O1090md3upO/WtJgjWtv0VejsdStR6KrILzbXDvNf7fbt+0FprgAdHUIkKPeJK7t+TjNkgpIvZ+SPqdHvFobg/SOlrRP17aok7n3Hfzk/5GS54MrOJUIU+nsCXAg4ifx2E37HWhxFJECjug71IUsPLZ3DARqYyFfQbx8q3k2nf+YLp0N4XSmk31hf4VLeMwo9Nke09ptPwiFrEhv8NdmyBd22jWCde6fWJ/45/m2HB6DdPwuja1rwz6jRYehd7Ha1daLRHAjFRAjQnduhrQ3tcmGo6FkE2/xcUx3tsQ9xJgd9/wh+3hUyWRjyz/qubuheUMpTFr2+tBz+/API6lV+RV1acL7g3vddt21H2tuRo4/3+7LxOQASzb8gUuYzjGpCgzfE89LImW4+BUAS4bLGkgwxWTlzQ2vR9QGcHpLXKPDLuXOdH3kmeqYkfPjbOqGYnK8k+o2i9slfIyX+LSXR3gWBi48QvatlsuXtSXJ+gYT/+3BwEB24qIdh0FE+/8vwVf6YNqeFKL9CPq5fYZTw1z93VThtXVmZMiacaU73RRcEOnr8UoFQbyq9KQinQ+b60vETtWtCCPMWMX2q05sPWXr1mG3jds5V9c0zLmgywsQ7hgTxNc+PlM+tEoWihPL7vJL5mSKSGoq0mpz7wG8rez8KfbmqpTYk6fNdmoMl6bseaS35jE3Or+DPT3e5tlRWHFXaXla2PyYZOlcS9Vb5hVvEa01uKKWbcL6NSv3dD2COtG0V0lKddKM5EIFMC/mcGLOHac1IC9OakRamNSNNTG9GWrSa1qyTbjQcIpDNts5NaMwepjUjLUxrRlqY1ow0Mb0ZadFqWmuZTnr4yw8TnHgaAPrwPbB0ud9RcKZ4APv3oXv/Ed3hzJSkvQOWOrNhHRmGefPd8vCAM5ePTEjyw7E5VP9AbO7evwf1i7R1ovlRgsOe5vLY/li5CcoeZ6qsEkBYRI4+xm3fvROZ78yg6V5YMhml70doZGrTtxvd8ATs92aCXV3gfTYk14Y+dIfbPq8H3beVtsKG+Ny9Of69xRfztIW3+jpky8x9gqFdBN6MKsx2l0yoguIQYcabW0u5SalwOvq7i9zKqkPQwgNu+8p3MjVCEDTvTVjUW/xSjvbMfjq9S4EzC3LnNZJbTk5vAiArOULN0pHZC4CSKZnIh5qj02/PBUPODF6zvpxsycQ9G4yWzNBVA7Le1Dyn+ygG3aVQbSIhI8VeX+5IKczeovbHGCn2kMGbWQVxCL5CeCv9BafBQDpp8791VkYQQnratpTOPSfOtLSg7WhY/hsOF52GOjP7Sm4SGRkpM6EKfZMkhITSVtLaRKE8SqFJolBPQQCBNwurKGRUc2tN7/87t3DQwbBnq1sezUNXZ2ym29YBe78UHxSZn+Xa0Uw2Xg8ysVn52PBlidCRqELBazppepk0E23vhmK+ZP6OhuBdLgiCkhsRGiKZTHx834/QIW++GYboyPa43CjkVmcPmm0rmapK13wY7nf7sm1x3QByHbFZbJApPycffqkz2AkJFxLyI9A+waPRmxLq7u8guQ7w7kl0vnj89OUHN7fWHvwHt7D2cBjyz5pCATq9afi8bqTrUPSBi+N9EV2dsG+vW85moL0DRny4v9E8DLvJnBXi36tQiM3Wh0fc7z/sjxkejPPP9UKfd0UbHHTm6pE55KKF8XIQxHkD+sjn3f87djq3sv6BuL5ROb09Jd3JypUuffS+sGN9HEKoWHA6BPdcb++O8xJxoeUA2rsTof+I3z26MhCFl4OykEv64D+gPd6VpWNzmZn+xDS31gDXpo81Cw4S5upRG1K4svy+Dgux+0N+ZMw9H4WyyzoNtXeV8tOBXQCMfv2/aP/AW9324SH33uXftcK2HoLRREjKpNsPlOrbUdjg2h7cexJ6TXk6cO1UwvULDeP6SUBwxov8MUXvMlGMj0uGiIvM9NvKQ6sFOsregptvbUEbcei4zDi6iEyko1BcAMH1EJx1YNpxaXK9hWPc6ZK6y7XH68mwsJWiYdw/SL7zA/rHO5CjnunzLgKx66xm2w90mwEQid37iqPlz18NoeC1FmQO0EQZifcAWXHUxHVPpJcx66VFvz0k656kfn3se1vpeDmz3IWxcE3JjXZqmlxr06RlOulG8yAC2RYyZzFmD9OakRamNSMtTGtGmpjejLRoNa1ZJ91oPASkhSaGMGYR05qRFqY1Iy1Ma0aamN6MtGgxrVkn3Wg4RKSlfE6M2cO0ZqSFac1IC9OakSamNyMtWk1rc76THv7sfQBITw96320ADP/v7+h423lxov6Ef10YOv83QIMA2eZ9IsMQ3bW7tCxrD4/9zPbthW7ngyZHPq08zIf3j9Qd65HFi9HH7/V5KPQucMtDfbE/3Ogoums3staHuFm6HB3Y67Kbt4id4vxXlnStgh2XuTR797jwL2sPLeXBoPMF1b4+ZEFvKZ1ueALxfvYUirDY+eY/lR9Bn/OXEQkozFtNdtT55hNkS/6bQQZKcbKyzwfvVy1hAQ2yLvyCR55+kavD/X/Hwwd/EIAjmRoBgkxzjpS5sHSOgAIF7SxdL5EQVde4ZIPRkh9/QP4An/6k51LSDygbxH5BOtZHKIpSJZBTr+kgS4aROORgfhjxPqSa8MPNBUO0Z/aX+atn8ZoMzmJ+mwuxUQg7S/7kQdBfOq+IYuhqngkGSucKIE/cSc8hbj4GBvZAh5usIcx0EoSxz36SgNinVTjdhRoce96RL137On8NboBCFC6HKWlmreljX4R5/rd8+IHSPS8r/Hwbvh1j9143pwa4tivn/RmzWXd81A4ltTQ0ELdJ87ohOmZk2M25Merzy8SPEM3HIfdU1dmlRSGOglzsE1kYcSGLwPlglsIb5aDnFUj4A5dH/+7Yhy/Ixv7E2Xbnfz/fhaPUretLc3DQuxi9yWk1OHtd3EaD9x/2dUiG2NHE7y+4MHDeR7FMGYnQNrLo9eiubyF0USlNrbV7/7akNUaG4nu1Z6H73SLyI7G/LMS/vwQw7J8nBSDp19uWgzZ/TKEQ67ark8K1vwUg+9ynwmgeHRp02YUhOuLSSVui/EUL3TN8r5vXQDdsRJY6nbB3Dwz6uQuGR5Cn/oVbHr0Y3bI1vm+CwNUJoKPbhT4FWNTh3hX6fN0XLiL/fTcXRu4165xewfmnL/Lh3Ir5cr/QYj5uuzJAzyv89uuQkYGE3mNfYDn6I/HcExVGLWpmrZXCmuWH0cII4ufDIUjMn5EMF5mY36JEctt4x0S+5PnhUt7ifcjb3//m8hCLhdHSfAFBcajkn06mLTGfh/eRj36/Qr68flFoyZGry+tTdq9k4/poGLdduXbIdZTm/yHT6eoBzk85KjM5j4g/797cJp/5Ye59DSC8HvHvc2RyZe0a2efHfunDfVTavDWt3iJfdA0n9O0HJvdDLz1HxoT6TPqKJ3zRB8NldIlrU+ToE+P0+aGydFIcjf3Qk23smPBn8bkUXF9i3st9ftdA6M9pjC98WX39PFhA2bwtGmTHhIBLzAmR1FrSNz16F/Ttl+gN0Ofb/Z4l5VoLzoqv/zT8/JtWazNkznfSjSZEhGy2gh6WYVSLac1IC9OakRamNSNNTG9GWrSY1lrHZsBoGgTnczLRn2HUCtOakRZTac30ZtSKWmhNRC4Vke0ict8E+0VEviwiD4vIPSLyjFqfh9Ec2HPUSItW05p9STcajxabvdGYRUxrRlqY1oy0qI3WLgO+Anxzgv3n4TzYjgROBr7q/zdaDWvbjLRoMa3N+U568fEdAARde5FlCwDIHtTtYmSC8+Mc9X4bHd4nO/LZbmtz/t0AXZ1Iws+bnYn4vYUCxd+6wWYdLpA5fFlpO13OqUe6u2HV6tjPaN4iGHSxXWXN+8G7oOuWb0BfP/tXvwSA3k3/A2ujAerTWZI4N1n6ZlfM/7yO4NBlFG75g6v2B38Ux6rdtBmNfEsXLXB+fetdnHRZuADm+X0i6KCPT5xrJ7PpEXSe9wVLxO+URStRH3NZ1ryfQE71x4/x30zW88mfKPmij375leSedewEKUtVIWjSETElU4pJHpJ1fuiRc7TG6YRimc+2alDy50lud4clfH4IS3HFywgLJb8iKdtfLPdnmvfy2N89EfNTJUDCAu0Zr8nE3ALl67+Nt0l4gK94FKs92l9izfGxy3z3wpI/lEhYdl2CKKZ86HzqVH4Rl+/9maT0zzjImeBPNx/+lkAKEySM6ti8WmN/X6ntklwbmvXXPgjcvigm76IFiPfRpasrji/t27NSrOb9fW6eCnBtoc9bd+yM/YQ72pH9/bBiRVyPYhR/NxFnPT+MrPjTUhLd8o04fbYN8b6Y2rsMxmiN+a92/w9dEvuh79iKPPkT7phd34K2Dje3AUChgEZzh2zYhBztWhvdtx2yudjfbbiv5Asv3QtL8zRocRTxPqda/B6y4LUVxQeWxW+Mz++hf4z9qidK38xaG83Hz8nu+bDNxTVnx04XAx3cb1UoQOB1lc3EemrLlcchz2bLY0aHXjdd3e63BchkyJ59Qlw+IPN9LPJCAen05e7ei5z8mTirG/9fSeOjv1lP23G+TTv/dQe0awBy7MfIX/8qstF90dFBcNrnANBNX4Wl/nleLMKCRfEcCgN95F7q8wvD+Hx27EQHBkrnLUsPQRNzgpRiq+/5IrL2g/5cz5l0Do1I+wDh1e9EFi+eODG10Zqq/lJEDp0kyUuAb6qqAreKyAIRWaGqW6oqOLqOuQ7nJz42VjqgnfOdDz/EscajdIW8u+/B3fvJWNMRHT2uPSjGcanJ+B8gmVfkBx+1Q8UCdL00PmboyrjO2baSNrSjJ9Za4vFL+zrnlx7VDeL40MXrSrHVyQ/7CYD8+Y0OEuDfWTNt5fVJ1jXypw6LEOYJiJ7HiTjUwVmT29BGvutZYPiq8rpOQFO3beDOL7p2GrrrF1RgUj3WD30cirSTkZFS+q7MToje8ZLHZ9sOvM6ZxHOoeF1crPfzlrZOtMtNVCGcDvMSx+bOjed3KObj98DIFzwx74Jmfdz1xLwNEhZKc1G5uQsS87hIcMD8B/Hx18fPTzkTeie5OFG6oPz8JqPptTZN5nwn3Wg+Wm32RmP2MK0ZaWFaM9KiQq0tEZHbE+vfUNVvTJj6QFYBGxLrG/226jrpRtNhbZuRFq2mNeukG42HQCbXOhNDGLOIac1IixpoTUQuBc4HtqvqU8bZL8CXgHXAIPBmVb2zqkKN5qMyre1U1ROqK+UAdJxtxlzHnqNGWrSY1uZ2J31kG9nnX+iWE+HQssc9Iw7RMW9+HJ6qs8eliUyg2jtLx9DeDQt8VmHRHT/gTUgHh9Bhl1+wqCM2mz/kSPTx9S5NILBre2kfm9fDqrUH1llD5JgnMb/tCLcemcNNQtg/SuagZbR98J9K2+TYj/n/oe9dz3On95xVBCsXI8e7sA+S60D3ezPRXIczAQNkwXK0swe2+LovWORC0YALVbLyaLfc/+M43EOF5M56RrmZ4zgIUhNzFhHJALcDm1T1/KoznJR+inpLydQ9Imn+HWqOTOhM9MKgIzaDh7LjQs2RCbzZnAZj0sXXriz8WpBFvcmuFEfjZW+yFLa537Zs/DEsxmZOnA7BxFbkyfKjcyqZ85WZof/iwGO03ERfJaCozrQs0DyhuOUMI3EoEBF3L5TO8YZSOZUylam7q3NttJYqhV3O5HvR4vi+zA8j7X65mHdml6U2bhEsdOGlJNsem94W80hnL1uCMwBYsfzmUhga7dsBbS7UlPQPwEIf+6l/AJYvj83aB/vLTZqjUG39fZCwiCeTjV1mvJsOTKE3DUG8PhPmvrL4jbAYwpv/3NdhKHZRmtcN3d6ceGgA3bQxDjm3oBei8IMjA3H4uEwuDh83uA9NmiFPh3TatctI0094YBP6m0+iIyNINKPuvl0QmZ1rCDtd6DHdtw855hjY40ORBTlKIe92702E0MtAR0ds/j44FId3A9jqQ5719qB7nEuDbtiCzJ8Xm9wHEodMy5a/xujmncghBwHQ8ckrKjvPfJH9P3QuawsuubG0WVa9K8536yXu3orCGSXDe0F8fsuWxcsbNzp3s2W+rpmsC5ME0NaB3vaXrpwT/6ayegJ0daH79k2aJKV2bSOwOrF+MLC5qhx1XxweLTI7j+7TyKQc4JHbYc1T3XIm654XpTBS2bLQkOCPSbjtldwOI7P4IBuXK0G83NbpXcl8VoV8eXzUqD7FgjMTj6LvTnaOkTYKo9D+4nh75px4uXh1HBIs9NcgMk8O4ndZ8iPQvcAtD/XFpv2ROXJ0HsUiDP2XW+69YLLalTNeqK9xaMrnKPvLzc2TyyIlU28d2IP0LGFcwmJ5ux/prlgoLWdkoNw0XMP4+VkslDSo2XYkCh+bCIUW109LdZMFr42rOtkpSkJrkbsDlLtz6Q3l75Kl7WG5q2S0DcrdAZLuIaXyfBi/yHWihjSn1mbO3O6kG82JUCtzlvcDDzC5V4zRytROa4YxOTXQ2qz5CRvNRTrt2pXAe0Tk+7iBoH2msxbFnqNGWrSY1qyTbjQcAgRS3UiZiBwMvBD4DPD/alAtYw5SC60ZRiVUqDXzEzaqpkbP0O8BZ+A0uRH4K/w0aKr6NeBqnFvFwzjXirdUVaDRtNhz1EiLVtOaddKNhkNEyE0+UlbJi+w/AR8BempcPWMOUYHWDKMmVKg18xM2qqYW7ZqqvnaK/Qr8WVWFGHMCe44aadFqWpvbnfQggKTvVuT3pmHsV1bMIwtXlpJofrgUHoggG/ssaehCXwCMDKCFUdiy0a13dZF97tNcsg0bSz5Hetc9FM//EwCyt11B+PDjiJ/wQFYsh02PueMXJeqcH2HvX3yPhZe+teLTbHvff1eULv/wHjI7Bks/enjmq8hE/kwjA+jD97h6jw4hXfPRxS70jCxcifbtcvvywzDqQ4EM7EWSIR8qQJ78iZIf3mRM4XMy6YusiEQTK90hImdMr4a1YzScR0ewt7QeSL7kK54vdpIN4tAwRW0v8wsaG4YtQsICBWL/zSg8mxCWwnwUpCfOS3JkgqHycGhRmZl57Bg6CoDlnZWdUzY4paJ0oiGhV1pIDg0D9o4698Ul7X8kK94vOiyUfO1UAiQ5Qpr0ydJwaof5MWTk2RT1linTNaV/k6qbMyMKn9beGYdLybZDW2fsow5xeJmRASTyY/fXd4X+0q0Xx2hk6cHu/8VxWBY696LrH0eO9GEUiwVo8/sS4Sx1x07k6EReEsQ+lhWSDOE2HsU/uPY3c8hidJfzg5Z53aX2fN+SJzH/oHvQh3y79shjpWeAZLLOhx5cWMq+yE+4DemZZqMGyJF/7sKwTUHz+QkLBIEL1xn50oYKI8Nued58N0cBIKtWuzSRj/jwSBzCtLcHht0x4f0PExx3TKmE8PENyFL3EJTRUUaudb9X5qAusse5uVnyT+xn4N5HaO91z+3swT1xZKtFC8uaBuntZOiHvwOg+7mVnWXbB38UeS5PTOSfG83pEGRhs7+0K5bH/s4QX6sli9xyKTzYaHwfDA1VVrkxBGd8gfBn75s6XTO2axD7Xkc+/5HPbyb2fdXDTkIKvu0LMs5HtvS8SLRXYWI5cXzJbz3vdRwWeKzg/GfXytWxr3lYKA89NZZwjC9uJUS+wblJ0iTfUf11+K/H3SvPBatuhvaueF+/nxOiMIp0+bkiRsu1pYVRpK2r8jpGROHmBi+fMmnT6m08JICMf7ca648e3b/RbxRpIAjK24BIM8V4XgXt34W0d7M/69q/3uHfxUV29JT7dmdz44dlLOQnDddYRjKcXiUk59kYHYrvg8g/PTr3XHv5cUn950fiftN0iOZkqCAU25zS2hTM7U660ZSIQDZT1UjZc4AXi8g6oAPoFZFvq+obalJBY85QA60ZRkWkpDXzEzasXTNSxfRmpEWrac066UZDUs1Imap+HPg4gP+S/mHroBsT0UqjssbsUq3WzE/YqBRr14w0Mb0ZaVGD5+i5uFClGeASVb14zP4zgCsAb+7Mj1X101UVOkPmdic9LKJbfDiXed0Ub3EhVrIvOiM2E523CN3nw5BpiKw4kuHAhW/JBUMMFZ35UIYCWR8WS3KLyOz8PXKst7jOtccmu0/Kkg+daamSQUM34pN72skEa3eit/zK7du1C0acWWWZqd6a97Pw0vfX9DL0fPXnAIz8w8sgI+R/8zgA7Sdsis1Usrk4rE5HtwvbNODD3/zxztg0tLsHhty1G/7WDXRe9N5p18eFm/nbifeLkMs0b4Mf4EyeOtgJRUWzsWlQZMbeHvSxL++sUudn1yPSVjoOKIUsGyosKpmxt2UG2DlyDEva/1hKI94EM5S2Ut6ZYITif/6by+iN74H8COJDv5Ewa8/Isys2c6+UUlg2biiFjiuEbbRlBpjftimud96b440Mlkz3JD8chz8Ed19FobE6e8bEj6uMjDx78vo2o9Y0dCGE9u+L78udO2D1YW55dAiZtyg2vQuLFDucyV6mTctNN8vCx1Ay/5SFK9kdOBee7uxO2vNRO7oYOejwkumvSlAyq9fs9jh8VqE8/F0y7FqtyL39e66oS19H5rgjXR127IQeFy6ut63Pmfkfcrirw5KlTkcA2zY6c2xANYS2tlK9dWRkup4VLv8jfUg4PjL+/hpobbb8hHXLVujyjcXO3bDcu0L1D8CSpW778D4YHnG/ARCcdBo6uB+AcPERBLsfcdtXHeo+h2x2IT6DpxyDHvMcn/cjtL/Kl9PRBcPOtSp39FKGbtzAY7/eAcCxLzmUzG7XpknfECS8cILzv053HQJuysp3og9c7Nw6AAJB896c//Y7Yclit1woINGz9JC1LqzfE+vjfHxIQN22rWQWP11VBGd/2S/98/h1bcZ2DZwbT2SCnm1zy5HJbWG0tByEw/ExIwPQ1uU0NZYgoOzB4Y//4q1H8sGTHnShZwFGB5mX2+OXi4kQbF2u3JLJ/Bg74/Z1MzzRKeg4H4audMs+fPAFq272ZSbM1otFFx4YnKl7FJqtrbPMXVMG9x9Y9+kQmb1PQFPrDZx2vNsA87z/6XguDqNDpeuNhmwYfjar2907PUEGgjDO1x//2OjzWNLh+no9HU5LvcU/+mOy6LB3tdq3nXD1MwHIFPsPdKGYrul6pciZoDfE68nzjvRUGHX3Unu5q1yUXn3/J9QcmezUoW8nJRmKcLzqVqk1H5r5X4BzcO5ht4nIlar6+zFJb6p/6OapmduddKMpkRqGWFDVG4Eba5KZMeeopdYMYzJMa0ZamNaMNDG9GWlRA62dBDysqo+6/OT7uNClYzvpDYF10o2Go9VCLBizh2nNSAvTmpEWpjUjTUxvRlrUQGvjhSk9eZx0zxKRu3ETr35YVe+vptCZYp10o/EQsVFZIx2q1JqIXApE0QSeUrN6GXMPa9eMtDCtGWliejPSYmqtTRWiuZIwpXcCa1S1309AfTlw5EyqWy1zu5OuUPij8zfPruwmc9xat/m++6Df++gumI9u9SEsQiXoupP2l78ZgGLYTqjOp6cj00dWne+I7tqAdC1gMLsGgC7ZXgo3lQ87yYjzychKHyOh84EMf3oFo/fvJLvC+XRk3/rv9TzzcRn4/U4WfvAcZK0Ln1SYt5rsoA8hU8gjy9z1Ce+8CXn6c+IDFy9jz8f+E4BFl91U2tx50YemXYfRr7yK3LOOnTSNAJmmm4REyTDidOB9esKgg0BH43Bo+7cj3c5fltFBuju876UEzh898oNTJcy4+QqKmi35pEthxPmjJ8J0hOJ87AYKS+gJXEiqXYVjWPz6N7k0A5ug5xV1PO/xUQkQdf7lbZkBpDjKzpGnArC8697SvA/ZrhEy0VwPhVF0yPuFZXJIzyvc3PwzJB/+lmwweZijGmjtMuArwDeryWRahCEMD6LrnyiFu5K1a2BX5Dfegz7wO1i0wK3v7yNY5f3elq6NdVbIQ3E0ngdApBQqBmBR7hFfXjEO4aYh/bqS7qF7SsfoXl/u7l3IM//aba71OU/C6B/30Hm287kPFq5EoxCRGroQm/O8r3D3wjiE04oM7HBzJPDINoJ1X6uqDoVvv5HMiU+dNE1TtmuBuHkPggD2Ov9yensIf+/9yY9aBY+tL20v3LuJ7Jpet97Rg3hfxcz+DfFb0PpH0KFBZLUP8Tc6SjDs/YE7eyEKeZQfiX/L0d8zf00vC45YAEA4mCf7hm/V55ynojcRom+fuyZy6unog+5DixxxOPqo80GV0SHnp7/BTbBf3NhH2wd/5PbNsPjw5x+I5weYgKbUWkTkJ5wfcX7UyXlJhvvdciYbz7nR3uXCQ0UhKEcGYt/Z4b54OZMtzcHx7mfvgXxYmi9GNCSnQ3E50VwdkU/uFD7ZdSE6vyDw/vn+OuSH0SHXnsv8g9gXurlI5vNw7L8/MuiOj3zme2ZYhz6n1XH9/RM0rd6S5xX5ohfyTivJfV6TOrDXhUrzrO64hdKdPLgvnuMgweruu8gW97qVtk40yDJadJpsH3kE6XXze7BgOZlo7qDI/zxtNIzvv7AQh53u7GGYJXQUfKCQjDoffH9MNDdSJji98vBwY6kg9BpUpLVJQzRTQZhSVd2fWL5aRP5VRJao6s6KKllD5nYn3WhKWi3EgjF7VKs1Vf2liBxauxoZcxVr14y0MK0ZaVKt3iqYbfv1wEf9aj/wLlW9e8YFGk1LDdq224AjRWQtsAl4DfC68jJkObBNVVVETsLNPrmrmkJninXSjYbEwnkYaTGF1qYynTKMirF2zUgL05qRJjPVW4WzbT8GnK6qe0TkPOAbjO9HbLQAVYZoLojIe4Cf4gaFLlXV+0XknX7/14BXAu8SkQIwBLzGR05JHeukGw2HiNhXACMVKtDaVKZThlER1q4ZaWFaM9KkSr1NOdu2qt6SSH8rzkTZaEFq0bap6tXA1WO2fS2x/BWcG+OsM7c76R3LaXvPDw/YXPyvNzNyxzYAOt9yLMFJp/kdeXRwX1nanDg/JSUo+V7K0rWEZGlT5z8SSlspJnTbpl/Hvt13/Yq2g7y/ydOfRmbbr8m+9bsADHzwHNqOcj4wuXf9oFZnPCnF4aLzZfN+mZm7r4HDn+x2ahj71OXaCH96BcO3OjeN7MruMl/0asi98Fkwf9mkaYRm/ArQA3Kmi8jqqx4ABb2VfNH5D7b3xrebds4rn6oiLMS+QIVR1MfP7cruIRP5ygU5KIyA96Mrhu0lf+7OzD5Ccf5Q83ObIO/92XpeAX0/KsXirEe86vFI1k0KI1AscFCn01ch7CQjzn8wO7ozjrm9Zwuy2LsKdVQfnjKQqeN1NqXW2g9CDv8Qcnj55vDqd7qFRQuRQ9YgC1e69ZXJRAXncxctF4tx/NyOHud/Ds7frBQLtRjHkG3vZt7wfSUNkmlD/T457lOEl7/NLa8+uOSfXm8y89thxMdNTvrUjQ5CWxe6f7s/jYKLcwuwbXspRnW1/uiA80dfvHzSNE2ptc4VyHGfOsB/Wn9woVvYvRc52s+ns3Q5uRWJa5AfKfn0arEQ+xOvXIWMDiFL3ZwuZNriuQJGh9Bbfg6AHP8M9D4394GsWknXqxYTPuGe29k3fIvwZheXXnJtyMmfqeFJT4xu2ows9POKrF5Tui76wH3IUudLr3fe5fz4gfAXv6awsY/MQc4HNfJHr4qO9rgOE9CUWgMIFhwwh4ru/R4AMtxfumfJtrk44ODu60wuPqCtM553o2t+qa0aDhfQETiX0rZNv4aVR8OuJ1y6+QexAB+7WgKIOgGRX3cyZnkNnk0VEbVjxaJrZ/t2uCr0LI3n2SgWmF+8zy1n2uIY80FQWz/6zORdhSr1Vuls2xFvA/5vpoXF9I4fk1uvLfNHz8t8cqF/xkXzZURIEM8R1N5V8tOO5iMCyA5scvMcAPTtROYtol39/ALdiftYJK6P3uDyDc6q7hQrRRPx3SNf8/bu+F1BlQ52xDoQKY+nXot6VvihumnbthkytzvpRlMiAjn7CmCkgGnNSAvTmpEWpjUjTSrQ22RuY5XMtu3LkTNxnfTnzqiiRtPTam2bddKNBkRaaqTMmE2q05qIfA84A/cSshH4K1VNP3SD0QRYu2akhWnNSJMp9TaZ29iUs20DiMjTgEuA81R1VibxMhqB1mrb5nQnvagj7Bt9GHDm6lEoq54LLqPrgjid7nKhXIbmH89wRw+L1IdPkZCO7F63nB9CvSmo3vUL9PjnI+LMPUbDeeRDZ2ocfO4KJOdGeXJHLCT7Mm+Tmh+h8MR+EkZZhIP5mp/zZCz9/i2M/MPLaP+gCxWk27YTHu9CPWT2b0B3OZOe4kNbKTyxn/anO7P0kTu20VajOsjaD5bM1yZMI5DNNNtNuN+FkJDyEb5scBZlIR3D6+PlkrlQ4Ez3ohAy2bbYVHxoXxxCBiDbznu+7UynPvmKw1jR6SY4zQ5uRiMTOMWFoQFoB0TiMB8pkQ1OgcHL3UroQmFFl2E0O48O8ebT+ZHSdZAlawjb3LnVYpw0I88uv97jUK3WVPW1Mz54xoXug+GrnOlZZJqWHznAbLtkJtq7LDbzLuQh503Vi/4qR6bGG3+PHPwkty0sAt70fXQQjfS0ZzMUCshBzqUHEXS9s1SUNaAj3sx0y9bUwrC1f/xy9N6/dedQGHWhcAC65qP5YfSRB1392ttLbRwAg+6ayDOrr4Mc/ZE4XNFEaZqxXQv3uPNq6yyZGmvfLjKv/s8Dkur6LyFHn4Dud2a5OrAH6V0KgGSyaNS+5Ydh63ZnbgyEv7me4LhTALi+/zyO/Ow/ArD640EcamzRAmQ0j94fW8VKjzchzab3GhOc/eWSW4msif1N5KBl6A533uHuIYKV7h7TfEju+FVQmNr1puI6PPuz6JbJ565sSq2Ba9vy17hlCaBYQBaM08QOXxW3Y/kR9+yM2sJsm3N1ifLwpu8dwV6+G7wHgNfu+hSabUeiZ2uxED+Ps4m3neLomPqFpEZk9j94ORRHY/el/Ehcr2Ix0Z6Pxu4Ata5D9JtMQJV6q2S27UOAHwNvVNU/zrSgcvqcWXlE5CIxJvxZrnhd7N4VJnQSveuN4yIW6GgpPG6gIc94juuH3PHThe65OEVIu7L80yAyV9dEGDQJYvN2Dd16IuxaWbpaEF33Or+zNRtzupNuNCcCZFtopMyYPUxrRlqY1oy0MK0ZaVKN3iqcbftTwGLgX8V1cAs2oWtr0mptm3XSjYYkqGSk0TBqgGnNSAvTmpEWpjUjTarRWwWzbb8dePuMCzDmFK3Utlkn3Wg4RCDXQiNlxuxhWjPSwrRmpEUttCYi5wJfwn3dvERVLx6z/wzgClwMa4Afq+qnqyrUaEqsbTPSotW0Nqc76RkZpTvrQm6Mht0ln3TlF6U0oeYIFzrfuIyOsKBtLyOh83XLBrE/UjHbS2aR98fo7EX+75sE570agODRX1H4kvPZefTGTTz5c89zxzy2C/2DD/W4dx+dn4kHCru/mPD9SJH2j/yk5INfeGAbuVPWA6D7dyLdzj+r8MR+dLhA33Vu34JLbqy63PDWjwMQnHQ2xd61U6ZvvntQ0EwbomGZz1JSaxL59ZQ2+OXCCAQZ1Ps9SVhAIp+zts44/NW8RQyGy/jKG5ym+wrbSr7GOrQf8eE8sqM7oTcx6cK8l9f4XCskCgGz7wfo1vWwdBUAmQVLUB8+Rzp7Yv/BICCQU6svt//H7v+OeeWheSag6bQmAdrRU661ts4DtFY2D0HkezncF/uiZ3Luz/vUybK16EbfXh3yNGRwDwC6axMMep/0jnYYHEJ3b3Lre/YQnPa5UjHj+SqngTz1LwDvhz/k/e87e6Bvj5sTAdANmyg87s9puEj7R35Sdbm69RJX/oLl0L1gyvRNp7Ugi/YsQRK+mDJ/WbnWvC+nrDrWzX8R+c7u3x7f221dyCJ3/zM6BL3L0D/e6Y474mjC+93Ez8/jdvRPj3PbVx8Mo74dHByCbLYsXKkc96m6nPJURHM/6M5vUrzpdwBkzjyxNMdBsKQ7Xl46DwqFmoT5A9BNX0UWriiFeZ20nlVoTUQywL8A5+Am9rpNRK5U1d+PSXqTqtYuJpkE5f6/ufYDn6Hg/LCj52d7t9NUqa0PoXN+nEfE6BCvy/+zXx6E/FDswx0EUPR5J/3To2dY54trdorTpuulzge/5DOdi0NjQSnMIWERje7F8fz4p0vSDz3yRZ6EpmvbxuLfSSK9lbQWZMvTJP2xNYyvTfLdTkNGir0AdGZ3ceevXR+DsOjSSfl8MC7vRBgzObPq05kRmXNiP/2wEJ9bdG+M9ceHGoVfS8wNUIGPe9NrbRq0zjz2RtMgCNkgmPBvyuNFVovIDSLygIjcLyLvT6HaRhNSrdYMo1Km0lqFbdu5IvKgiDwsIh8bZ/8ZIrJPRO7yf7PTkzVmlRpo7STgYVV9VFVHge8DL6l7xY2mxJ6jRlq0mtbm9Jd0ozkRqXqkrAB8SFXvFJEe4A4RuW6crwBGi1MDrRlGRVSrtVn7umk0HRVqbbLY1auADYl9G4GTx8njWSJyNy5k1odV9f4ZVtloYuw5aqRFq2ltznfSo1BWnf7/sQSSJxBnOiQaEpIlI85kaLTYXQrBlmGEIV3m8xogOPUcdMN9AOhj6ykMO5PRtjZh+DoXbiF31CJ0mwvnqMPFxjFb8OYk+Sf2k3vMhSfSkRFk6RIAOj9zNc/7s8u5bP1fA7CgFmWevM6VIyEZxv8tklQze6OqbgG2+OU+EXkA99JR9066Jk2ZxtuXoGROlW2fMLRLMegm6HWhPKR/F53Dmwhv/RUA844+Al3sTUs1dOalgGqIdFR7JjVEAli4BPa5+uWybQx3HwFAR/bpaL8LFbaV01gxtXX61Hiz/7HXeyKadabQqbQ27ll19MSh/qLwRJH2Mllk6Rp3/NaH0G0uVO3eL11P9zMOAiB3+tNgeATd9IA7ZngEOa5WZ1Q9kmlD+71p/v5HYF43suZQt+/ZnyV7y0fdvuGp26CKyjvIheFKSWulr5sAIhJ93ax/uxZM/KpQcl2Bcj32LHHhosCZTZZCsI2gw32w3IdGHtxfevbolq2lEKb60CPIiuUuTTZTs9+sVkiundH7netRe/ddyEIfEm7JIoJnfxbAhWur4dcdWXlMLbU2Wezq8Q7WMet3AmtUtV9E1gGXA0dWVLlJKJ1f5sDAr9E+GavHts5YX5lc3KaFxdhkN9ee0GMW3bu1FL5MkmbMhTFh1xqBTLZUd80PI1GYuCBTcmfTh/4RWVX15Y/JtlesNWjO5+hk51fS2th3s/FcFsHpJ2EO3hm4tqHkegGQCcrTNTKqoInwcqrOHB5cWMCOntoWN8e1NlMapt9oGBGCm71xor9p5SVyKPB04Dd1qKrR5NRSa4YxGVNpzettiYjcnvj700QW433dXDVOUc8SkbtF5P9E5Mn1OyOjUalQa5OxEVidWD8Y97W8hKruV9V+v3w1kBORJTU8DaNJsOeokRatprU5/yXdaD5EZKqRssnM9JL5zAN+BHxAVffXuJrGHKACrRlGTahQaw35ddNoLmrQrt0GHCkia4FNwGuA140pYzmwTVVVRE7CffTZVU2hRnNiz1EjLVpNa9ZJNxqSKUbEJnuRBUBEcrgO+ndU9ce1rJsxt5iLo69GY1Kl1ir6uplYvlpE/lVElqjqzmoKNpqPKuNWF0TkPcBPcSHYLlXV+0XknX7/14BXAu8SkQIwBLxGVccOGhktgj1HjbRoJa1ZJ30MImEpVFsm6ccuZ9Kx7asAaK4dNqyH3nluXzZLrstdyrb5bWje+ZtkVs0n3N7nkrz1uymdwdTIotcD0P3F17P9Vc8CYMkHTiO8/R4Atv2/k/j5Fb8lf4kLd7Ph3Gew9FT3btjxyStmVqZU7oMjVOdzIiIC/DvwgKp+YcYZ1YGSf5OG5X6eY0Na+JAUgeRLIY5o74LhfmS1s3AN77yP4CjnfytHH1/yWatJ+JVa0nsB0utCFgHoyAC5HheiKPzxWwhe/h8ArCheh+J87TYPPJ1V3b0zKm46vk3Vaq0pGKu1KNSfhs7HbCgew9LBvW4hLJR8abuevJhd17twjMsWdSCHrSrtC1767/Wv/3ToeQXyzFcAUPzum5BDV8AO1z99/A3HsfaGuwEIr/wTRj7vfDlzxx1McPaXZ1Rcylpr7K+bfo4DjXyJJYB2768eFiB3LgC66xLnP7zeh9fuaHd/QPjHTUiPn4NjXje6b59L09VJcMrfp3IaFTP/1XR93oVh3XDuM1jx2icBEKzOkr/EtcG5t3+P8MdvYfQrr3L7urJVvQtUqrdatGvehP3qMdu+llj+CvCVqgqpBv8sLbVtyXYtCguliVC3xXzsCxyFzvIhTAmyY+ZTeEU9az59cudCNF/Lzm+i3m9esm3oZveTyJF/7kJQAgx9y/mtz3/1jIu05+iBjDuvUBQuTa8fP7Racn3sfglqE8KslkTnkwVG/O0fBO5+Ca93610vhaK/t4rXOX91gOzzZ1SkaW1irJNuNBwikKvuJnwO8EbgXhG5y2/7hH/pMIwSNdCaYVREtVqzr5tGpVi7ZqSJ6c1Ii1bTmnXSjYakSlO9mxnff9MwDqCVTKeM2aVarTX8102jYbB2zUgT05uRFq2kNeukGw2H0FoTQxizh2nNSAvTmpEWpjUjTUxvRlq0mtbmdCc91Cx7Rlzc3/ltm0vx0CdCJaAQdpbWC2E7RX+J5mVBVr3LpXvin2HZMsKbXFSv4HVvI3PzIwAsffISMktcHoWHdtL2wR8BsPvNp3LNf27ndfpgDc+wegZ2DAIw70e/I3fUIgDae9u4vOtoXjro6rpk4/lVl/N438kAFEJlcce2yRMLNOM9KFH8S+9fM56fTSn2ZmEEGRtjM1oXSn5Bkr8mTjPUB0vWwMAet2/VMgi9JWshX/I/y1/yWnb+76MArPhJA0WeK9X7WDJ9mwAY3TxA2/BVbn/H+eB96lZ19AEz050UfZxbVWcbNWniJtVaFN/c+2NO6tM1OoS0+XZNgnK/zAxxnN1d34rjCG/eDCeeDUDmtt8z/zAX67W4c5AMm8i8zs0vsOVlJ/O7G/YCsG5vY7Vtow/sor0jA23OxzkIpDQHx7If/prwL18IQPGR7QRnz6wMyXufVgnieMwTJm5Cram6cwxDF4uaSbSmIYwMIB1j2jXw8ardoix/e8mPFkA3bUbOdW2X3HZv3Ka15dANWwHIvPqfCK9+J+FWNy9eI83xAqBFZcflDwFw0Nu6yRyyGIChT66j8zNXw5dfCYB0VPfKJfu2unu+rXOKhE2oNQAUKfg2KJObvF3zcdFLp1lq1zR+s82cA9EzND/sdAzovMXueRo9q/PDpWVZ9Hp06yX+mBFk9Z/V4LxqSDRHDbhz9jHTdeslyPK3l5ZVtSpzQhnaF7+TZA+MWV+euDn1VprvR4KK/KIPiJmuYSzA4KzYZzuZJMgm3kkS73njHdNo/ul+7hmKhfLnW/G6OGZ64dqp37OmoHTPw9x8jlbBnO6kG82JoGTE3CiN+mNaM9LCtGakhWnNSBPTm5EWraY166QbDcl0ZoM3jGowrRlpYVoz0sK0ZqSJ6c1Ii1bS2pzupI8U2+nPHwTAjqGD+M0Tztx2174hnr7WmaOtmd/Bmnv/CgBZezjZ9m72zXMmkQvaDhs/4z17YPXhJZNPgPWXvxOAw9//TPKP7QWguHu4tL9jWTenvqC7didXI6KQREm6nljH2W9tL613XnRV1eUc+kcXPif/y/vY+iffnjStGymb3DWh0VAC8tpNRkYIcCZUMtznzBK9iVQYdLB31IWyW5R7JDZbC7ITmjnpwB6KvWsByPaeiwC68+cu/8WLIetMg8KfX0Pw0gsAyCybx5Jz19blPKtB1rw/XvHR1XKnP4g+dp/bf+z5NQkft2nYuVZs6heetPiJyevUhFojLMLgPmeC6OsuYaE8nFAmgw4602Bp64xN7IKgFArrALZuQA4+3C2f+K7S5r3Xf4IFZzm3oXCwQN/Pn2CBD/zVvayLpz27WNvzqxGdf/O/ZetLbz6PoCs74f6ZoFsf8QshdC+YNG1Tam1gP+FvrkfWHgYZHwNq22aKd/wBgMxzjocu91zL//Rmsqc/A1l1ZHx810vd/2MtGPfshuXLAQhO/JvS5sL6L5I71R+/fSfSXv6KEiyfWVjGenPIdb8rWy98+40AtD/Ltfdt7/vvmpSz6z3/zB9+uZMTP/DkSdM1pdYAikUYdS54SICMDqFRu5ZrR3yYNbJtkPGuPkEWGRmA9nXj5zni82vvKrV9AujoJbHbgIaQNLnNNO6rsSx7a/mGHZe5/3O5OI03e6+K/EjsDjC4b/I6NaPewmLs3gWI15nmh5Gu+bEGwhCy/toG2ditIjhr8umJvTm4S+LDlUXuZtMIOTarRO8KkbSKifOImGHYtTJGB929DweGrxtDU2qtChq3JTJaGEVonZEyYzYxrRlpYVoz0sK0ZqSJ6c1Ii9bSmnXSjYaj1UbKjNnDtGakhWnNSAvTmpEmpjcjLVpNa9ZJNxoPaS2fE2MWMa0ZaWFaM9LCtGakienNSIsW09qc7qS3b3uEFd93/jvZc07hyL0bABi+4h42/nIjAAuPW8bmzf0ArPrH+Ww77OVkwslHafZ88ToWvL0PnnswAMLpHH3nA27fW0+n53TnhzZyx9bSMV3/cA39PvxPo9PxmY8y+L6/YfNLTgJg8WkHE3RFPjnCXZ+7C4ATH/pDxXkO/cCFAtt800YW3T2VD4sSSGGKNI3FcKGTP+59Mgvai6UGpG+0nZGBkP0j7lxGiyGrezsACCRkwehd7uDOngN9Nj3hdT+FV7j5DpRfIJyOPPOv3b5r34McczQAcvLJpWOCF/8bXPWOWp9ifXjqqXDbzwAIf/4BRk57CwCdbINMjv73/i0A875yYGiTiehtc+HdMr1L2dQ/wbwSJZpPa+SH0S2POP/y+UvdtpEBdIPzv5eeHuhoh917AdDVa0rzH0hHT+xfNoahS2+k893e53O+0xrAku/8ij1vdcvzX3ksXfnYB7336zcg73pejU+wPnRe/DGGPvQZAHa98bn0PnsVANKeobjN+a3e+pU/cPqmytu1KAwnGUFWL58idfNprbCjn91fvYXuIx8gd8RCAHZf+TA/+6/dAKw99E5GfXShtjY4sSNL5gVOk9I5sf+4btuOROGwVsdaa//45YS+7ZIVywkf2VA6Jlj3NcKfva+2J1gnMm9wPsHhDy6l+N03MXr/TgCCRR0M3LsDgN4z15C9cPL5WcYS5DKsPqqTnTdumCJl82kNcKGcwsjnl7LQhpJtd+HVwM2/kXNtlQz1TRqSTof7/fFtaO4XbpnTXSjA7Ze69Y4ekvNFy9I3u2N3fpOGZ6mff2bn+tL5lHyGI39+4hDClaIjA4kQbBM8NOLUzae3ZNgwDUvrkvF+58MDbl82B9Gp5Sr3JVdirZXClYXXl4dBhXg+onHCtzUamnGh+KQ4Gte3mI91Uhh19+J0Q8ll2uJ34Cl80ptSa1UwpzvpRnPSauYsxuxhWjPSwrRmpIVpzUgT05uRFq2mNeukGw1JK00MYcwupjUjLUxrRlqY1ow0Mb0ZadFKWpvTnfSgp71kZrbn2u/z22ucid7SpULgrTNu//ctvOwvjgAgvO9BdG3A0vzNbmfHBePmu+iymxj80PPpfO75pW2PPPepACx/xkElE7bshXD/044BoL07y8pnr6ztCdYJ4XS6v3w6O886HoD9t21l4fkuNNO9n7mNDm8R+5vDj+HkRyozDd37oLv2C49YwIIXHwH/efMk5StBg4+UichzVPVX0XouU+Sgrr0s0TvQzQ8BsKJ3sTPJy28H4KbshSzrdKbY80fvQTc9DEB41HMnsnYnc8Fl6N2fdivHOZPQoU+6UDNtT1tKcMh7S2kfPe1pAKw6/3DIONOt9vNpaITT4UR3Xnrln9CxwYWXY8WR7H773zC0y4UxvGPVMRWbIe8ZORSAg3/5QbLP+8spym8+rREqDA6hmzZTeNSZW4f7RhBvilfY0k/neUfHx2czsMyFoiQbh1YcS9fnr2X4My8BoP2TJ5S2bzj3GSw61oWsDNZ9jbZ18Ks1rl07aGWWhUcsqP4kU0A4na7PO62Nvv0MCt7NKbtyHg9/z2mrtxf+u/1oXjnyYEV5at69LAzdtJnuCydv35tBa2PJLuxg0QXHoIN5wn0uXFGQCzjtvB4AJCM8fGcfAMeetZz8g7vJPNW5XejqwyeMUBQ8758Ir3m3y+Op8fbwZ++DRQvc9pM/Q+bkxPb+AVi+rLYnWCci8/3Mq0+n+F9vJufvn3D3EAte7u4d2nKEl78NgOCl/15Rvm3z2zj4xc+ITcKvvG2C8ptPaw51obHAhV4LiyXzVx3ci7S7cH9aLCDR9tEhZJLwh7LkTS7drm9BR09c0o7LXEgtgN4LSlrVLd+o3emkQKQ1liTM80WcGXIQv1nohn9xu1b/WYUZB4nFybsKzak3KTfjzzpT7pK5dXT+yXBjGsaaGY+JTNf1hgPTRNvHltfAlLSWIT7HIFO6Z4nCvUbnK2dWlnEQxCE+KwjB1nxaO5AD3usmoPFVYbQgikg44V9aiEhGRF4rIh8Wkaf4beeLyC3AV1KriFFHTGtGWkyutUabDEdEJho7NBqe5tOaiLx2tuthzJTGeI5Wgmmt2Wk+rVXzXjenv6QbzUuGhpgY4t+B1cBvgS+LyHrgWcDHVPXy2ayYUTtMa0ZaNIjWKqWyz7tGQ9KEWls925UwZk4T6c201uQ0odZm/F5nnXSj4RDRRhkROwF4mqqGItIB7ASOUNWtUxxnNAmmNSMtGkhrlXLC1EmMRqRJtfY0oDhVQqPxaDK9mdaamGbUWjXvdXO7k957CN1fvA6AR59yDEuXOq+jed2UfNLPe8tyOt7t/DDJtrFCbkb7dwEgE0eQoevz15atF0fc/R7Mj30+Bz/0fAp+wKd/e4EtP3yCUz9f7Umlx/y1CwAY3DHIQ59zvm/Dw7BslfMd2bsvzx9PfBIAR932+0nzWnnFb8dsuWyS1NXP3igi5wJfwnnPXKKqF88gm1FV5yCjqsMi8seJbq6s5FjSsQpYxZ6/ORWAu67Zzuo1WQb7nDaee+lWdOWLANCtm5DVRwEwWFhIzyQRTuS4T5Wtj/hwUbnh+BmTv+S1bHrMxUKad/tWJHBaXzq9851V8g/tIofT0X0v+jrrn1COf67zIdy0Wdn9ZnddF11206T5HDLPh+NZ9zWWTFlq82mNzhXIcZ9CjoO9PqzjQ7/ZQ4eL7sfgIDyzPUvnhd5/rKMd9u9zywcdPmklOj55xYEV688TzGsrrQ9+6Plk/ZNjx9YCm55w836cXtl5NgTFkQJhv7tf7vrC3WzZ4gIwrVghjI7CvU9xfsNPvW/yeRCi+Ud6Lkxunejnr7/WRET8/nXAIPBmVb1zhsWNsuDQkr+0XPknACz6k5Mh6y3hg4AV293vT1sOHRhm9GpXXNs7JtdacO6/Hrgxm0W6u0uresdfuYV53W4ehg1b3PopMzyjWUAygix34euCIw6O/cn37oMu11YVf3AhmVf/55R5Re8zMZdNkLL5tKaq4QknnAC9fi6gnd90IZ0iNETzbl4Esjm0WChtD4OOKX03ZfEbyzdoWArjBqC7v+MTBqWQlaWQb81CVO9MzumsLNSXu0K65RvIij+dMqvIl78yqtPbrGktCo2W9BmPiHyki4nzGh0CPy/ChBNuAARnjb878jtPllfaFk6eZ6MiAaUXgrGE11cWji137jQKbKq2rfL3ugmY2510o2mpZvZG70v5L8A5wEbgNhG5UlUnH0k4kGNE5J5SleBwvy6AqurTZlxJo2EwrRlpkYLWzgOO9H8nA1/1/8+EY2ZcWWPWaTaticg9z3zmM2dcZ2N2maneTGvGdGmitq3q9zrrpBsNRw1mbzwJeFhVHwUQke8DLwGm23E6tppKGI2Pac1Ii5S09hLgm6qqwK0iskBEVqjqlhmUdyzweDUVNmaHJtUamN6akir1ZlozKqbJ2raq3+tsdnejAal69sZVwIbE+ka/bXq1UF2f/AP6gWcAS/y60fSY1oy0qHrG7Uq0VhM9gtPkTI4zGoHm05rprZmp6jlqWjOmQSrvbA3zXtcyX9KHR2DJCudjokVFQ+dr1H38Utjof4uVK3lo9ByOXNk57fwjn+wnznk6B/39SwHY/cBuVj3dxUddf/sugsDF4AVYtBDa250DShDAsx6rLAZ0mnSsnQ/A9ru3k+t0Ulk2T0rLKw5W2ua5azr4oeczsKmfpd+/pSZlSzjp7I1LROT2xPo3VDUZ3HQ8z55pO5eJyFW4WRjvE5EVwJ3A7TiTlW+o6j9NdvwZl5zBw399E53dbixMVixn65Dz4Z+3YglZcf51PdnpDbYtuORGAPrfcxZdR38cgMJj+zjhzc4HdNcd2yiOuOt3x9HHMDwMIyPu9E9501q6/uGaaZWXFm0vP5Vbn/d1wLk4rVghDO9xcdJPOiVHm/eL1i3fYPei8wBY3F79JK3NrLWCnwvjyecs55GbnKvTvHnQ/vRlEPn29vU5n16A7POnWzUOv/leNq5zc4gt+/Ir2f3AbtY+0/nYbvv9Hjbtc6d75byjmTcvPm7VyoCj73xg2uWlQe/pq7nnH38HuPZ31Sr3M3Z1wppDhK4Frl0b+ssXkj3YzYuQe8f3qy53Cq3B5HqrRGs10SM4TSZNQsM9Q25h/zDBocvdchDAkkVueedu8g/sQnLOX10WvX7aZQZnfIHw5j93K7/5JDow4Jbbcu6v37WZ4eVvgwXzS/t00zYAMhdcNu0y643mQ4L5vq5B4rvI4iy6Zw8A0tnG6FdexUPfcJaRT76n+veBZtMa8LEyE2QNIZOFyPdcglJca8m2o8P9bnthlEBOnX6Zy97qYqUDuvd7se9xJvFaPDqEbvpqWbzx0vEV+HWnTtKPOgggiOcSSV7H6LwpFpDlb69J0VU8RxtDa5H//nhx0KO5EfIj0PniGRTq44XrDc5Pe6KY6GN940t1qsCvO20mu15Jin4ejdGhmV27cUjhna0h+hDQQp10o4lQhXDSiTd3qupkMw9vpDzExsHA5hnUZK2q3ueX3wJcp6pvEpEe4FfAP80gT6ORMK0ZaTG11mByvVWitVrpEWDtDI8zZpsm1Jqq3nfCCRZQoCmp7jlqWjMqJ513toZ5rzNzd6MxiUY2x/ubmtuAI0VkrYi0Aa8BrpxBLZKOL2cBVwOoah9UMXOF0ViY1oy0mExrU+utEq1dCbxJHKcA+2botwnlmjSaDdOakSamNSMt6v/OViu9Vf1e1zJf0o9+3graVjlbzD2/214ydy9sHqB4pZtZX0du48h/eFdV5RRGioTe1HjZusPY8dPHADj0pCUs/tbNnOjT/Xz50XR1ueX+frjtSDeR7okPNY7Ze9ux3ozx8jjEHJQvz/PXdGj7IL0nLif/1VcDkHvXD6ooWWPTrJkcrVoQkfcAP8WFWLhUVe+fQVYbROS9uFG1ZwDXAIhIJzBh0LSF//RuAGT+co488nCY769jRzeqblxs2+Bqjpw/fbeKJB0nrkC82VTHm89EVjhz91W7NiBr3g/AGmDjuhPo2+xMAx+44nGyVzmtHff7xtEaALv3RhGJ6B9w1np7djodFApw2EufDIAsXEk+dAnX94+wZl77uNlVRpNr7enLAGg7ahHHLnIx2KQri+QC9OFHXKLR0fHDXU2D9l5vNllUVr79qRR3OzeE7uXdPPXLPyul+92xTlttOdi7T7lptVs/dUNjaS0yyQYYHY2jYkWuIYuOcvesdGTJrHDm7uEtHyV49merKLU+WhORd/r9X8O9BKwDHsaFjnlLFRXeABwXrey4/CEAeg/tJbuhD4Cwf7QUnm/ztY+x+KhF9H59nHBG02HnbgB02ZJSaJ/8bx6BotL+kZ+UkoWXv80tLFmELF7gtv3ywwSnfa668muMDhdjgYUhmnyR9C8B4batFJ7YX0q2+82nThlqcopSm05rIvLeMhPkYgGybeUuAv6ctJAHcRapsvKdMy818VtIm3umaLFQKkcOea/btsVby2aypd+y0lBmqZL8whhO0AcIgoSpcoDu/s6MXFPKmbneGkJro0Oxm8PYsHv5Ycj4519vleba0XWP/k/+XklXtMjsPRmyLTKZbxQqCU+oYXyOxQIMX+WWO86vpuBmattm9F6XpGU66UYToVrpiNgkWejV+FGrKngb8GngbODVqrrXbz8F+I8q8zYaAdOakRZ10pp/qYiWFfizqgqJeRuwrUZ5GWnSnFr7dI3yMtKmSr2Z1oyKaa62rer3OuukG41JFSNlNaRDVQ8YplfVG4AqPxcZDYNpzUiLxtBapXTMdgWMKmgyranqO0844YR3zHZFjBnSPHozrTU7Taa1sRun815nPulGA6J+tGyCv/S4PFoQkR+lWbCRFqY1Iy2m0Fq6equEy2e7AsZMMa0ZaWJaM9KiObU20/e6lvmS3vP1i7h5tRs4GxlRRn1EhacM5ll60goAsof0Vl3OYb+8p7Q8dNH5ZNqd72PSjxvgeVsf5KGTnY9tR3uRrQ1oVCinOR+Y3u8+QJ/3QZRAkIzzBQvzIV1HOt/NcN8IuaOXEu4drL5gBaYOH5MGyTAMh1V81IKVAOweWcPCJRtd2A6/fVXxNwDsKhxD+eSR0yd74bdLy3rHXzHyk28B0Pb2V5alO/jq2wl/7FxqRu7ZwZ7fba+q3HpRfPp5HPtuF7LrkUvuoXd1D52LvZ91ECDHuwk7B7Nr6NYdAIwUe6ortMm11nGRC1elP76MwIdDlFwGzYfIsPMbJ6z+wZUMrTj86Rex+WcuxOeK08s1/PQHnO/5Y2cex/DIyIRukbNNZt3ZHHOHC1l31xUb6fDfjDvaYXhEaF/mfIWza3qh12usf6C6QhtHa5VSFoZm+U/+AYDNL/owHTtdOLbhvSOl+QqWP/dgHv+fR6j2KRq89N9Ly4Vvv9Ftm9/O6P07aR8n3eiXX1nyW84eMr/K0mtP5vij4lByAKN+LqHR0dJyYf0++h/fx+HrDgVAh6vUSZNrDYDlR8LujeWmrdFLeJCJQ6ZVU+iyt8ZZR2HJ8sPOFz6Zzvue66avxr7emQPDss020unuPh0dcn7W4xGGsZ+/BJVEAZia5tLbAVrTjh4kP+Z6RbrLdThN1IIolFoUlkxk/OsvZ8ZpYOowZ41KWIy/eo+5p2ZM82qt8j5Egib95Y25jZZPrjN76ATLxpzBtGakRcNorVJMh02Lac1Ik6bSm2mtqWlarc1Id9ZJNxoPrW72xhpynIjsx42Gdfpl/LqqavWmF8bsYloz0qJxtFYpx02dxGhImlBrIrK/bMZto3loLr2Z1pqZJtQaVbzXtUwnff/oKk54k7M22PW77dz5S2e+nR8qkDnImTZKzpkArT/reADWXH9XVWV2XnQVySBbhf98A5mTngKAPvIYB5+9BoCwb5RjE2GMGoYlrn4H/eU6Mn9/DQDFQsjIHmf603PEAjTvTHXaT1wOo6Nk3/Ct2pRdCxOsKlHVGdmzRWZTbZkBJNfhzKWA4WJvKQTbYGERiyPbzRqE15Bn/jXtyeg16syTM4ygEhC87E0AdJ6zm86eV1RVVr3IBCNk33QBAEcfscSZ5XlTbXnmMxlY4E5wtNjNwnZnbt2TO7b6gptZa8OuHdOO9jisWEYgEFi00K0X4gfayOdfTvuHflxVXTs+9T8c9ql4Pbzm3X4hhGHn2rHy/MNZvnuYzs9UO+l9nVi6lq53PA+AZ8z/FXvv2wlAJhfQe9wycke5ayfdHYQbnWtFTdq2BtBapahq5oQTTiiN/kv/LgDaunN0rnChN0f2j7Lfu0J1reohCGLrvqGLzqfzoquqqkPymueAwY+c61aKIdLjzCdHNvbTNt8tt73nh1WVVxeOOx1u9tdheAT295V2jT7gws0V9wwjgZBd0Q1A2wdrMC1Fk2kNoExvw31oMR+/kGfi11XJZNHE+enObyJL3lRVHWTpmw+s1/ZLnbuaJKxWvZl7VaHf6oTOWwyA7N/uPtsVvKudBHE4LygzF672usV5NofextVaWDhQZ9G6BOXh7ArXuv+TIdOmS+acxLL/f+Tq+HeJzNsjt4Rk+gZBs+4FVgojzv0kSaSFMBG7PNsGuXNrU3iTaa0aWqaTbjQT1YdYMIzKMK0ZaWFaM9LCtGakienNSIvW0pp10o3Go7nMWYxmxrRmpIVpzUgL05qRJqY3Iy1aTGvWSTcakxYaKTNmGdOakRamNSMtTGtGmpjejLRoIa21TCddJKTj/S401arhAVb85g4AMue+iJGv+NBV7/tvhj65jp7VVYZ1GgflF4y+/qN0scVt6J1P5wte5vb17WLgg87npPuL102UReoIpwNQeGo7S791EgB73vH3bLl/LwBLnryEjred5xLv3oVu2FSbglWh2Bw+J+PifXW6n/gZ+1eex3DBhQXqCPcRqrvlVnd388h+59u/tidLMH5OM0J/dxGBjymlhQKsWgtdcWiifPhbAHLBSTUstXqE0wl7bgIgOP1c9I93lTQ1suxEsri4ibnsEKNF57vZXq3HT7NrzfvPyaqV5Lq6Spulpwfd5uI6Buu+Rnjj/3Pb22vb5OvvLkJWuZCDBEHJh67t8FEKtz3A6Fde5dYbzFdYOB2Odv6anX9+JMG/fAeAwvYBckctJDjKzV+iGzYRLOquTaHNrjX/2y44ew37bngCgMJgnl7/vNzzwC6OvvMBtr/qWS7ds1bWtPjwZ++j4/lHuZW2tpJvd+6QPvKP7AVg4H1n091g87sIpyPP2AOA7t9J8ac3uuXhAtLhGrC2oxYRzG8nmN8+UTbTo9m1BrFvcMlPNyh9QVMNSz7kuutb5T7jNUA3fy1eybVDxoW3JD8CA/tcmi3fKIVmaxSidza6r0NGh9D+RJi6yG84CGC0UL6tWuaC3iKf/SjcWnQ+uXaY93K3PHxV7UKJRUQ+7kEAGR8LVEOn9Wg+mfBqaF9X23KrpKS14Pp4o4blcx9A7F8/dvtMmQtamwYt00k3mowWGikzZhnTmpEWpjUjLUxrRpqY3oy0aCGtWSfdaDxazOfEmEVMa0ZamNaMtDCtGWliejPSosW01jKd9J7cFmTpWgB+8IcnsXXFCwF47+/+leLOwVK6jhc/Hf3hbTUrV7dfCsCe+c9jpNjLUGaB27HkWNrod3VbkCN7cO1N7GtFNjiFotxSWl9z8lIA2o9fBlu3AlC89xFoy9TObDts3pEyjcx6sm30/OGH9K45GoBixyr2jq4upVvZ9SAAw8UFdNXgTtQH/8EtLF7sTLTAmef170ajUB75EbIjf3DLSxrL3B0gkFMB0M5foPv2w6IFbl1jZbVl+ukvHATUwNwdmltrOR/kccXBiA9/RlsORvPlCb3ZnI7U5uGmm77qFg5aHpuzhYXYDK2jm+ypHYT3/L4m5dWFKIRO17Xknur0FP5mI7J4gTOnBnctgxo6ozSz1rpcWLrsqU8ncp7pXr+/FCYxs2XA7feNWThYuxcp3fw15Nhjod27HuSHoeA0ngkLBAc/BEDhD1trVmZN6XopAMLlJZP2Yr5IMM/pLLNqPsH8dnS4hi+fTaw1cG2btHWiWze6DdksLPUuFEnz9tGh2pog9/0I2rrKtxWd1qSzJ36WBg38+pw5B3LXxmb6o0NIm39WBFm0xhbbQFPrTYMskvX119BpKrpeSTPtWn/BDa9PuBwkX2YybnsUaqxWpuL1IDjLnQe4eyJ5jTJ1ukeaWGvTpYFbGaNlUYVC6/icGLOIac1IC9OakRamNSNNTG9GWrSY1qyTbjQmLTRSZswypjUjLUxrRlqY1ow0Mb0ZadFCWrNOutF4qMazWtYYEflH4EXAKPAI8BZV3VuXwozGp45aM4wy6qw1EVkE/AA4FHgceJWq7hkn3eNAH1AECqp6Qt0qZcwO1q4ZaWJ6M9KixbTWMp104XTy6kJPnbBqPiuO3A5A/kuP0vGip5TS6abNdH7+kzUrd8/85wGwiN9DYQDE+aM9MHw2y7zbk+7bRO7opTUrsx5kdAiAjb/dxprnrACgsGWA/ltcyKwNt27lqff9oTaF1fcmvA74uKoWROSzwMeBj9aygFJoikX70PZudMC9Jw90HkdGYl/hvDqfp57cltoUPH+R+1/Dch+9zh7Eh4XTHRth7363fUltiq0HoeaQ0VHkqKcB0BnsRB+5E4Dh7/yC3ouuqk1BTd7gl7TWtQtde7hb3rfLmYP19cUJvY9124feX5uCIz+6TDb2lwsCyPnlXDtkM0imtqGR6sY85+ucOagb3bWX0ZsfAeDebz3EiQ81RbsG8DHgelW9WEQ+5tcnatvOVNWd08k80poetJnseW4OleCW3zB6v8umY4UPi7jQhRFq/+T/m/YJTEi2zfnXRj6OItDp53EpFpC1awDI7NxfuzLrRLhvpPR/0OV9hsMQWTSPzLn/WptCmrxdA6+3tithxSFuQ3645FetIwNxwlwHLFlTs3J1ZCDhv50B1bi8IFsKsUphpGZl1oUgg3S4e1KLeTTyFc4Pgz+fmoWQa3K9CaeDeL/qts6J/dAlQP3vX/Mn29gyJYCM3xY2iXm3huXXK8jE5yVn1qiM5tbadGmZTrrRZPjJiGqNql6bWL0VeGVdCjKahzppzTAOoL5aewlwhl/+T+BGajwAaTQRddSaWW0YB2DPUSMtWkhr1kk3Go+pR8qWiMjtifVvqOo3ZlDSW3EvGkar0mKjssYsUn+tHaSqW1xRukVElk1UE+BaEVHg6zNsO41GpsmtNowmw56jRlq0mNask240JDp5qIudk43Ii8jPgOXj7Pqkql7h03wSKADfqaaeRvMzhdYMo2ZUoLVJByAna9umUY3nqOpm34m/TkT+oKq/nMbxRhNQ53bNrDaMMuw5aqRFK2mtpTrp+/POl/rwtp+hu51PerhiHre97WoATn7kCwQv/4+alrko7/xodc8W6OqFXvdxY3XuMfaPrgJg57xzWLLikZqWW2t0v7teK45bzLzzDgOgsLGPtiXOd6tm/uhQ9UiZqp492X4RuRA4HzhLVetrNyNS8g8fLsxnSccf/Y7D6M0d5ZePGvfQaRe1wL27696tsV9QrgNJ+jotPCiOAd3AZPZvgBOfw/6upwMgxSI9K/YB0HnRn9euoLkyKlvMxzFxO7qgMErx8R0ABEBw2udqW14Ur3o44fceZCGXi9ezWejqrG259WBgD7LC3Tu5nh60r49c3t0/NfNHh0q1NukA5GRtm4hsE5EV/iv6CmD7BHls9v9vF5GfACcBlXfSw7D0+weHriZ4eK/LN+ea0u4vXldxVhWzZyf0Lojn2ggSMYUzWad5QDoyBx7bQOjA3lIdJRCKOwbdcleO7IX/VsOC5ojVRiGPdMxzy22d8e+eay8lkSVvmmbVJ0e6F0DRX7uwiIaF2Ec9LMS+6I0cJx38M8HdL9LejYb+nIKgdr7oEXPlORqRzcV+4EHimdZxfm190cNi/NxuYvK4+UFyuq/cf17FxVGvJXNNa1PQ4K2M0bLUyedERM7FjfifrqqDdSnEaC5ayL/JmGXqq7UrgQuBi/3/V4xNICLdQKCqfX75+cCn61kpY5aYWmtmtWHUDnuOGmnRQlqzTrrReNR3pOwrQDvuhQHgVlV9Z70KMxqcFhuVNWaR+mvtYuCHIvI24AngAgARWQlcoqrrgIOAn/i2Lwt8V1WvqWeljFlgrlhtGM2BPUeNtGgxrbVUJ31x+2oAwl9+ifCJbQAU1u/n5EdqaNI4hs2vvxiAFV94NYNfuJzswc4spHvdScw74ngAdN92dP0TAMgz61aV6ti2AYDFHzsPBl04ttya1bQ9/aLal6U4k8o6oKpH1CXj8eh8MVL4Ucn0vDO7m0BOrVtxuuUhAOSgtehO93vRNT82TcaZ8jWDP48O7kMWLKczsxeA4WIPzHt5HQqiblpLlfmvhk1fdct79ziT7bd/r27Fhde5IAnBs06Abf79fEFvyeyY9k4XIsu3FY2M7t8JXf4eacshhQLB675Zh4Koq9ZUdRdwgG2h7yit88uPAsdVU44sej36yOfdShCUzLfbP/ijarKdFH3wIeSgZdDrw6615VCvO1m8GPZ7t4tGd+UZHUK6XYi6zEEKPkRh9sJv17ac+rdr6Vht9LwChn24zcJoyZRWFry2iqpPQX6kzKxegm4XtgxAA6RrgVscbfC2LdsOQ85FjCDjTPWp07WbC8/RyCw7vN6FDRP/tTZzTv3KFHFuCVDuwjM25Jo0dijTQujcT3Kou3bRO2Y9rt1c0No0aKlOutEstNZImTGbmNaMtDCtGWlhVhtGmljbZqRFa2nNOulG46HaUiNlxixiWjPSwrRmpEWdtZaW1YbRJNRRbyKyCBcq91DgceBVqrpnTJrVwDdxcyiEuPkVvlSXChmzS4s9R62TbjQeChSKUyYzjKoxrRlpYVoz0sK0ZqRJffX2MeB6Vb1YRD7m18eG+ysAH1LVO0WkB7hDRK5T1d/Xq1LGLNFibVtLdtKD0z5HFJSq3hdg5RW/LS13f/FDZfvCn3/ALQwP87M/vQWA54/jdtv3rucB0PPVn9eljlOx4dxncPDnX+lWRvPgwxXpXfcgT69HiXPInKXnFfFinYuStR+Mlw8Zs1NvcP8P7YPNbv4Dlh6Yh26/1B2/7K11qOHU6G1/6RYOXg2jQ26KPyAro/Uqcc5oTVa9yy2sorZhYsYh8+r/jFfGag3Q9V9CN2xk1w8fBGDpBNMJDH7kXLr+YXYsYHe98bkALPqLF0OnD7HU3gkd7ZMcVQ1zSGuHx8+ythTmUQlefGB4Mjnc/R9e9Y544yTXN7zqHQTnf73WVauI4g8uBCB42rHIsT7k5voNBPl6fRGaO1qj4/x0y+u94MBtUZMwdKXzWYcD/YYT6O7vIIteX/u6VYjuuAzp6IFM7OcsmXrO11BXvb0EOMMv/ydwI2M66T4cYBQSsE9EHgBWAdPvpEe+6cHkyWrCRD7bAVC4Nl6XSSoTXu+PqXGos0oJr6ezVL2Muy8mq2/VzKG2rQJaspNuNDgKWmydEAvGLFJHrYnIBcBFwLHASap6++RHGHMaa9eMtDCtGWlSX70d5Dvh+GgCyyZLLCKHAk8HflOvChmzSIu1bdZJNxoPVajbFwbDSFBfrd0HvByYnc93RmNh7ZqRFqY1I02m1tsSEUkOUn9DVb8RrYjIz3D+5GP55HSqISLzgB8BH1DV/dM51mgSWqxts076LBI8758AuGn1MeRy4xuo7nrjcymOOLOqeptLT0S2M4fu2g2APOlpyJI3ueVxzFxrgQIats5IWSrImQDogxfBgvnjpxm8HJk/3nMyRbqc2bF0zYeOHnLBSQDk6mQ9VU+tqeoDANLg4VPqgax5P31/dya5eeObWBYufR0A2UN606xWGZ2rfIvau6AUplAWvR5W1qc8a9fqQ3D+1wl/+WG3EoViSxDt0/2zFzJLVvt2tbsbepcAEBz+obpZ1JrW6kTni9Gh77jl8dr1Ph+GMEjDVnoSMjlo64xDYXXV12WgAr3tVNUTJjxe9eyJ9onINhFZ4b+irwC2T5Auh+ugf0dVf1xZzRuY7PNjN8WJwuaG10+8Ly3GmrZn62t232ptm3XSjcYjBEZbZ2IIYxYxrRlpYVoz0sK0ZqRJffV2JXAhLuzfhcAVYxOIGwn/d+ABVf1CvSpiNAAt1rZZJ91oQLSlRsqM2WRKrc3YTE9VD3iZMFoZa9eMtDCtGWlSV71dDPxQRN4GPAFcACAiK4FLVHUd8BzgjcC9InKXP+4Tqnp1vSplzBb101ol4f58useBPqAIFCazEqkW66QbjYfSUj4nxiwytdZmbKZnGGVYu2akhWnNSJM66k1VdwEH2FCr6mZgnV++mfoHNTEagfq2bZWE+4s4U1V31qsiEdZJbwBO3fCHA7ZtetGJACw7/3Cy73hX2lUqI9ueQQ738W42PApL6lxgi83emCby9IvG3a57v4fMX456/6JZe9otdR+lw96V5MNO6hUMq4RprW70fv2GcbePfvEVZE88DIDMc1MOr5Sg44y1bqGzB6lryBiPaa1uBKd9btztevenYXjYpXnd29KsUjmhf6nMj8JDPirUiXUsz7RWNyYMrdafcINeUKeJLSpEOrqdr3ImpVd801t98HMJHfBClvBVVx9ab1ZHKJJ+8fWuSH21NmW4v7SxTrrReKhCvnV8ToxZpI5aE5GXAf+Mi0j/vyJyl6q+oC6FGY2PtWtGWpjWjDQxvRlpMbXWJnVRnIJKw/0pcK2IKPD1aeQ/bayTbjQk5k9npEUdZ3f/CfCTumRuNCXWrhlpYVoz0sT0ZqRFNZEEahTu7zmqutl34q8TkT+o6i+ncXzFWCfdaDxUYdT86YwUMK0ZaWFaM9LCtGakienNSIsqtVaLcH9+PgRUdbuI/AQ4CbBOeiux6n9um+0qlFj81mdAYdStdHTUv0AFrbPplIh8GPhHYGkakz80OrLgte7/Wa5HuPQYAFQDilp3j/RUtGaU0/bBH812FQCQZ57k/s+0QSZT/wJNa6kjx31q1ts0AFl9sFsYHUWHXLz2utbLtJY+815eWpx1zbV1OT/hNObaANNb2kS+6pkG0BqkG6u9vlqrJNxfNxCoap9ffj7w6XpVKKU72DAqR9WZs0z0Vy0isho4BxfOw2hh6q01w4iYSmvV6k1ELhCR+0UkFJHJzP3OFZEHReRhP4OtMceot9YMI4k9R420qLPWLgbOEZGHcH2Ei8GF+xORKJzfQcDNInI38Fvgf1X1mmoLngj7km40Hqr1Dh/zReAjjDNKZrQY9deaYTjqr7X7gJcDX58ogYhkgH/BvYBsBG4TkStV9ff1rJiRMtauGWliejPSoo5aqzDc36PAcXWpwDhYJ92YmiCgeJObLLH/xg0suKT+H1/qFWJBRF4MbFLVu0UawlDISKDqjHs0RSMfCx3Togz1AaDFAvr4IwAEp7y0rkXWU2uq+gDAFO3aScDD/kUDEfk+LuyMddLryfCI/3+Ywj3OgKvttPoWae1aC6OhC/uXH3Tr81Io0vTWukRuFSmZvbeS1qyTbjQeVYZYmGL2xk/gfEgMw0LHGOnRGFpbBWxIrG8ETp6luhj1ojG0ZrQKpjcjLVpMa9ZJNxoPrS7EwkSzN4rIU4G1QPQV/WDgThE5SVW3VlFjo1mZWmuGURsq09qMByBVtRL3nfE+s9sNMNeoc7smIhcAFwHHAiep6u0TpDsX+BKQAS5R1YvrVilj9rDnqJEWLaY166QbjYeC1sHnRFXvBZZF6yLyOHCCze7ewtRJa4ZxAJVpbUYDkNNgI7A6sX4wsLnKPI1Go/7tms1/YMTYc9RIixbTmnXSjSkJzv5yyUN4wRvSKbOVfE6MmGxwSmk5l1b0GNNaSyKHvDdeHu/bdB1oAK3dBhwpImuBTcBrgNfNbpXmPnL0R0rLbSlNOWTzH7QwuXPd/ylEMY1ogLbNmA3kzNTjwLWS1qyTbjQcqkoxhZEyVT207oUYDU1aWjOMemtNRF4G/DOwFPhfEblLVV8gIitxpsbrVLUgIu8BfoozQb5UVe+vW6WMWaFB2jWb/6BFaBC9GS1Aq2nNOulGw6EKYaF1JoYwZg/TmpEW9daaqv4E+Mk420vhY/z61cDVY9MZc4cKtWbzHxg1wZ6jRlq0mtask25MG+UXpWXh9DoUoC1lzmJMgt4QL8uZdcjftGbEhHoTIqG1a0b9Ca9HA/cKVnO9VaY1m/+gVain1sDaNqOE8gskCsVm72xVY510o/FQCFvInMWYRUxrRlqY1oy0aAyt2fwHrUJj6M1oBVpMaylNzWQY00NDnfDPMGqJac1Ii8m0Znozakk9tSYiLxORjcCzcPMf/NRvXykiVwOoagGI5j94APihzX8wd7F2zUiLVtKafUk3Go5WmxjCmD1Ma0ZamNaMtKi31mz+AyOJtW1GWrSa1qyTPg5Jn+uI8fx4xks3E0TD+vhu1IGkv0lIlskjsMy4kDk5IjYRY3U0kc9YLfTWdFqLVkYGoKMuhZjWKkg3U+ri/1gHovMNCGGoDzrrUohprYJ0M6GuPpA1pnS+QRbp3+WW59W8ENNaBelmQjNqTSSAJ+5xGw+ph0966+gt7WfoZGU0GqX+Qd9Ot6G3LoW0jNbAOulGA6It5nNizB6mNSMtTGtGWpjWjDQxvRlp0Wpas0660YAoGrbOTWjMJqY1Iy1Ma0ZamNaMNDG9GWnRWlqzTrrReLTYSJkxi5jWjLQwrRlpYVoz0sT0ZqRFi2ltjnfS+2rmF1JL/5ID8pYAJsm/EfxRkufv6gsBp1aVz4RpFMKm8zkxrdWS6BpEWpOO82ecx6RpTGs1yWem+TeC3sa2bdL54qrymDCNaa0m+Yybt0SBahq7bTvgGsx7efV5jJemKbUGtdKbaW2cdu2Q91aVx6TpmlJvja+1SspoSK31XlBVHpOma0qtzZw53kk3mhLVlhopM2YR05qRFqY1Iy1Ma0aamN6MtGgxrVkn3Wg8WsycxZhFTGtGWpjWjLQwrRlpYnoz0qLFtGad9DlIGuY39ayD0lohFpoZ05qRFqY1Iy1Ma0ZaNLvW3PGmt2ah2fXWalqzTrrReKhSbKGRMmMWMa0ZaWFaM9LCtGakSR31JiKLgB8AhwKPA69S1T0TpM0AtwObVHX6E9kYjU+LtW3B1EkMI10UCMOJ/wyjVpjWjLSYSmumN6NWmNaMNKnzc/RjwPWqeiRwvV+fiPcDD1RdotGwtNo7m3XSjcZDoVCY+K9aROS9IvKgiNwvIv9QfY5G01JnrRlGiSm0ZnozaoZpzUiT+j5HXwL8p1/+T+Cl4yUSkYOBFwKXVF2i0bi02Dubmbs3AY3gQzIe9aqXAvVyORGRM3GN/tNUdUREltWnpObEtGakSSPqrVm1JiIXABcBxwInqertE6R7HOgDikBBVU+oX60aB9OakRatpDWX95R6WyIiyfboG6r6jQqzP0hVtwCo6pZJ3tn+CfgI0FNhvnMC09rcxjrpRsOhWtcRsXcBF6vqiCtLt9etJKPhqbPWDKNEClq7D3g58PUK0p6pqjvrWhtj1rB2zUiTCvS2c7LBQBH5GbB8nF2frKR8ETkf2K6qd4jIGZUcYzQnrda2WSfdaDx0St+SakZljwJOFZHPAMPAh1X1tplV1Gh6ptaaYdSGOmtNVR8AEJH6FWI0B9auGWlSpd5U9eyJ9onINhFZ4b+irwDG+7DyHODFIrIO6AB6ReTbqvqGmdfKaEharG2zTrrRcCh1HZXNAguBU4ATgR+KyGGq2kIGNEZEBVqbMSLyj8CLgFHgEeAtqrq3PqUZjU49tTZNFLhWRBT4+jQGOI0moYG0ZrQAddbblcCFwMX+/ysOKF/148DHAfyX9A9bB31u0mptm3XSjcajvqOy7wJ+7DvlvxWREFgC7Jh5iUbTUt9R2euAj6tqQUQ+i3uJ+GjdSjMam8q0NqmV0GQDkKp6wMvrBDxHVTd7387rROQPqvrLCo81moEW+9pkzDL11dvFuI8pbwOeAC4AEJGVwCWquq5uJRuNR4u1bdZJNxqOOvucXA48D7hRRI4C2gDzzWxR6qk1Vb02sXor8Mr6lGQ0AxVqbVIrockGICuvh272/28XkZ8AJwHWSZ9DtJrfpjG71Pk5ugs4a5ztm4EDOuiqeiNwY31qY8w2rda2WSfdaDgUKBbrZn1+KXCpiNyHM0O+0EzdW5cKtFbN/AdJ3gr8YAbHGXOEOrdrFSEi3UCgqn1++fnAp2e1UkbNqbfWLJKAkaQR2jajNWg1rVkn3Wg86mjOoqqjgPkqGY6ptTbj+Q8i82MR+SRQAL5TRU2NZqfOZnoi8jLgn4GlwP+KyF2q+oIxZqEHAT/xk8tlge+q6jX1q5UxK9TfJNQiCRgxLWaCbMwiLaY166QbDUerTQxhzB7Vam0q82MRuRA4HzjLLDZam3q3a6r6E+An42wvmYWq6qPAcfWrhdEIpKA1iyRglLB3NiMtWk1rwWxXwDAOwI+UTfRnGDWjjloTkXNxE8W9WFUHa1Fdo4mZQmvWthk1o3G0FkUSuENE/jS1Uo10sXc2Iy3q+852gYjcLyKhiExmQXmuiDwoIg+LyMeqK3Vy7Eu60XC02sQQxuxRZ619BWjHzaANcKuqvrNupRkNjbVrRlpUqDWLJGDUBGvbjLSos9amdOMRkQzwL8A5wEbgNhG5UlV/X48KWSfdaEhCMww2UqJeWlPVI+qTs9GsWLtmpEUFWrNIAkbNsLbNSIs6vrNV4sZzEvCwdx1DRL4PvASwTrrRGtiorJEWpjUjLUxrRlo0gtYskkDr0Ah6M1qDBtDaKmBDYn0jcHK9CrNOutFwKObHZKSDac1IC9OakRb11ppFEjCSWNtmpEUFWqu3G894n9nrZkcic3nCYRHZAayf7XoY47JGVZeOt0NErgGWTHLsTlU9tz7VmhmmtYZnXL2Z1ow6MFOtQYPpzbTW8MwZrYHprcGxdzYjLWZVayJyI/BhVb19nH3PAi5S1Rf49Y8DqOrfV1PmhHWZy510wzAMwzAMwzAMw5iKKTrpWeCPwFnAJuA24HWqen896mIh2AzDMAzDMAzDMIyWREReJiIbgWfh3Hh+6revFJGrAVS1ALwH+CnwAPDDenXQwb6kG4ZhGIZhGIZhGEbDYF/SDcMwDMMwDMMwDKNBsE66YRiGYRiGYRiGYTQI1kk3DMMwDMMwDMMwjAbBOumGYRiGYRiGYRiG0SBYJ90wDMMwDMMwDMMwGgTrpBuGYRiGYRiGYRhGg2CddMMwDMMwDMMwDMNoEKyTbhiGYRiGYRiGYRgNgnXSDcMwDMMwDMMwDKNBsE66YRiGYRiGYRiGYTQI1kk3DMMwDMMwDMMwjAbBOumGYRiGYRiGYRiG0SBYJ90wDMMwDMMwDMMwGgTrpBuGYRiGYRiGYRhGg2CddMMwDMMwDMMwDMNoEKyTbhiGYRiGYRiGYRgNgnXSDcMwDMMwDMMwDKNBsE66YRiGYRiGYRiGYTQI1kk3DMMwDMMwDMMwjAbBOumGYRiGYRiGYRiG0SBYJ90wDMMwDMMwDMMwGgTrpBuGYRiGYRiGYRhGg2CddMMwDMMwDMMwDMNoEKyTbhiGYRiGYRiGYRgNgnXSDcMwDMMwDMMwDKNBsE66YRiGYRiGYRiGYTQI1kk3DMMwDMMwDMMwjAbBOumGYRiGYRiGYRiG0SBYJ90wDMMwDMMwDMMwGgTrpBuGYRiGYRiGYRhGgzCtTrqIHC0ivxORPhF5X70qlSYi8riInD1FmotE5Ns1Ku9dIrJNRPpFZPEMjq9ZXaZZ7iG+zpk6lvEJEblkhseeISIba10nwzAMwzAMwzCMNJnul/SPADeqao+qfnmyhCJyqIioiGRnXr25hYjkgC8Az1fVeaq6a7brVCmq+oSvc7GOZfydqr69XvnXAxu4qkl5VQ1c+TymrHMjYbqpSXkz0k29BvRE5FQRebDW+c6EVtVXM1CvgfZqBrlrWIeW1F0jtGv1xNflsAaoR0vqq5VppOfqbDDdDvQa4Pv1qEgtEJFMPTuRNeAgoAO4f7YrYtSMaODq6VMlFJFDgceAnKoW6l2xZiAxcHWKqt492/VJEdNNFTSiblT1JuDo2a6Hx/SVoBXOUVX/brbrgOmuKqbTromIAkeq6sP1rpeqzqt3GRVi+kowW+coImcA31bVg+tdVoM9V1On4i/pIvJz4EzgK35U7SgReaEf1dovIhtE5KLEIb/0/+/16Z/l83mriDwgIntE5KcissZvFxH5oohsF5F9InKPiDxlijpdJiJfFZGrRWQAOHOKOiEibxSR9SKyS0Q+Wen5j8njFBG5RUT2isjdXrDRvrf48+sTkUdF5B1++1FANBq011/Pycp4sohcJyK7/ajqJ8ZJc8AXoeSonB/d/S8R+bavz73+d/u4v84bROT5iWNvFJG/F5Hf+t/gChFZ5PeVWUb4tH8jIr/yeV8rIksSeb0pcZ3/crqj0YnyLhSRJ0RkZ/L3EpFO//vvEZHfAyeOyWuliPxIRHaIyGPiR11FZJGIbBSRF/n1eSLysIi8abK6TcIaGnjQReronlAjWnXgynRTHTPSjbSOZZfpqwFpAf2Z7qqjVZ+HlWL6MloLVa34D7gReHti/QzgqbjO/tOAbcBL/b5DAQWyifQvBR4GjsV9xf8L4Ba/7wXAHcACQHyaFVPU5zJgH/AcX4eOKer0JKAfOA1ox41YFoCzpyjnItyoEcAqYBewzpdxjl9f6ve/EDjcn8PpwCDwjImuyQTl9QBbgA/5c+oBTh6nLmcAG8cc+3h0Pj7tsL+2WeCbuFG3TwI54E+Ax8b8vpuApwDdwI8SZZXV3ad9BDgK6PTrF4+5zs8F2oDPAflpXueovH/z+R8HjADH+v0XAzcBi4DVwH3RtfC/yx3Ap3z5hwGPAi/w+58PbAWW+fz/ezr3QaK+PweK/hr3+2vxQuB3wH5gA3BRIv0T/pz6/d+z/Pa3Ag8Ae4CfAmv8dgG+CGzH6fwe4CkV3BNfBa4GBoCzJ6uTP+aNwHqcjj+Z1FAlv5VfPwW4BdgL3A2ckdj3Fn9+ff53eIfffpSvY3RNfj5Jec8GdgKr/fpxvqxjxuq+0f9MN+npxqdX4M+Ah3Dt3xnARlz7uh3X1r4lkX4+rq3c4c/vL3BtSruv51MSaZcCQ7i25AwS7THwUVx72ocboD3L9FV3fZ0E3O7z3AZ8YSbnmNDNu71u+oC/wT3bf+3z/yHQNkV9Iq19FPfM+RbuHvih11gfrtNxQuKYY3HP071+34sT98pWIJNI+zLgnrH3Fu694dv+2u0FbgMOMt3NjXYN9xFMffp+4NXAQuAqXLu1xy8fnDim7DzG6OUa4D1jyrgbeHniXjjCL68Dfu/rvwn4cD11ZfpqrHYN1zcYAsJEuSt9HX+N0/wW4CtRPozfH7wReDtN8lydrb/p3iQ3kuikj7P/n4AvTvKj/B/wtsR6gOvErgGeB/wR17gFFdbnMuCbU6RJ1ulTwPfHiG20ghvkIuLG7KPAt8bs/ylw4QTHXg68f6JrMsExrwV+V0FdysTrtz1OeSf9usS+F/kbKuPXe3x9FiR+34sT6Z/kr09mbN192r9IpH03cE3iOn8vsa9rBtc5Ki/5kPkt8Bq//ChwbmLfnxJ30k8GnhiT98eB/0is/zNwL7AZWDzjG8gGriCFgSuf9jO4B3Un7gH6nsS+x6eqcyP9mW5S1Y0C1+EG9Dr9eRWAT+MGK9f5vBf69N8ErsC1j4finktv8/suBT6TyPvPiNu9M4jboKNxL2grE/U93PRVd339GnijX56HMxue9jkmdHMl0As8GTdIfD1u0Hc+rqNy4RT1ibT2WX8encSD5+twz9a/B2716XO+Tp/ADTA/D/cyerTf/whwTiL//wI+Ns699Q7gf3DP3gzwTKDXdDfn2rUjEuuLgVf437zHa+PyxP7HmbiT/ibgV4l9T8J1nNrHloXrgJ3qlxdGdU/jr4X11Yjt2ti+xzNx/besr9cDwAcmqWfpt6RJnquz8VdVCDYROVlEbvAmxfuAdwJLJjlkDfAlbya+F9iNuxlWqerPcSMv/wJsE5FviEhvBdXYMI06rUymV9UBXOM5HdYAF0Tn4M/jucAKX/55InKrN1Pfi2uoJ7sm47Ea9zCuBdsSy0PATo399of8/0l/o+T1XI97aZio/lsTy4OJfMZe50Gmf52nVYava8QaYOWY3+gTOFOyiG/gLAb+QyeYwE/chBX9/q8iEytVvVFV71XVUFXvAb6HexBPxDuAv1fVB9T5FP0dcLw4N5A87mF7DCA+zZYKqnGFqv7K12F4ijq9ErhKVX+pqiPAX+JGSKfDG4CrVfVqX8Z1uFHfdf6a/K+qPqKOXwDXAqdOswxwLxXzcYM1m3FtxZzAdFNX3YC7VrtVNWrz8sCnVTWvqlfjXpyO9uaKrwY+rqp9qvo48Hnc1w+A7+IGUSNe57eNpYh7CXuSiORU9XFVrVWbPm1aSF954AgRWaKq/ap66wzPMeKzqrpfVe/HWWtdq6qPquo+3EeHKX1jfb3/SlVHEvq72eu+iPu6fpzffgruGXexqo7696KriDX3vWhZRHpw98r3JrgOi3Edq6Kq3qGq+yuoa01pId0lSbNdK6Gqu1T1R6o6qKp9uEHtya51kp9Qrv3XAz/212AseVy71quqe1T1zmrrPlNaSF+N2K6V4duYW1W14J+bX6dy/TXlczUNqo2T/l3ciMxqVZ0PfA3X6QY3ajKWDTjTngWJv05VvQVAVb+sqs/Eje4cBfx5BXUYW85kddqC6wADICJduAfZdNiA+5KePIduVb1YRNpxJuKfw5mWLcCZwcgk+U1UxuEVpBvAjZoCJX+YpdMsayyrE8uH4BqHndPMYwtQmlBCRDqZ/nWupIyxdY3YgDPjT/5GPaq6ztcng2tAvgm8S0SOGK8AVb1J3Yz281T1yZVUygau6jZwharmcSPXTwE+r6rjtTFlSBw6sF9E+qdbZlqYbuqnG8+GMeu7tHyinWgAcAnuC2Zy0G897usYeEsOf23WAMf///bePM6Rs7z3/T5VWlq9THfP9OyLZzwe73jBZmwMxjaLYxscBxKCnZBAAodLLuSQ3Cxs9+Zw/Dkk5nJOEhJICMchCQFiuGEzYMBsNmPM4AXb2ON1PJ7x7Hvv3drqvX+8VSWpR91St6SS1Hq+n0/PaKmq963ST2/prXp+z4P9gVuCscmc/gh7YemIiNwhImtmLheVPjtIX+/A/nZ4WkQeFJE3LGQfi5aZeZF75vNqEmodNcZMz3ht5sXnLt+vvgbYa4wp/uFerL8vAm/yf2u8CfiFMaZYqwH/jo3wu0NEDojI/ys2KVkJIvLbRfr7ThX7Mi86SHcz9yGqcS1ERLpF5J/E5gIaxYbED0gVPml/Uv9t4Gb/pZuBL8yy+K/7fd4jIveKn2+qTH92FGmr5osQs7TRKfpqxXGtBLH5rr4lIod8/f0l1eu6Lc+rUVDrJL0POGGMmRaRrdirHwFHsVeIiss2fBr4oIicByAi/SLyZv/xy/wPKI6dfE5jr5rUs0//CbxBRF4pIglsuON8j8HngRtF5FdExBWRLrEJ3NZhf9wlsfueE5Hrsf7n+fItYJWI/JGIJEWkT0QuK7Pcs9iT++v94/Z/++3XwltF5FyxFzBuxfq15/s5/Cf2GF3hH+f/zvwvVFTiy1gtDfrH/g+L3nsAGBWR94tNMOeKyPkiEiSXC5Lw/T72gsrnqjmRVYleuGrMhStEZC3w34B/Af6Xv+05MYXSgb2mdTLUlkN10yDd+FS8oONzDHthsviuwwasBw5/8vRl7FX/38LeFRkr26AxXzTGvNLflsGGPM9cJip9doS+jDHPGWNuwXoZPwb8p4j0LGQf60i12gMbIbReRIp/lxTr70nspP16Zr/bhLERIv/dGHMuNp/HG7AhzTOX+0KR/q6fRz+rpSN0V2YfohrXivkTbDjwZcaYJdiQaoq2XXJTB1g1Y/3/AG7xJ90p4MflGjHGPGiMuQn7Hfs6djwst9x5RdratoD9qYaO0FcLjmvl2v1H4GlsxYEl2N/ZxdqDWfTXxufVhlPrJP3/BG4VkTGsDzn8shob4vxR4Kf+FZ3LjTFfwx7QO/wrLU9gTzZg/RH/G5voIEiq8D/r3KcdWK/DF7FflpPYpC5VY4zZC9yEFeBR7Bfiz7A++jHgv/ptnsSK7c757oC/nddhPeSHsAkerimz3Ah2f2/HnsQn5rs/Zfh37N3KQ1h/zbxrUfrH+Q+x5foOYj11R7Del3rx37E6eQEbLvbvRe3nscfuIv/9Y9hj1C8ilwD/F/C7/nIfw37RP1CnfumFqwZcuBIRweryn7FXlQ9iE54sFlQ3jbngOS/8MeHLwEf9i6OnYceL4hrIX8SGxP82s0ySxNbzfbX/o3wae3eimeVBO0JfIvJWEVnu/+gb9l/Oz3cfm8jPscf0z0UkLiJXY89lxaVvv4g9L78K6zs+BRG5RkRe4l98HsVeeGqG/jpCdzOIalw7TOmx68OOM8Niq/L8txnLPwrc7OvqUmzodTF3YSc+twJfMqXRHACISEJs9EW/sZFto+i4Np8+LZZx7TCwTET6i17rw+phXETOBv4geMMYcxQ7R3mr/534fU6NFm7H82rjMS1gjNe/1vijQmLAGrbbi02OsanZ+9joY4Y98e3BXpj4FjZ8qjjr663YgXWYQvKP38EmsQuygX7Wf/012ARp49gLDV8Aeiv051+B/zHjtUp9ehs2S2gt2WwvA+7FhlYdxYbObfDfew92UB/GXky5I+gj1SdTfJ9/LIJsoWv8doIENhX73Ep/qptodOMvayhNsHQ1cyfcHMT+0A4uwv4FM5KZYhPznKAoCy6lCW4uwEb0jPnLfQs/2Y3qq6H6+jz2gvA4NjP6ry1kH2fRzX3A24ue/w/g9gr9Kae1j8zYzxItY+/i3YtNSPUk8MYZ62/A/jD/9mzbxd6RegY72TgM/B1VfFdUd201rr0be7F6GPhN7DnxHv/4PIv1Jhfr6nTsRaBxvz9/V9xnf5l/9td52YzXDXAG9iLDd7E3oUaxVQNe2Whdqb5aa1zzl/ssheoRa7AXDZ/2+7jN79d9Rctfj71pNozN83IvM+YbtPh5tRl/4u+4oiAi92AHk9vrsK0bsRkjBfuFvAybBVQFpyiKoiiKoiiKMgu1hrs3HClNPlH899t1buc7s7TzocprL6i9K2dpr62THBRxE9ZfdwDYgi2dZqI+zoqiKIqiKIqiKO2E3klXlDZDbDm408q89X8YY2bLyLqQdr5D+dIwf2mM+ct6tVPU3pXY8h+nYNo8+UcroLpRGsli1VcV/fkQhWSkxWwzjUnGphSxWHWn41prsFj1VUV/dFxrAXSSriiKoiiKoiiKoigtQsuHuyuKoiiKoiiKoihKpxBrdgcaydDQkNm4cWOzu6GU4eGHHz5mjFle7r0lA+eaXHai3FsATE2++D1jzHUN69wCUK21NrPpTbWm1JuFag1aT2+qtdZmMWkNVG+tjP5mU6JisWmtFhb1JH3jxo089NBDze6GUgYR2TPbe/ncBOde/MFZ1334p38w1JBO1YBqrbWZTW+qNaXeLFRr0Hp6U621No3Umoh8FngDcMQYc36Z968GvoEtqwTwVWPMrZV7PTuqt9ZFf7MpUbHYtFYLi3qSrrQpIkjcbXYvlE5AtaZEhWpNiYr6aO1fsTWePzfHMtuMMW+otSGlzdGxTYmKDtOaTtKV1kNAHGl2L5ROQLWmRIVqTYmKOmjNGPMTEdlYnw4pixod25So6DCt6SRdaT2EjrpSpjQR1ZoSFao1JSqi09rLReQx4ADwp8aYHVE0qrQYOrYpUdFhWtNJutJyCIK4nXOlTGkeqjUlKlRrSlRUqbUhESk25X7GGPOZeTTzC+A0Y8y4iNwAfB3YMr+eKosBHduUqOg0rekkXWk9BJy4VgdUIkC1pkSFak2Jiuq0dswYc+lCmzDGjBY9vktE/kFEhowxxxa6TaVN0bFNiYoO01pHTtLz5n48Y3c97mytyzYN9wIgXFWX7TUF8+PKi+x7EtbbRK9ivNL3pPDFEeOVPC+m4jFaRJ6TQBdQP20sBq0VH5dG0klaC76/Rpy6asNwb1trrXhcmzlGlXt95ntl1/VyGCcWLlfVMa+D1pqRcbsc4Rjk5cB5TV2329Zaw98HL2cfO3P/xAp1ZjwQp7w+J05iepeVrtcC45qIrAIOG2OMiGwFHOB4vdsJtZbPgPu6Om74xyDX1G97TaDk98Ucv7mMcXCwmizW08x1ZPw49AzadYpfbwG9RYb3Q/KSwpUr6rpNoK5jZeSYH0Nmyj5OpMpqTdITZONDxBy7XM5LERdbLu2U+cGJfcjgGvte0TjZUVqrgo6cpCstTodlb1SaiGpNiQrNuK1ERR20JiL/AVyNDYvfB/w3IA5gjPk08BvAH4hIDpgCbjbGmJoaVdqTGvVWxcVHAT4B3ABMAm83xvxiwQ0q7UuH/WbTSbrScojQUZ4TpXmo1pSoqIfWNOO2Ug110totFd7/JPaCkdLh1EFv/8rcFx+vx+Y72AJcBvyj/7/SYXTabzadpCuth0hHeU6UJqJaU6KiOq3VmswLNOO2ouOaEiU16q2Ki483AZ/zIzW2i8iAiKw2xhxccKNKe9JhY1vnTNJzd4MbB8AFXEnXb9veD5Gsv73Ej2HiJADm5EFk/Xvq1069CDyaXg58L4gRB8ln7etuPPTI2Te9ghdlfSESaTb/U7i9Yl/nPL1fEmvfcJZG+q2Ltz2znVb1ckblPw+Y73FYNFrzv49iPKjDhebibXtmm922eHgmXl+/Xh0p8WimJ2b1ztmF/fGpzPtzjW3BOvY423Gt2sNdhdZqSuZFAzNu5839ADiSLbxY6ThVy8iX7P/9q8J2gLrnjqknM7Vmkj32deMUzqvGQcSzfmrAuInSbQTHbw4NSs+g3SbgyJVV96+dxzXwvf3Fv0Mq+Pvng3f3e3Fe9+sFv3sNv1WioERrUyOYVP+py5TzCIdjHBj894vyG8xcx/QuC9dpsfPoWmBv0fN9/mt1maR7Zlvo2TdODNfUcX4w/S0IxoZA08Hn0oIe9UBreS+J6xQdB3HC/QDCvBsAnthxTRIpYjIVvh5zpgq6K25DHFi2gbwJ5mTz+z3R7mPbfOicSbrSPnRYOIvSRFRrSlREoDXNuK0AOq4p0VJZb7VGCJXbuOY/6EQ6bGzTSbrSckiHJYZQmkc9tCYi12GT2rjA7caY22a8P2fSGxFxgYeA/Zrwa/ESxbgWVcZtpbXRc6gSJVXordYIoX3A+qLn67B2HqXD6LSxrXMm6bFr572KOfY5GDoNsGFDU/mlAKScY0ybpcT9MgMZb4iskwLAyWdxu+xysmYTmeyzAJxMn8Zgcg9CHoC8SZLzkgAMJZ5m2th1utyLF7qHVezQj0vKHiBOacin2KtTRhwbzllURka67NxBzI8LYXhzlPywKxaHkM2vq+1cYmEhYef1CAmf7zYaGR5f6/4IV0VXpq0GrfkT7E8Br8P+kHhQRO40xjxZtFilpDfvA54Clsy7/XKfYYXdKQ5dB8jkbQibIx6eH1abN0nAH8coU46Mx+22cIj74W2u5MLQNs84OOKF68acy+exV/Mj6z2AIzl/HwohnqYoNO8UjjyPWbEZ8LVWdEwqjmtgrUJgL8vMgzqUYGtaxu2yFocKu5PO25tnCXcifG08u4KYZMgae840xkG67XlPsvlwOYNLzkv4be/E4IQ2tZhkQq3lTQw3/PxzDT2HjmWfojd+JOx3GCKb7AlD0oPvVfj40HOYVdZxIFxFzttu98mpMqTWy+EY32Iwj19s7XwOBX9skyKJzXNcA8LPJHzuf2HldW+xI5MJXi9azmwr2cbM7YTbID8v+8F8mWkvCUPXu/pKSj8WM7MkpJFiy1K8ZHvlkFwaHH9Qa63fbHcC7xWRO7DnzpF6+tGLP0cJ/5mbnLe95DvsmXj5MSBZZE0w4BEP9eaYbaGebLOF+YHgEcOOm3UvCTeDYJx2JYfrSypmxsAr2HE8YqXfC98e68V6wuOXN/dbq0CgwzksKjI1ghtount+/W33sW0+dM4kXWkfOiwxhNJEatfaVmCnMWaX3ZzcgU1yUzxJnzXpjYisA14PfBT4v2rpiNLi1GFc04zbSlXoOVSJkhr1VsXFx7uwkWg7sdFov1djj5V2pcPGNp2kK61HjZ6TKmpuXg18A3jBf+mrxphbF9yg0r7U7qUrl9BmZmmYuZLe/C3w50Df/DqutB0d5qVTmohqTYmSGvVWxcVHA7RgFmYlcjpsbNNJutJyiIBbW/bGf2XumpsA29T/q1ShtUpeumoS2pRdRkSCC0kP+xeOlEVMHcY1RakK1ZoSJao3JSo6TWsdNUn/0V5bGu2MwS6G09YLES/yNgwkp1ndvZTJnPVbZpa8kqnJAQB64sc4Pr0BgGVd1ks3ll0Vrht4L9P5vrCsQE/8GK7v/+mJHePZk6vp8RMeLEnkyBnrSffM+aS9XgDWdN9POt/H9oPrABjqTjCUsts4OR1naZf1wKzuXhq2nTf3M5JZw9GplQCkYnBgPFgny6vX2xvGE7lNLF1KoZwagGslIL4PHayvySOG8csqOF6GKe8x+1j6SLr+nMX7PlJUwu0UFlyeR3Bq8JxUUXMzEip5qgM/cdQlygKqbbfY9xxVX8PSOA0/RrVpjeoS2sy2zG8Av+qXyuoClojI540xb51vJ/ZPjJKKnQCsNy5nksR8/27cmaI/cQYAI5mdxJ0BADJeD47kQh+cwQ09dQaHmJ9zw8UjZwqlo4q9wgA5seNhwplgOm8DAgoeYTsOmfyz4eOclwrHS0eyxJ1pu4xxSMUuDLc7nNkVepBFvLBv+XDctM+73BQJZyLsd+gvLePEDjx1ZvmWsA+Ge4N0HAhX4bENx/he49k8n34prfkpp2attQTbD41y2pKi8jt+mbSDE8LGJaMMda0FYO/EBDE5HYDpfDdJ137OwXEP1st4CXrj9tyccCZI+xrKm4J3cySdIOYIXTG7bl/8MEenVgOQdAnPs3FnisP5NJ5vw3fFMJG1j3sThm7/OwKwLFn4St6zb5jVvVZXMUdIuPY70RM7yvFpe17dP5bmrKUriYktpzbT2xtz/DJrxg2/UwDeivMLnnK5F5G4fxyq86cXl22rXj2LQ2veDM9uQPHxdeRK8ub+8NgE3utguXLrQ+mYUowdBwu+cxGvxIdePF4GPviZZL1UmLMo6GNA4DUPtl3sFQ/645k4jvjt+GX8iseioKQfbqKkfFxpvqCism1chcuPgx2cNeeGiSVLy9FVTfvrLfguzsxHkMn30LX3R/a9TX9M1nvAf8ch56XCfCjFBJ9ZQHjemeFZz3opHP+xK+nwdc9zcARy2Lwqgsd0/hF/uWx4Xixe35EcnomVlKscyz4FQNyZJuGMh+vEnSky/pxjIjdErz8TdCRb+P44pd8joCRPlRfrCY5CIR8EgFwD5of2+Rz5XYrLCHbiebRaOmqSrrQHIuDO7TmptZwHwMtF5DHsZOlPjTE75ttPpf2pQmuVeBDYIiKbgP3AzcBvzVhmtqQ3H/T/AgvGny5kgq60B3XQmqJUhWpNiRLVmxIVnaY1naQrrYdQ6UpZreU8fgGcZowZ9+9ifh2beVvpNCprbU6MMTkReS/wPWyu788aY3aIyLv99zXpjWKpUWuKUjWqNSVKVG9KVHSY1jpmkn73nhNcssqGRD5+VFjZY0PIvKLqNM+ddHhhZITjfhhdzBFW9/oh37KWVMwuO55dQTrfhePHSHrG4PmbOT6VpS9hnxhWsCplQ+ePZc8k5xnW9NhI2CNTa+mJ23CorJdiPGO3dYALSbnDnLPMbuPwZCFEr7cvF4awDmeGGc3YfqbzF/PC8BTp/ETYnyCsPuk67JuwudPGMjm83ngYUpP3EiRlDIB+dy95P2w1CG0Jwl4m8kP0xI4BMJ0fCI9XmkGSjJU93sJVbD88CsDG/gyeGQZgTfdA2eVL1xViDfScGGNGix7fJSL/ICJDxphjddl+laHZzQpzny+t3s+Z5dpmhsrPvW7tWjPG3IWdiBe/9umixxWT3hhj7gHumW/bO07Y7/yqnpEwLDfnGbrjLhN+OFvMEU6kp/011oXjVsKZwJVsOB44kgvD8XImiesVwtgDaw7Y8SEIlQPCMcmRXFFoaQ4Rj3S+UFUuCA92xCNvCqcezxTCBceyT4XrZL0BpvPdRcvZ/1OxaRLORNjvidxQeCbLeqkwdNgYh7gzzU/22TKar92woyS8NefvXxA6CPYqfXGoquCVljuSawA4md5NX/wIeWNDEKsp+9Xoca3RPDNsj8nmgQlGM4OALXkXc+z5YrDLZd94P0enJgHIeuD5Nom+hA1Zt+sIqRik/YjlTD7PZNZ+5gl3IPyc03mPVMx+XhPZHKmYQ86z2v30j6Z488vtBrpiwnTebvvwpINnMiT8OkL2PGg36JAPw+LzJs6ecfu5H5/KsjQVZyxjdZiKOYyk7TqT8ZXE/B+EmwZSZDyYytswzfHsSrrc8FRC0rXnwh/sWcKvnbEzfF3EC8+bXe5wQYMC054N7U+Jd0r4fDB+PXVykhXdttR9THaG1pW5aHetQRAWXlyGrzBOGArhxDlvOyKF3yvFYcaeiVO2JJtQYocxlFoUguUcJ1syZtgw9GzJ8+I2g20Uh7rb5baF7RT3wRi3xMZTGCOz4VhaHAYPfnix0+Vvonw4sUcMwePZYRv6fNZA0b4Wh8374ciB1mwJrSl/uXurLtPa7nrLm/tDy1NoL/CPecxJkzvtFQA45n6EgiWs+Jwp4pWEtRdbxxx825ev56AkpSOxgvWLXHhOcsQj5yVDHRnjFP0udxCb+J6YkymxXziSC8PihTxdbtG53deT6z8Otr0kfjC06Nrt+xZYPB49dh4AFw3tOMUGEIbmm0JpNvFyIIRziVPGtKB0qfMast4DxPN2bpOP3V91ibl219p86ZhJutI+iECsgeEsIrIKOGyMMSKyFXCA4w1rUGlZGq01RQlQrSlRoVpTokT1pkRFPbQmItcBn8BGP95ujLltluVeBmwH3mKM+c+aGl0gOklXWg8BqSGcpYqam78B/IGI5IAp4Gb/bqfSadSoNUWpGtWaEhWqNSVKVG9KVNQ+P3CBTwGvwyb1fVBE7jTGPFlmuY9hrYxNQyfpSsshIsRiC79SVkXNzU9iS7QpHU6tWlOUalGtKVGhWlOiRPWmREUdtLYV2GmM2eVv7w7gJuDJGcv9IfAV4GW1NFYri36S/p3dNor5yT0niTnLANix9yTLz14BQMJ1GElbn0TgPQv+d0U4NmlLXaTzBZ+3Zwwre/JM5awPY3g6G3rgzhiEpDsMwNLkLo5OnW3XweX0/nH2jK32e+bRl/D9GQJHJ+22jk8JY5kuzhi0no4NfYeZyA4B0Bs/QmrslwB0L/1tJrLWD3dw3CNvDKf123Ums3m6/b4+f3KS/WPWj9qbiPHgoS42+sttWvIMo5k1dv/cPuvt9Fkaf56M8T2tkgk9qIHvzj6+FDy/1EIujYmnSjxMl6+yPsOHjoxxSe4L9sXud5/yGc1EAMdtz6uyre7fXggzPd+t1IdAbwst1dbOWnthbJonDvtlVZYPcmzSeszW9nXhGUMmb8eUk9P58LFnise5OD3xLvqTdowTvNCPNp1PhB7dvsQgXa5dJm/ipGLDYZmsuDNF2veMTuUHcHx/3GByD4JH1vem2bat7y3nxcLybjmTxLfkEXem6Iufg2esnzfj9ZDwy1oVezwT7gQn02tCLzQQeqR74uNkMrY0zEByLxmvh8vXHPP7XuyrL/KpzvCjJt1LQw9psQe1eGxbmtzI8bQblrXpqsIi185a++XxCR7dPwLAdVtc4o4NPOpyR3H9z8iVPmJO6hQ/riXHdM5+/p4xTGSFrG8+T8WcUJNgz192e9YvDvY8nTeQ9ezn9sbLNjDtn39H0y5LknadoZRLOg9jGfv88ESalT32cx9Ou4xmVoV9OG9pMmxv7+g065dYn29XzKHbt2imYuMcmbQa7ku4uGI4OLHcfw4rcvcBcCh2FeNZ+5ti6xo39K3nvBRJZyzUm/UdF7zVvbHz/NfvR7JThbJGRSW7zhnsZscJe6yWdqXpL1Rkm5V21lqhrJlr/dFBRcWislbFnt/gefHjkvJXM3LsBK95Jh7mrxjLrA5/28SKS2GZeEnZNZE8Ttp+D/LJpWGJwOLPFzilLFfgt7Xe5/LeXtdMkacwXs4sOen85Mu2T1e9sey+Fj8O/j9zICgXdlWYTwPuJZO3Oku4EyXjmitX4OGPfV6caudC7aq3oBwegJu3Y7mJ2eMdlvIsQsQL64WF5fL8aZQxTvi5F5cycySLY/ySeUFJsuMv2u0Nbil8fuKEeRIEm6OiONdBcB7yTDzM6WKMG+aEyZsY47mVYWnJdP6hsD/F3w8RDzc/Ts4p5IsJxuy8SYalTUdueR8Xf+l/+W3GfH3ZwSfvJUv2Nczb4sQQCno33IuMHLKP+1eB85qiNreSw5a9y3lJ3Cpt5lVorVL1p7XA3qLn+7BVdwptiKwF3gi8Gp2kK8oMpLMSQyhNRLWmRIVqTYkK1ZoSJao3JSoqa61S9adyM/yZdte/Bd5vjMmLNPfik07SlZZDUH+TEg2qNSUqVGtKVNRDayLyWeANwBFjzPll3hds8qUbsKUl326M+UVNjSptiY5tSlTUQWv7gPVFz9cBB2Yscylwhz9BHwJuEJGcMebrtTS8EHSSrrQemilUiQrVmhIVqjUlKuqjtX/F5m753CzvXw9s8f8uA/6RGWGjSoegY5sSFbVr7UFgi4hsAvYDNwO/VbyAMWZT2JzIvwLfasYEHTpgkn54xPqxN65ZEvrG+3oS5P3gholsnhO+7239ki5G0jmWd1vfRSbvkfN9c0uSblhT/fhUll3DU/Ql7OHLeobjE9YXsvNIluX9QY3A80n63omEm2XLYJy4fwVoSSIX+jpP602yaq3tz/6JUV4YibG2x/oyd46czkuWWXuFcBUsLdRIXdtjPSXffvJFVi/r5oHdtubgOy9ZH9a0zeUNu47ZmoxrBlJM5zyePGa9N0cnN4V+vZPp88h5QU1F4dn00rCWfM4r+FtXdg9zMm23vaU/VfCYOOVjSAAuXdEHWC/6px/Yw/nrBmZZ0iICjl6VbQjF/rO5/Nsz66PO5vlutF+9uOZ5dXXPq9u/cPk21tpIOsempYU64jGncOKazOZJ+4PcslSck9PWP9YTd8Pv+UTWwxEhne8KtxfUqI45eUb9XB2T2Xzo/024hsGuJSztsmNKziRDT5xQqC07nl3BitRKUv4Z5uDkibBvCXci9MD1xo+c8rkGdaDT+cPhoHJ0qpfzllof5fH0XhyRsK0T03mGp+047xmXlT2B53M9cWcq9PVN5/pDL3xP7BhZY8fpTL4nrFubye9maXJjiSd4NgLvH8BzI1Ph+WU22llrmbzHZRus719kmOF0cIx7SRbtd87L4fi+xZgj4fkz4TqMZTLhcjFHQq15xoTb6E0YBnx/uYdLVywRLnNyOkd/0goqnffIeXa5kXSO85b2h9u+/+BImGfm508d4ZKzrIf8DafvKDuGnDPYzY+eORI+T7gOV/vnqP0TGQa7gnfyNm9CosfvA7zo3mCPiVfwGec8l71jm8JtDXXtI+vXP856KVKxYQBOpqfZ1Gc37soVEKeMC9YSaB96+OauY+FvlNmoh9aMMT8RkY1zLHIT8Dm/Msp2ERkQkdXGmIM1tUshlNWTwn4W1w4X8UrqQ5f22ympXV3sRQ98xsFrec/+/umJHQuXKa6RLeKdkrOCrjcAtnaTMdtL+lfwrntltebKFSU+aOs1tmONkXvDoFtjnFP87t6rfjPYiZK+el6hVnuwrF3fLTpG28J2hKtIzhEtHCznSKlney7aeWwL8Fw/H4A5NXdE8ec/M7dBMcU+9eK8J4GOHcnhShqWbbDrGy8cG2JS+MwdyeHgldQOz3nb/e45jOdW+uukSSZsbqoYl5d8rkn30nCdrJcKz3GuXIHnbgv76kjO5n4AHCcWvr70jr8hqHnkSA5n3yPk117i77dXekyCqaSBvNlOzLncX+4q6A+O1akEy8WK9q8StWrNGJMTkfdis7a7wGeNMTtE5N3++59e8MYbwKKfpCvth2YKVaJCtaZEhWpNiYqItFYuAdNaoKZJutJ+6NimREU9tGaMuQu4a8ZrZSfnxpi319RYjegkXWlJxNEBX4kG1ZoSFbVqTX3CSrVUobVKWZArNlHmtZkJmJQOQc+jSlR0ktYW9SR9uihErzgUcfNAHs/YUI2cSbKqx4ZKZj1Dwk2E5WUMThiy4ko2DNHcsMSGSB2ZtIfPmzIcOTkJ2FD6IMTvopW9YQmZZak4jx+dZKArCBGJkXBPPZ9N5xOs7oXu2EsAuGAZUCHMN5v36E/GuPGSQvjlWQOp8P9bv/s0ABNTWfq6E1y5aSkAXe4kR6fs/g2lsuH+9MQd1vTG2XnS7u/6JV1hSTfPxOiJ2/DWg5NTrO5eOmffZnLpxsrLi0gb+pvGml6mrBaqCSWfbZ35hpgvBMO9C+pjJdpRazmT4Xh6L8tSS+nyywZlvRTr++zjvJcg66XojdsQ3vHsCk7vt+GcMWcqLL+TN0lSsRM4/hi3KuWRMzYsbyy7mpRfimYsk2dZyr4+kc2zJOmXTsOG9o7nbMhuwnXCsXN4ymVFoZqQH3Zqx5fiMHE4Z9b9zJs4Mb9EUiHc166/LAk/2T8cvrbED4PuS7jh+DSV62Ii28WEX9IrFXMY7LL9zni9uH5JG0dyTOXsuDSZW8pIphCGPB8CO9Rs1Elr/0qEPuGJbJ7th0aZznlhmbTh9AADfjU7g8PhCRvG3pdwiTlOkW3KCUs4nZzOhuvnPFvONCiTNpnNh+Huk1mHkXSwvkfM19MzRydYvSTJCyfseXZJKkbKz/DbmyiN3d07PM3KPtvBj1xfrK/Zx49czuPb9+8B4BO3XBy+HljKAA5NBd+htL/vKRu6itVQEMY+ll3JRNbuw1TOYyyzipXdQZm6LFO5AQASToZfHLUhtS9d3jtr32bSE3c5OZ2dc5kqtVYpC3IlqknANE/GTwk1z3mBfaJgl3DTJ/CSNo52ZsgxUvqaSOFxEBpf3EbwfGZptGDbBjdcL+clZg0VF66imkTQxSXhXOeKotevIqgslef+Uy53FPc1wDOxsGSWSy4s11ZcQg5seS5XbDhxEGJcDcVtzblPbXgeNUyE5yQA8UPNg5DzoKRi/9TDpHs3h8u5QVkzHPImRdaz54q4Mx0u45lYGC4fo/B55EwcY5zwM7NlRm0Y+lS+n5Q7Eq6f85IUH9IgLD7uTM04h57BbASl2rImRUouDF935EqCiHHDveCV2iTCY1L0nfDWXRzqIeclQ3udS/qUdrPeA35ft87at5mUK3lXjnbUWi0s6km60qYIGjqlRINqTYmKOmitWT5hpc2IZly7E3iviNyBvRA0ojrrUPQ8qkRFh2lNJ+lKyyHY5HWK0mhUa0pUVKm1WkOQ1Ses1GVcE5H/AK7GanIf8N+AOIT+zbuwtoqdWGvF79XUoNK26HlUiYpO05pO0pWWQ0SId9CVMqV5qNaUqKhSa7WGIKtPWKnLuGaMuaXC+wZ4T02NKIsCPY8qUdFpWlvUk3RHhIPj1i8x0BWnx/dVG5zQX+6YHF2uLWEQd6bocguHxJV06IOKSbpQKsFM4Zk4mbz1qw11J3j5GUMA7BmZCtf/l5/s4s+utb+ZfvTiEMdH0xzyvXcbl3WHZWI2Lyn4H3Oe4a7HD/DHVxY8MJV4z+Ub53w/8EpOp3OcHE3zXL9t75Vr97MyNQzAeG4lu7Mrw3WOT3l0xYJyJYR9Hcv00ud7AEfSOVYXKkBVxaUr+kq8pLPR7uU8FiuN8IU3imrLw7Wf1mz5saQzzrQ/BiWdcfKhd3OKhDsRet2WdT0fjnfpfF/oY4cxWzbN94LlZ5wOlqcO+v9bDxpAKraU50+mOX/IbnvCDIX5KiazeTxjj2WQiyPAIR+WPKuWSvkunj1k92Ptsu6wRFzSTbKux3qLV6YmSOf7ePqkLYc1lfM4OWz750icrpgdB3OeYdj3+PYmpumKuWzqm1dX2dKf4rmisX82ItBanX3CEt61CMqHnpzOsSxlva6p2BRre31vojNZsuaRyVSYnyUVc8LtxBwh6cKEL5HjU9nw81uaivPTZ20uhUTcpcdv5+iJSX68/SR9/rlr1bJuzvbzzcz0pDuO8A9feASAq99/TVV7+b5Xnl5xGc/Y8kRBPgbBY8+o8Y+J4dyhNeGym/ptycHx7Aqmc4XvWM4kw+9SkBNhvrx6/SB37zlRcbn2G9csM73hwW+wYp+56eorKTdWsp4pLctWrlRbcQk3+55T4r8O/d8zyrs5M/oWLHeKL34OikuczUXBVx7z27DP905cxMa+nwO2hFwS62PO0h96nR288HFAtZ7fYgL/ejXlsdpVb+VwJEd3zH7Hcn2nERd/vjBxlPGuswCrO1dyRX7zRLhc3nSFn9eU1x/61Y9Pb0bEK8kXEywXc9Kh3lLucJj7IiD4/CZyQ/TPXYExJOle6v8/93LGTQSNhN+DqXw/3bGTdt+8BAaXpD9XijlTYfnC4pKF5Z5XS+BfD/zsc7GYtFaJRT1JV9oTEYhVqDk89/qaAVmpjlq1pijVEpHW1Ces6LimRIrqTYmKTtOaTtKVlqTGK2X/SoQZkJX2ppOuyirNpVatqU9YqRYd15QoUb0pUdFJWlvUk/S8ZxjL2DDtiWye42M2fOTaLT0cnbIlT1Z0jzKSWRuuszL1JF3eYfvEjZPFxj3Gs8cgbsM7jBNj7/hWzl22C4CR9HpSfmjMS5fvxfFsaMsb12fBD1F52erVfOnAKP29dhsHR9NlhXbWQIqz5hHqXg1BGZrPPPginpfmqz/aCcD5bzmTmNgyEzFnivVLrBxikqYvcZD94zYEsLh8zmQ2x5EJexy/vf1FLvrNi+bdn1etHZjzfREh7i78S6gZkKujISXN/G22Sjm6SvtYq9aagTEO6Xwfo5lYWFry6GQPG/ps2GPG66U3fjgMX8/nk2Q8W8Ks2z1xSthjoYQPZLEh6YOJPRydPhOAoa6d9MRs+an+xH5WpOJhqTYRj4E7/x8ADt3wdxycsMcyky8NC12RWkm9eadfcvKzj+zjgrW2HNNIOsdI1o7nifw4Xe4Yp/fb0MKx7EpSfrje0anBsDRbJu+FoaeT2erDVmeypX/ucP56aK1ZPuFM3gstDBPZfGiFGknHWN5t92k621uy3EtX7GLSL23nSDYMFc56KT/E01o1zhjsDkuK9cRd3nCBDRtPuE6oo6f7kjz66EHWrLbrHDk5xfJB67Uancpy6YqCP+HNZ63gze9fUe9DwJruAZ46OclE1oZfe8b+2ceGF4b9kFgRliRtKP6GvmPAELtHJNynyaw9fx6fyobHkXmUYAO49rS5rSDtOK4FzAyVLS4n5vgWgeJl8iaJK+nwNYNbPsTdL6cGsHvspazufo4udxgg3G7QThjy+54P0f0P/6MQUk/puObKFTQCV64IQ8wdyYVWC4AliaPkgnJcMkFe7NjukAvLiNlteAWLppM+pe/zoVLZtnbVW1AmLeuliPnlFO35sDA1yptYeM4cjr+Ufte6h4IQ8LivnayXCse4mGTC8+8XHunmhnM3Avb86Trp8POLSZrj03bs+u3r7uAHP7nBtunEw/4EBGWZ641wFZ7ZBvjaL9LQWHYVYO1unomxNBmUnMyG3xnPxEu+bwsJdS+mUtm2dtXaQlnUk3SlPREafqVMMyArQCRaUxRAtaZEh2pNiRLVmxIVnaY1naQrLUcVnpNayxRpBmQF6Dx/k9I8VGtKVKjWlChRvSlR0Wla00m60pJUuFJWa5miOmdAVtqZTroqqzQX1ZoSFao1JUpUb0pUdJLWFvUk3TOwc5/1aS4f7GbdoPWB/GjXFGv67Y3TJ4+6jIxbz2I6m2fL6tO4dsOw3UA+Szx7yD7u6iNrrPfnwPiFLE3uopf9AKS6R3BNUH7HIe/Y5dz4VOhp/8J9R3nhxWG2nG69ZL9/8bqG7fdsPLd3mKsvXsvvvdx6+ZLuQU6mNwKQwGUwuRuAXx5dx3nLkvQlAk9Mkk/f/QwAf1PkQX/thrl9ceX4m23P85LTBudcJoI6iB2VAbmdyqYVU2u/q/HFt2PNTc84TOcT7BqeCMtibR7s5vi0/T52xz2ePL4hLJM1ks6FfvW++EE8E/e3Ews9i2C9d0GpGGMc1vXYYJWZZYiOp08Py9Ok3GFevO7Ttp2pHJeumJ+3th7sPjDKa7csA2AwuZuMZ/tgcPFwSLm2rwlnIvQgingcm7JlMw+OT3Dj6UM19eHzTxzksvUDcy7TjloTgYQblF4r+MYfetGW5tk41MNzx6xHe7A7zo4XT7LR9413ucO4vq8y7S0JtbZn1HrX1y+xxyKTd7hg+T7Alo4KvLN5YuH5aXw6x9aXrWPfkXEAcjmP372gUPIsSvqThZ9NQYnXVMwh7fvnB7viYSnWld19TOc89py0z0+MTlcsmVqJH7x4Iix7OBvtqDUAg5R4YoVCOadib3Cxv9qVdEnZtuJ1cl4iLD9ZzOa+n4HxyPs5OBzJcmDiYsDmJQr8trG//xuMmaroyW4knomFvnSAJfGD5P0x3JUYrmfLYXpOFyKl3uBU7MKa2g7KYVXys7er3grl7fLk/ccGl7SXIumXMHUlF77XHTsZaiPppNkzcQUbem3ugOAzCXD8Y/a2lw6TdF8ErG896YzxyxHru17Xe5SNfXaO8dOfvgJHbO6XoHRa1BiccJzOeikSrj0GmXwPffFDHJi0elrd/Xghl43kwthUV64oH6daBUEOhkqlAttVawtlUU/SlfakDiXYNAOyUhWdFjqlNA/VmhIVqjUlSurwm+06bFlcF7jdGHPbjPevBr4BvOC/9FVjzK0LblBpWzptbNNJutKS1BLO0qwMyEp70kmhU0pzUa0pUaFaU6JkoXoTERf4FPA6rBXxQRG50xjz5IxFtxlj3lBbL5XFQCeNbTpJV1oOEemoK2VK86iH1qq4CyD++zdgIzfeboz5hYisBz4HrAI8bALET9TUGaVl0XFNiQrVmhIlNeptK7DTGLPL39Yd2DK5MyfpitJxY9uinqT3xB3+5KozTnn97+9/gYeftLXQ3/Kq07n6tKA2boy8KfLeOC7EuwAw4nBk8mwATot9H2I9+KUBcaePQdL60J8avoxNS6x/++69Z7HRr517w4WGe1Lx0I9263efZt1K652Myp8+cmKKvoRLztha7btOrGNtr/XXuJLlF4eDevGGbzzdza791qbd1x0v8aLXwlVnr2R1T2bOZdqzxEJfWQ91s+uFC1eV9KFd/OlR9bNWrVV5F+B6YIv/dxnwj/7/OeBP/Al7H/CwiHy/zB2EEpKusHlJF5uXdJW8/s1d1s+2vDvBhiUefXHr813TXfi+eSZOzkuEj/MmRkzs+yl3JPTeJdxxHM/60/NOT1ENYoeUOxz68vImhiP2+F001MtXnrP5PU7rT5XUrm4kfd1xpqzVnP5EwReYzveRcMYZyRZyRE7nrV/60EQu9KfX6kcHeNm6AZZ2HZtzmXYc17pjDhcN9cKMQ/Qf41YzI+kc5/vnsZjjsPa8ZLhM1kuRNfb8l/MSTOdsLfs9I1O85rTx0K+ecCZC7+N4dgUPH14NwNnLcjxz3C6zaWk3q5d0Mehr/ncvWMNP9g/77QpXrO6v966XZe/oNANdVmMbl0zSNWD3/bkTGTb22749cWScrrj9vvz4hQmOD0/R32ePS61+dICumMuyVGLOZdpRawBCzyl1ktN5mxvD9b+vANNeHynX5tmwddG9kjrpweO4MxXm1DDGwXX8PDvTE5iuPoxXGNdWdz92Sn8S7kRJzXKoXDO8XgTeXM84CA5xbxiArDMQ+uw9E8c4hf0rpp79LPb8l32finqbqyJPuZK4l5XZxstF5DFskt8/NcbsqNTvuSinNYDp/CMknYnQc308fSaDiT2A/UyKz4Vrux8h7yX97eVLcryk/LwtHNtDfumZAORNkrQHW/p3ArZ+fdCOI17YH89sw+Baj3cEBHlqsl6KhO/F7848z7i7BYD+hP14Vnc/Dti66TH/u2RwiEntWgt+e1SiXce2hbKoJ+lKeyIC8Q66UqY0jzporZq7ADcBn/NtFttFZEBEVvvJCg8CGGPGROQp7A8WvYOwCNFxTYkK1ZoSJVXoba6KPNWUxP0FcJoxZlxEbgC+jr3orXQYnTa26SRdaUGko66UKc2kotbmugMA1d0FKLfMWvwJOoCIbAQuBn5eddeVNkPHNSUqVGtKlNSkt4olcY0xo0WP7xKRfxCRIWPM3OFLyiKks8a2xT1J907C6P9nHxsPHLu7f3jFr5csdmjKhu6t4n7ITJHvsuOFaybwXL8cQT6F54dN/eDIFbx2zUOQteGgiMOR9PkA/P2dO+jxQ9s2rhnj/OU2BC6TdzlwdCJsM5V0yeXmDiGqN59552V8+Js7uPg6exXq2aMDXLLCJssczqxn/4jdn4mpLIeOT7JhlQ1X3Xd4vG59eOnyXo5Oz13tzGZvbLcv4VjZ0PaZYdvNDn+Piplh9q3ahyq0NtcdANvMqcy8CzDnMiLSC3wF+KPiHyOzYZhkOv8IrmTDkO2sl+LG0y8uWW4k45dziR0Ly5IVlyTKGw/HZMn79peR7FqWxZ6279HD3mkbaveh23/B377bjomjmeV4BlZ2P+/33eOFYbu903qTZLJ2TNs/Nh1ZuPufXbOFXx6f8PcpxmTOlqJLucNkvRQ7h+0Y3BVzOTZZKMc0kbV+pXr086yBFGPZucfJdhzXPDPNWPYpv3yd/WzHsiu45dyNpyy7ZzzN2u7HGM2uAmAiN8SSuC0v5FIIVX752gESzgSeH86bePpu0mdfD8CDh1bxmTseBeD3f/OCsNTYslScTN7j6QPZcDtB2HmUh/Ta05by7ReOA3B6f45M3vZvbV8Xhyds+OfYZIbuAT/MP+9x5rp+ct7MIWHhvHJNPwcnT8y5TDtqzTKOZ7aFzwwuSffUkN+U3B9abjwTxzPx8DkGHMc+NsZBfF9i1qQIKom9kN7KW676Fx742UvDdgKC5YP1i0fvSmHf9SQIfQ5C7fOuX97SUBJyXak8Wj36UPyZlKNGvT0IbBGRTcB+4Gbgt0q3L6uAw8YYIyJbAQc4vtAGLaVaC86DXW5pCPzyrgdCa45n4jwzfAkAZw8+iEMWJxzbUqElI8YEWc+eV2IinMycBtjPbTC5h5gfUm6Mw2zzzWIdNpqCNWJ7qPF8agVxL/itkMSRHOLva7myhrUSlJ0rtpaUox5jWxV5hH4beL//dBz4A2PMqX6YCFjck3SlbemgC2VKk6lRaxXvAsy1jIjEsRP0LxhjvlpTT5SWR8c1JSpUa0qULFRvxpiciLwX+B520vRZY8wOEXm3//6ngd8A/kBEcsAUcLNvH1M6kFrGtirzCL0AXGWMOSki1wOfoXyehIajk3Sl5RBsEiJFaTR10FrFuwDAncB7fb/6ZcCIMeagn/X9n4GnjDF/XUsnlNZHxzUlKlRrSpTUqjdjzF3AXTNe+3TR408Cn1xwA8qioQ5jW8U8QsaY+4uW3469sdIUdJKutBwiENfbAEoE1Kq1Ku8C3IUtv7YTW4Lt9/zVXwH8DvC4iDzqv/Yh/weLssjQcU2JinporYqQ0KuBb2DvOgF81Rhza02NKm2Jjm1KVNRBa9VWEwh4B/CdWhqshcU9SXdi0O2XZslOh570kpJU+QyrYoH3IwHJHty87y1046HfJMlJVqds+YGB1f18bffFXLTSek6mcx6f+pa9CPPYt57lz2+7FoDDJ6Z46pj1soxM5/jojeeF7f7ZNc1JTPnRG88L/WxPvXCQ45s3A3Bospfu5CQAz704zMR0lkeftMfh7377kprb/cGLts1r1j/N8lhlj/tiGe+b5csu9sI3q+xa0O58jkE9+jrfY16r1qq4C2CA95RZ7z7K+9XnRMiTdEf9bfi+Xmf8lP3u88tAiXjh8tO5AXzbOAl3wnri/LKTjuR4ceqVAKxIPc3yrmcB+Mt3vpRjU3ZbXTFhLJPjxPTpAJyYznP1ut6wzVvOXTXf3akLFyyzJTCHM4eZzPp9dR3GsqvxjM21sWdkin1H7NiTyebLluecL4emrO9/ILGXnkU4rjmSpTd+BGOc0LfbnziAYU+4TKDBtd3WFzyYtO+NZtaS8eznknTHwjJrXfkxAPaMbgRg5ea3sfOoPZd2xQzXvtZ+Lqf1p8h5VpsT2TxxR3j31tPCdoPPPGpev2kZAMem93Pv8/bzv+aMoTDHwWBfksmMfbysL0nOM3Up8wewf2KUweQeVqTGKi4bQUgowDZjzBsW3tJMTInvW/DKjufF++ZINvSlA7ikw/JlUPCRx50pXOzvsTP6H+CBn700fE/IF0q1FfnTA69uVGXXyhFzLidv7g+/Z/aYFPYveL24hFXg762FvLk/9EVX48Vvt7FtptYCbczUmytOuJwrac4ceNQuZxwccnj+NMqRbMHPbVLh3GGq/yIGncJ4WbycRzzMKVBcbs2RK+u2l/Mh5lwe+vQ9Eyfm2HxdXj4+q0e+Ht+N4twArlOz1iol+60mj5BdUOQa7CT9lRU71SAW9yRdaUsE0VA9JRJUa0pU1ENrendTqYY6aK2a0pKKAuh5VImOKrRWKdlvNXmEEJELgNuB640xNSYpXDg6SVdaDpF2vCqrtCOqNSUqatVa8+5uKu1GHca1akNCXy4ij2F/5P6pMWZHTa0qbYmeR5WoqIPWqqkmsAH4KvA7xphna2qtRhb9JN3EbFkFgv9nvu8mED+8woiDeIVSMaQnMF02DM84XcQyNmTbdXt49YYRjkzZMM/dI1MsXdoNwOA5Q9z/uC07s2X9AIf8smaZbHTlFCrh+qVKDh8c42cHVgAQc6ZZ2WOP0V9cdzaTf34d/2X1h+rW5mvXPQKAkVjhM5mDmI74HUErlGprZ63NFYZY7r2u2DB5r/D9Kw7tdCUbhrgPZ9ZzaMKWLrv9O09xzhYbrnvlluVM5zx2jNlxbTKb56KhQrh7s3ElzVjGjuEj6V76Enk29dvP95VrlnNfdwKA6Vx9xuOVqfnNSWrUWtPubop4s5Z6CnTmkC3RXF/8IFnPliIT8mGJo5xJMp3rZ1WPPZ9O5payvNvqcP/YNP299jN6+vg4a/usBmOOMBVxydJKxJ0pnt9nQ2RTyRgD3Tbcenl3gleusTa7b+46hiP1G1/W9DxS9bJVaG2usNBqQkJ/AZxmjBkXkRuArwNN8fE5ki2UJZPyd9kcKZSbxNiylUHZtpiTCde3b9vHrVLFTsiHYdWeccJyiIIXhhtPZp+l2527NN98CEvaVUk7n0dh9nPpzNeD42KMY+cM/rjomXh4bg1KowJ0ucPh47BcIPM7ts0gZ5KIsefJwvfEau1EendYXrMezLe0YS1aqzKP0F8Ay4B/sPl9yVW4O98wFv0kXWk/BGr+YaNhoUo11ENrilINVWptromT3t1UqqJKrc0VFloxJNQYM1r0+C4R+QcRGTLGHFtAl5U2Rs+jSlTUQ2tV5BF6J/DOmhqpEzpJV1oOEanpSpmGhSrVUqvWFKVaqtTaXBOntrq7qTSPOoxr1YSErgIOG2OMiGwFHKBp3k2leeh5VImKTtOaTtKVlqTGK2Wa9EapGr0DoERFjVrTu5tK1dSitSpDQn8D+AMRyQFTwM1+JQulA9HzqBIVnaQ1naQXYYxjy7T5pdqKfeyOXMmL2Sn7cj7N7hGhN2F9FEnXIev75Zav6qWny3rT+roTjE3aEgbvvKT4t1VzWZFaCcDt71rJr936fQB+55YLefqw9Zn+01cf51/+3+9y6bbnAbjlf93LxjNs2Zm/uun8BbVpnOqlJtTsb2rrsNBafdrNKrk2G3OVYjPcW/J+SXnECPajDlpreYxxSjxfrpMuPJYrmMoXZD+Ztd5zz8TCE+HmjYM88NA+APp7k5y+rDtc/te3rGho3+dLX/wcLvW79PknDrJxaTeHJ+y84Q//5gd89f9+LQBf23mUv/HHt/M2DHLtaUsb3rc6aK2l726KeNZv6fsXRbyw7JoxDnFnKwDH08fIewl2j1od9cQh4drPaOeR8fD8OdgbZ3jabqs77nLF6v4odqNq+hNn8NEb7eObP34P111rAxbigyluf9ieft55yXr+v2eO8KntuwHrXf/9i9c1vG/1GNeqCAn9JPDJmhqpI6Wl2/xzh9xb4jUPCMbEoGybZ0o9sYFWWwVHrgyTZU3nHyFvbA4HV7JM5mxp4CXxl5DOW6dMLv+IX6ozGhttJ5xHZ1Io3xf8Trk/9KfbkpVBXoNCPo7Aqx48L84p0CoE5d+6XBjLPgVATDLEnDQ5bzsAS5OXk87b6775/ENhbpsu9+KG96/TtKaTdKUlqZCwpR51EDUsVAFaJzmQsvipRWt6d1OZDzquKVGielOiopO0ppN0peUQoeF1EDUsVIGqtKYodaEeWmu3u5tKc9BxTYkS1ZsSFZ2mNZ2kKy2HoElvlGiog9YUpSpUa0pUqNaUKFG9KVHRaVpb3JN0Lw/D9gaq9A1h3MScixtcnNwUBP6kfA6CuundsKHX1nx9flRYljJse97edH3HJbvY/sxq2+SaJfT1WJ/TCwdH+MCrzwTgff/xCL/45tNs++Itdd3FWsmmbR3E79+3m5ecY82cA0M9vPItX+S+L9l57Z8dnSCZcGfdRlXsedT+n8nA0lVzLytQy3dwMYSFzuXjns86reZPL0fQ36bUTK9Ra81BfM+bW1Ut24zXS8IZt2uKV6gnjIsr0Bs7D4Dj6b1hXev948LLVlpHyUO9m1l32iAAJ0en2QW89Xw73r3tk/fxzHd2ArD922+v2x7Wg137RkjGXRIx+wE7jsM7Pv0zAP753S/n1p32mtzuI+OwQE96LqwD7lX+LNpQawaHnJfCM07oL591WeOQzveV1AUOvIo2x4F9bVVqiIOTJwB7ntw9Ms0Nm54A4OfxM/H8YTjhOuwdtnlgbjl3Fd/cdYyjIzZvShS+7vngeYYfb7PVPN90/Vms9fM2fOQ7T/GR68/h7++37yXitZ1HRzNrcSRLwpn7s2hHrQUE41Ol2smzLWf95vaxPadsA2yN6sAnHHOmyOULOYfyvjcdrK828Hl7OOH42CoU5xjxTKFO92Tucbpjl4aPa/38vaJjIuTnXrgt9SbhPlYau8tprfCafe7KFeS5H4CclyjUshcvNFsWciHYdZPuVvLm/nCbrlxR4z7VF9f30GdNihjpcP/T+YfCfAfp/EO4VfwOmYtMvueUNmelLbW2cBb3JF1pSwSDK7XNlzUsVKmGemhNUapBtaZEhWpNiRLVmxIVnaY1naQrLUmlq+iKUi9Ua0pUqNaUqFCtKVGielOiopO0trgn6dlpmBgGwBzei/dLWybbG0njnr8RAFmzhm/mbAj6RStTpNxhhjJ++MmSN5fd7MHxNGctnSwqq7ae7ffdDcCv3ngOh45PApDJFkKEensTnPmqjfXbtzrx7Y9ed8prHzz8BFe99cLw+cffdEHN7Xw9a0Pnf/LIfv76NY/Puay9UlZb+Ey7UU1Y+kJC4FuJcvs4c1+iDs9vR615xmUyv5SYZBAS/mtxMp4NGXMkiys5JnM2hDvhToThio54s5YXOjSxlHW9BwHYuvIM8D+L7Q//nMsvWQvAVDrHA48dCMPdB5b1sOnVmxqzozXyF9edXfL84QtX0ZWMzfr+Qjg0ZUNhjXHoic+dc7IdtTaR7eJnB89k84CD69hyoocmuvjF3mEAXrFpGd1x+4Ppe0+f4KozhljbszNcvzv2EuDUbLwnppOs7rWPt65cRqC1g0ef47IzlwNweCJNIl6aIGh5f1c9d69ufPn915Q8/9wvrc3u4jNtScM/vKI+35H3f+EET93zAm/6Ly+bc7l21BpYe0UYZm0gb2IlIclBCLEjuXBME+ORJxmGCs8soVy6/pVFrz8elsQCSkq1BSHkrZieKhW7sOT5VO4xgJJ9Cb53teCZWNHjua2i7ai3nEkylS+UdQzKj07k+lnW9SIxsaVKPRySvr0kJlOhnsqFpgcaOvU8+0D4yDOxkpDuau0dzWCmjrKe3Y/i/tejzN94biV5z2qs2HpSjnbUWi0s7km60qaY8CSpKI1FtaZEhWpNiQrVmhIlqjclKjpLazpJV1qOTrtSpjQP1ZoSFao1JSpUa0qUqN6UqOg0rekkXWk9pDVDf5RFiGpNiQrVmhIVqjUlSlRvSlR0mNYW9SR978QS/uezrwXgNeev5slzxgD49vee5dBnrX9w+ealTE48DMCH/uByXp68J6iWwGxZ/r+xfQ/Xv2w916wvlI668yPXAvDHX36UC8+ynrqnXjgRrvPRG8/jv37h4XruXsP4y5uO8+dfHeSdn9kOwMrVfaR8L+fJ0WmefNj67b7zV9dXvc0f/mwPAM88cpBb9qyvsLQp8VcpFsO9CFdV9KY3pZRZHZirz43zqref1rJekoMTp+OI0J+wZcTS+T72jNqRqz8ZoyvmcnzKXm3esCSJ59rvb5c7wmyOr89ve4F3XnMGAEsS94bH/DPvvIz3/rstx/Yrr9hILlc4QX7ilov54y8/Wu9dbAj//fVH+dA3lgHw7n95gIvOWwnYsljH/VJfd/7vh+ZVJvPeF0YBcB1h/cCSCku3n9aOj0zz+e88w4YNA2xY1QfAvfc/xyP/8ggA/3bucry03Scn7pD4kyu53vdhp2Inym8Um9clb2wJrHU9Ba392TVb+MbzRwFY29fFzmOFUmM3nj7E3Xtm32Yr8TsXPAfAHU+exeefOMhO38Pf35vguV12H7ZetIa3X7h2XtuNxRxWnruChx7eX2HJ9tNaORzxMIE/vOiHuWdiiO8Yz5Occ19zvs7i4pWU++yOvST0c8ecNPmikTHwfU/nH6nj3jSGrtgwANO5gXB/AvJFP/HnW0ou5yXDyVDFEmxtqLfiffJMPNzXhJPBMzHGc9avHnOmitbxijdw6jYDjZrS0rKBPz1v7kfwSvz+Mefy8L1WJzgWeS9JzrPzg6yXCvc763XRHTs571JySXcU4xRKw85N+2mtFhb1JF1pXyqfFBSlPqjWlKhQrSlRoVpTokT1pkRFJ2lNJ+lKy2E9J51zpUxpHqo1JSpUa0pUqNaUKFG9KVHRaVpb1JP03u44J0ZtGYVPf2MHO75nS8MkBrsQx8aq7PzqU1zxXhuK8rNnj3LFRTGmemxpntQs2/34my7gI995imuKorbfdfvPAVi3rr8QwnbhWm7++D3hMudfuLpOe9ZYhKv4+JvgbZ+8D4CTJybpW29Df154+ij9S+2Ref2Hv1u2hFs5jh0aB+CCKzZw6bkr+dKfz9W+wemgxBBzUS50vfh5cRh4O4a4V9v/INS//u23n9byBiayefaOTvPiEdv3sclDxF0bLnbk5BRXX7QmXD7mdLGyO+E/njp1gz5/ddP53PajZwF4/6sLr9/88Xs4bYsNE7/x9CE4fYir3vYlAPpOG2DdpsH67VwDEa7ir26yj//rFx7myAl7LFYsTXH3N58GID6Y4tJXfYaHfvKuqraZy9swv4efPMppV85dZqsdtbakL8mvXLWJqXSe8Ulbgs2NOZz1mzZ01nGEFx+0odcXXnsGuw+Msn/NOgA29KVn/YXx2g1L+fYL1qrxkmWF1+/ec4JlKavVy1ct4fJVS8LXxzI5Vvcm676PjSAYq245F7701GFOX2vPnyPjaV73io0AJFyHrzx3BIBf37Kiqu329CV5y5s24PlRtZ+ftf3201qACcLY/VJMQYmqnEmG+2Rww7tpnonTFZt9XOtyLwZs6HrSLRyTqdxjYZhu3NkaBrtP5opLxLb+T+RAa6lYoRybiIcxDk5RePZ4bgdQfdh7sA0A15lbS+2oN0e8sLQaQFyshkwsKKPm23gkGx5Hg4Prl2YrRxDmnTPbS173zDbARsg7cmVYktIz28Lw7na4OxxoLeYQhrvHnDQ5z47L3bGTCPmSUP9qcMmRiNnPIudVLvfXblorh4i8whjz00rLtWIZSKXjMYh4s/61GiJSyUSjtCztpTWlnZlba62mNx3X2pn205qIVJ8MQmkx2uc8qlprd9pPayLypyJyvv/aG0TkfuCT1Wyj9S8TKh2JS1uFs/xzszugLJw205rSxrSZ1nRca2PaUGuVMsoqLUwb6U211ua0odYeAP5ORPYALwc+YIz5ejUb0Em60nKImJa7IlaBS5vdAWVhtKHWlDalDbWm41qb0qZauwDaIOZXOYU205tqrY1pR60ZYzwR6QKOAWcYYw5Vu4FFPUkf7IrzVzedD8DvfGIb67dar3gyVdjti1+7mbf5ZYdSMYe9sdUMsrvitj9y/TnAOeHzvF+WaHBJwTP38R8/F7Z18tgk2374PFx7Vk37FCU9fX7pkkSM5561/kHHcUI/PxB67u/4s6vn3NbM939rzqUNbo2eExG5DvgE4AK3G2Num/G++O/fAEwCbzfG/GKBzWWgr2JptIVSja+nHf3o86Van9P8vOvN1VqldcvRHXO4aKiXi4Z6ecfdttTTzp+9iJuyrsrceIZk3OWWKzba5eMuoxn7e2RlamzObX/g1Wf6j84MX5ucyNDTVShP9MFvPIHEbCT02N5Rduz0y2L93tZKXW8ZMpk8E9P2c//yZ59kYtdJALo3DuClc7z2j+4E4Ad/+6tzbqc4/0hl2m9cG0zGQr/013ba0mg3/8qZxPxzgCPC4TfYHC4J12Eynef7jx8E4B1XzFbsz/L6TYEZvfB9jTlCb6IQZf/QEavX3oRr8zAMT9s3VvcvcJeix3GEVf1dAJyxvAfPr/F6cjpLd9zu6388eYhbzl1VcVsf+7WXVNlq+2nNGONdeumlhXJV+UdKSlUBJf7d4lJNYrzZa+b6BN70kn0omqcVyq3F8BaBE9TghPtR7E2fzD1Od6yyjsodr7laq0VvzdaaZ7YRm5HXIO/7rLNeKsyTMJlbSk/Mlm925tBbUFZtNkKPuniENZ/bFEdyJTkhgjwGYMvKVVOOLSh5COBWNFm11diWMcZ4AMaYaRF5dj4TdFBPutKiCN6sfxXXtV7KTwHXA+cCt4jIuTMWux7Y4v+9C/jHGrp7dg3rKk2mWVqrcl1lETGX1irpTcc1ZT60m9ZE5Jc1rK80GdWaEhVtND84W0R+6f89XvT88Wo1uKjvpCvtSR2yN24FdhpjdgGIyB3ATcCTRcvcBHzOGGOA7SIyICKrjTEHF9DeOVBF+IXScjRTa8DGKtZVFgk6rilR0aZaA9VbW1Kj3lRrStW02dh2TuVF5kbvpCstSM3ZG9cCe4ue7/Nfm+8y1fXWmD0LWU9pBZqqtbppUGkHas64reOaUiXtpzXVWztT03lUtabMg/aZHwRaK9LcOPBSYKhaDXbMnfSRk1P0+b4wxxFc31O5cc0SDo3buodLkjEuc7+K9Lx93tv/53e/HID3/vtDfMo3q+zZN8KqddY7l57KMTWa5pp3fQWAvjV9dPke0rHhab7zV9cvfOcaxIoVvQAc2D9KPGmP19DqXmJBHUlHSPXYmobv//rjPPXoQe78yLV1aVu8ObM3DonIQ0XPP2OM+Uzx6mXWmen8qWaZqhCRb11yySULWdXvyPzqfxd73yt50cu934h641EyW534hdJErdWswUza9v3Ca8/giW12zI/1d3HOpqX0xO3mJ7L50PtayStXjjs/ci23/C97zP9+SZLdO4+z+WX2fLXn6aNMPD8JwGXX/jMxf4wF6D19kO997IZ5txcFl16wmi/+7wfD5z2n21rvsb4EfWcvo3vA7set332aVcu6AXjXyzbU3G4FrcHcemvquDYyYeukj01m2egfE0dgebc9BxydzPD8/hHifhHgpcmN827z1esHuWffMADbD40ynrHHK+E6JFyHiWn7/CvPHWHQz5OQcB32j1iv+lvOWTnvNhtNLu8x4Pe12Me6vDvB8Sl7R6gr4fKp7bv5+pdtje7v//WNNbfbbloDPlCsN2McBC/0A9sGrYfclRw54/oNOiDXzLvNVOzCsK54Ov8Qxq/LLkWO9LyJMZ7bUeLpDqjG1x01wSQlOHZuUb+L78gF+w2lfuCa2l74ebT5WsPF8+zn7zqn1kHPeikApvID9CfOmHebjlwJWC963twf7kyxf9vglnrVAc/XZDW+7qgJvpcz68aLeCX7lc7bj30qv5SBxOl1abtd5geB1owxT/jRk78AHgI2i8hnjDF/W2kbHTNJV9oJA2bOK2LHjDFzZR7eR2mJjXXAgQUsUy2bFrie0nSaqrVEFesqi4aKWoO59abjmlIl7ac1Y8wTl16qBQXak5rOo6o1ZR601fxgkzHmCf/x7wHfN8b8roj0AT8F/rbSBjTcXWk9DODlZ/+rzIPAFhHZJCIJ4GbgzhnL3An8rlguB0YW6G8CqC3VpNI8mqu1atZVFguVtFZZbzquKdWhWlOipLbzqGpNqZ72mh8Ua+01wF0AxpgxqCLLHR10J71/MMWq9Tb0/MCeYfIT9tjt2jfCY08cBiCRdLn8bW+vqZ3jRyaY3jAAwPlnLeeee18AbDmz4jJkv/L+u+gftCE0Xl+y6lJmUbLMD109sH+UXNYPo/IM2bT9IjiO0OWXmDu0b4QNm5fyF9+2uRdufX0tSaoN5CuG6s2+tjE5EXkv8D1siYXPGmN2iMi7/fc/jf2y3ADsxJZY+L0aOrwXmHfMWCPDzou3PTPkvdpSZu2A4d4a96N5Wptt3fm0f9Y5tjzWxjVL6Ftiv6+pZIyY6/DsCVsWJZ03ReWuFkZQjtHzDG96wzmM+BahpSt6+HhRmbJXv+frALhJl/SxSV711jsA+Mnnb66p/XoTWHYA8uk8eHZ8y09lyU3m2LB5KQCJhMNyf5y+78AIr1xTS+mv9h7XfnjPLgDWnDbA4eMTAExM5+jpsueAn/10D+s3L+MTt8yndNOpHJ+yYfUre5LEHPs5PbzrOJ5n+JOrCqGmX3nuCGDDxpf12LDQe/YNc/W6gZrarzfpbB7P2EhJzxA+BujxbSiHh6c4cHQC49dn+z//7UH+4W0vq6HV9tOaiPxhaQiygyO5kiDToOxaEOoO9Qs7D5JRGdwwXLcvbvM+TeasDaE4/L7aUmZREvTbzHH/bWYG7On8I/Mst1a25QXrrRW0NpkbxBXbf9fESsr7TeX7Sbh2vFuVGKqh2YJ+gzD2fFGJwaRbuPnrmW2IeEWarPV3Tv3J+/sQY+qU98JwfS8e7mvOSzKS2QmwIMtAgbYa2/aKyB9i78y/FPgugIikgLlrlPp0zCRdaSNMVaF6FTZh7sK/alX02qeLHhvgPTU1UuAdwOE6bUuJkiZrrdy6yiJFxzUlKtpTa7fWaVtK1NSoN9WaUjXtNbYFWnst8BZjzLD/+uXAv1SzAQ13V1qTfG72v9ajq/IiSsvSXlpT2pm5tNZ6etNxrZ1pM60ZY97d7E4oNaBaU6KizbRmjLnJGHN38KIx5sfGmP9ZzQZ0kq60IMa/WjbLX+vx9WZ3QFkobac1pW2poLXW09vXm90BZaGo1pQoUa0pUdGeWhORryxkAx0T7v6593lc+RabZM9k89aHCJw8fwXnXrIGsB7rWvmPPyn4Rt7/9cdJ+p7t6anSXBXf+9gNXP/B7wCQz+URp/Wul9x0wSoAdh8YZfjYZNllkn4ZuamJLJs3DjKVripxw9wYoHL5mFaiduEsqNHZfeczl6tUqq1jaT+tlfDhaw8B8J/PDNLjfxfjrpDLe0zlgjIutZ+4bn9XoXTbbT96lu332XJvL926vmS5H33q1wB40//4AcOTWYzn0oq8/iyHHddaX9wD33gK1z92bnccN5Vl6VJbYmzNUC/9STuGj2Vq1En7aa1kXPvc+6ye3vo3JxnxS9SNnCiUNr3o0nXc98OdUKMn/de3rCi0+UubULevO8Fze4fLLvf3978QnrvXDPXU1HYjuGhtP+OZwnkxk7fHMZ33wseHjk9yaP8ol71ms10mW+N5tM21BpCKnSCT75nVX11c5mmhFJcfC8qS5YnhUnrsAu/5eK6QMqRcWbZmE3esPzhnknim/M97g3OKL71m2ktvp2itN36EqZzNQ1Lwjdvj1+WOMZUfsMvVOGMKSqllzQMAOOKR85KnLOfIlWS9B8LPyZEs0pRfmbMTlEM0ximpT178vcx6KbLG5nRJuqP1abh9tbag+nMdM0lX2gmDqdFzEjEtd/lOqZa205rStrSd1nRca1tUa0qUtJXeVGttTdtqbUG600m60nqY2rI3NoF5Z3ZXWoT205rSrrSf1nRca1faUGsiMlqccVtpI9pLb6q1dqYNtYa9o57yH+M/N8aYJZU20DGTdBk/ztmvsdEGe58/wfGfvghAdjxDv19eKO2HpNWrHNrHfq20PMeHv7mDl569HIDn9g4ztKoXsGWNvvDHr6qprUawvteG5Lzxiov4yn22lNzURCYswdY30BWWZtt8hi3x9KHXnlmfxlvPWzIrxhj30ksvXXCH61FeY+b6lcLfFwt12Zc20tpM0nk7xnfFHeKujaxyHMERYVkqKH1S2L+/2fY8f3zl5pra/MCrz4RXF77n337hePh40h9Dr7r6dE6OpfnI9efU1FajGOp6lrdfbUve9HUneH7nMQBiMZctZy5j02pbaq076XJgZBqAt56/uvaG20hrM8e1iZwtP5TqGWOZH1Y+MZrmyAH7u2P5yt4S29at332av7ju7Jr68LsXrCk8uWQ9H/6mDTf2PBPaO44cHaen157D33P5xpraawQXDj3Mtv32esd0zmNkuvAD8/n9wwCMjKcRR1jhl/t73ysXFBlZSptpDaBYb54plG+aiZAvCSStRxmx4tD3gKncY+SJFYW2F/TdauXXAFzHlsY0nl+KrYwlQMQreb328ms+baK32bSWM3YMifufdVAebebxms4/AtR23OLO1qLH9v+x7FOh3m3ptb6wLFwrai0oS5fJ9xBzbNnMIPQ969lxLE8stA0knamy37EF0WZaq4WOmaQr7YRpJ8+J0tao1pSoUK0pUaFaU6JE9aZERWdpTSfpSuthAK9tPCdKO6NaU6JCtaZEhWpNiRLVmxIVHaY1naQrLUhnXSlTmolqTYkK1ZoSFao1JUpUb0pUdJbWOmeS7jj88W9YX8fukWkevsZ6vt582QY+/d1nAPjELRfzrtt/zsBQd92bP5Hezf9zQ4aJnPUMbR5cw9tfbks+7DwZ522fvA+Af3vvK+ve9kIJ/L6vXPVDLnqTLcf2p/+eYd8LJwHYcv4KbrnG+lv3jkwzNpmpT8PGQL4OpdxamEaWRau03eD9VvOmN6VUXJtrzRVb2nH9ki5Sm21eCEeEJckYB8ftWHPj6UP8aK/9zibi9S2J9ouj46xf0uX3xbYNsGVZNw/tOcmntu8GWs8rLFzFWQPbAfij1yzlf6fs+Hbk5BSbVvdz1nLrud4zMkV/d3lf7Lxpc60FvtzLL1nLA4/Y0mjp6Rwr1ti8CLt3Hud7H7uBd3z6ZwBccP7KurZ/954TXHWBzQuQcB1G0lb7x5f38OKhMQD+7Ku/5ONvuqCu7daKcBWXrnwcgNHsar77rO13JpMn6X8fN6zqo687QV9Poj6NtrnWiglKsAle6G8VnNDfGniE68lk7nH/kYNLrlBiysRC7/Jk7vGW8woH53RXtuFIjky+UJIw2AchXzimUqc7km2uN2Mc3wduc2+IeOQ9+11MumMMda0FYCSzky63vvsZ6DcmDo5jfd6eiZM1KbKePfeM53bQGzuvru3WSqC1mHN/6NkvV97PFfs7RLW2MDpnkq60F+1TYkFpd1RrSlSo1pSoUK0pUaJ6U6Kig7Smk3Sl9WivEgtKO6NaU6JCtaZEhWpNiRLVmxIVHaY1naQrrUmDEkOIyFLgS8BGYDfwm8aYk2WW2w2MAXkgZ4y5tCEdUppPByUhUZqMak2JCtWaEiWqNyUqOkhrHTNJN92DbErsAuDcPV/h+l7r/fjsrv/KxFg6XO6Kl63jsWeO1q3dF8Zsjd1N7qOYsVG6umxt9GXdDog9/Kmhs0NfX0vivIZe+TEAsVgf/UttDcTNGwcZz9grWgeOjuM4Musm5oUxkGuY5+QDwA+NMbeJyAf85++fZdlrjDHHGtWRehO5n7sBBD6nyPalsVprODFnCoA1PRNk8t3+a0ImX3oSC2qlZ7L12df9E7Y29qoeD8ev5eqZGHm/zuuQO0Zq8xCPHhytS3uNIOZcDkA32zljnc2tMTGVY3lvgqRrPXYJ18GVthjXGk4qdgKAKzefEb6278h4+PjYMXtOTabseW1iun53Ow5MDnPeUIyka73nWS9Fzli9eyuX8KRfX3zngdbUW8G7/Dh93darfzLn0dNlvy8rl6bo703W7fvZ7loDWyvakSxpz/42MsYJP/9iPBM7xQdbC1nvARwpzUMReG5dSde1rUbhyJV4ZlvoA/ZMDIes/54H/uO60eZ6c500XcHjWI6TmdPojR8BCL3qYD3XhvrldfHMNuJOue1liJk0Oc/mP6ibn7sBuHIFee4HbN6I4pryMckgYnVRt+PW5lqbLx0zSVfajMZdKbsJuNp//G/APcw+SVc6gQ66Kqs0GdWaEhWqNSVKVG9KVHSQ1nSSrrQexkCuYZ6TlcaYg7YZc1BEVszWC+BuETHAPxljPtOoDilNpLFaU5QCDdaaWnmUEB3XlChRvSlR0WFa65hJunAV3a4N2Tar1uCttGVaXvzOGK+6fEO43MnRaf76N0fq1u4m97sATCdPIxPvCUNnevbejSxdA8CIu5Z1Kw7Wrc1GkDM2nPDZXx5iuR+aP5XO8+PHbL+ff/ood/zZ1fVrcO4rZUMi8lDR888UT6JF5AfAqjLrfXgePXiFMeaAP4n/vog8bYz5STUrRh6y3YHUtXxcG1+VDY5Dd3wHG5cMATCW7SeT90IrCtiwbYA/unIfsLnmdoMQd1eyYSieQ564H36fcCaIOYP1s8A0EBGPvoQ9FS4b6OLoeIbtvuXp+19+nB9/5tfr11hjtdZQK0+gtZXdu7j+bKu1n6TivOCHmA8N2XJPff02cPSDrz0InDnffShLTNLE3Ck/VNd+ZikZBiBv4pwxaPtzfLxOZUAbyNhk1v8/QyppdecZGOxJ8PpNy+rXUBuPa2D15sp2EmFZqlhYcjIIAwY7FiXd+tkc8iYetiN4GDuy+W0VQsU9U6fSjA0k5pe/yhaFIOdNPCxlV9cScm2sN+EqRGzIdtyZYkliPy72HJczhbKI9daawUU4NXTb4OJIjoTr98GrU2nGBlG8DzmTCJ+7kgvnPI5cWb8G21hr86VjJulKG1HZc3Jsrrs/xpjXzvaeiBwWkdX+XfTVwJFZtnHA//+IiHwN2ApUNUlX2ogO8zcpTaTxWlMrj2JpsNY0akMpQc+jSlR0mNacyosoSsQE4Syz/dXGncDb/MdvA74xcwER6RGRvuAxcC3wRK0NKy1IY7WmKAUqaa12vZVYeYBKVp6HReRdtTaqtCCN11oQtbEF+KH/fDauMcZcpBP0RYyeR5Wo6DCt6Z10pSUxpmHhLLcBXxaRdwAvAm8GEJE1wO3GmBuAlcDXxGZ1jgFfNMZ8t1EdUppLA7WmKCVUobWWtvIo7UODxzWN2lBK0POoEhWdpLXOmqSP2xIyY0NXc3zC+tCXDx7kXz75MwB+9zO/zh9fuZl6eDYDjruXAHBifIiB5DBLky8AIKu3YE4eAGBDz7dYt7KOHtsGMJxZD8DKdVle8XJ77I4NTxOP2WCMuvrRG5gYwhhzHHhNmdcPADf4j3cBFzakA0XU1VfdQdT1uC2SJCR5L4nrWD9uws3jiMvuo9bLyYalXL1uwF+yPscu8OVN5wfsfVmsXy8utg8Gh5gjdCfqV66mUYxnV7C2z/qol5weYzSdI7uqD6C+fvTqtNbyVh7POHTFbN6WzcsG2HfYlsWKu/bnxMd+rY4+V5+RzBJ643FijvXYBjkRwOZF6IrZH23JeGvrLWeSYR8dEU6M2v3pSsZ4+4Vr69dQ48e1SBKwGpzQH+5KNix/VlwWq8u9eP69n4PAxx2075lCHzzjhF70Vi6LBeCQw4jVWsxJ4/m+dCFPd6y+x2yxnEfBaivpTIR5D4KcCABL4mdSrzwbYL3mQR6XYoR8XUu9NRon9O+nSnI1OOLV14sODdVaNTYeEVkPfA57sdzDXkj/REM6hIa7K62KZ2b/U5R6olpTomIurdWuN7XyKAUqa21IRB4q+iuxPojID0TkiTJ/N82jF68wxrwUuB54j4i8qo57qLQSeh5VoqJxWqvGxpMD/sQYcw5wOXZcO7fWhmejs+6kK+3BIroqq7Q4qjUlKhqvNbXyKJZFErWhtAl6HlWiorFaq2jj8SOIgiiiMRF5ClgLPNmIDnXWJL3Phi7eu+sYLx45BMDJ0XR9Qxpn8OEv2hJl73z9AJ+4cz8rli8F4LqLX8K5y1+0fUhv5OToiYb1oR68ONYPwH/5jZcwkbWZFdcO9XDj6UP1b8ywKEosCFedUoZNQ9wXTkOO3SLRWn/iDPZP2BD0k9Mwmk7zzkvWN6y97z1vw8NfsSHJoQl7whzsStIVs6Uak844KXeY8emGdaFuTOSG6I5bDSTcODnP8NbzV9e/oQZrLSorz9LkRp4ftR+sI1kSfvj2+155ei2bnZMnjo6zujdJf9LqLuE6HBy3YcnLuxOMpK0GY25rl/ybzvXTnbQBjMsGUjj+caxrqDtEMa4FURu3MUfUBuD4P2SDqI1b59NI3NlK3tjSWMY4GD/4M+k2LgedwQnD6gWPmJPD+KHijoArNjw5Z5KzbqNVMGGIuweNPHaL4DzqyhUA5M39OJJDxIZtN1JrruTIevacWRz2HrwW0Oqh72bXLwDIbXw1Il6ou7iztQGNUVOJ5gpUa+MBQEQ2AhcDP69y+/OmsybpSpugV2WVqGiuv8lf7jrgE4CLveN5m//6x4EbgQzwPPB7xpjhhnRWiQAd15So0KgNJUp0bFOioqLW5owQqlPyVUSkF/gK8EfGmNH5rDsfdJKutB7GtP1VWaVNaKzWAn/TbSLyAf95SeiUiLjAp4DXAfuAB0XkTmPMk8D3gQ8aY3Ii8jHggzPXV9oIHdeUqGiw1lopAavSAujYpkRFjVqrh41HbJjFV4AvGGO+uuDOVIFO0pXWwwC5fLN7oXQCjdVaNWWKtgI7/R+0iMgd/npPGmPuLlpuO/AbjeqoEgE6rilRoVpToqSBeptHRNpuYAzIA7m57qYqbUxjx7ZqbDwC/DPwlDHmrxvVkYCOnKTfePoQNMJLXYZP/17Bk3Hp75SOGd/ZbSMupnOTfOU/bYLdcj7Sj3znKfv/9ec0qptz8q7bf87bX382ADnPsLrXerEe3T/SoBYXz1XZKD3oc7U10xtfablmeeer7Wc9W2yg1qrxN60F9hY93wdcVma538f+UJmVtT1L/P8X1Nd5ccu5hWixDb2nvr9nPMaekSm+v+1pAN5yzsqy2/nwN3fw0RvPa0gfK/Huf3kAgD9+40tI+WfCpDtNV6xRp8XFM65tXmK94Szp4tIVfQ1v741nLJ+1D994/mj4mmdmz+77jeePctPmU7cTBf/xpM2Bc8GqPs5fbv2lLwxPkss3Sg+LR2uBV5iI0g2U9dH6bee87aEvfi6m84/UvTTcfJjKPUbM6Qm99WDLYTWO5kakFXGNMeZYLY0FenMjsIHHnMvLTsKSrtWQYCej5cq0BeS87eG2mkHe3I/Z9AoA4jJFzks0+LvaUK1VY+N5BfA7wOMi8qi/3oeMMXc1okMdOUlXWhwDJqt3AZQIqKy1OZOQ1MHfVO50VjLTEJEPY8t+fKHKbSqtiI5rSlSo1pQoaazeqolIUzqFBmqtShvPfUR2yVAn6UorYgxkF8ddAKXFqay1Rpcp2gcUh8+sAw4UbeNtwBuA1xgzx21CpfXRcU2JCtWaEiWN1Vu1GbcNcLeIGOCf5pHRW2knOmxs00m60nIYwHg6H1EaT4O1VtHfBDwIbBGRTcB+4GbgtyDM+v5+4CpjzGSjOqlEg45rSlSo1pQoqUJvjY5IA3iFMeaAP4n/vog8bYz5yTzWV9qAThvbdJLeRK7fuAyA3/jLH826zIe/uYPpdHNLWwwOdTOeseElL1kOq7utCfWioTJm1HrgARkN1asngcd8Ls939H7wyjTcG99YrVX0N/mZ298LfA9bgu2zxpgd/vqfBJLYHxwA240x725UZ+vJab1J/vqbT9LdEy/7/mcf2QfAmuURGOhnYcUKO371JdJ0ucOArQG+prtBDeq41hBu2ryce/YNAzCSzp7yfvDe2FTzzqPrB2zd476Ew5KEDZTZvOF02NCgBlVrDSHmXM50/pFZ3896Ns+FVOFbbySOZBE8xPehh77+RlFZb42OSAtCkjHGHBGRr2GTsrbtJL3LvRjPbANmr5OeN/dDC2gtyNMg4pF0m661RYVO0pUWxHTUlTKlmTROa9X4m/zndwGnJB0xxpzRkI4pTULHNSUqVGtKlDRUb9Vk3O4BHGPMmP/4WuDWRnVIaSadNbY19xKMopTDYD0ns/3VgIi8WUR2iIgnIrNe2RWR60TkGRHZ6WcUVRYjDdSaopRQSWuqN6VeqNaUKGnsefQ24HUi8hzwOv85IrJGRIKL2yuB+0TkMeAB4NvGmO/W2rDSgnTYbza9k94C/OeHXn3Ka+//+uMAbFk/wDsu2RV1l0rwPMPmQRsD+syJaVY3Khw0wIDJN+xK2RPAm4B/mm0BEXGBT2FPCPuAB0XkTmPMk43qVFTMFj7eiqHukdBYrXU0n7ilfAmiT9y3i4s3LQXgyrWPYcvfRs9l59qycN2xEyWlihqGaq1hXL1uoOzrjx4bJ+OXOfvt858FVkfXqSKC0nB5Izx70paB21q+KmF9UK01jNlKq9lSWPa+V8KdiLBHp+JKDhEvLOHVcBqotyozbu8CLmxIB5qII1eWfT34veaZFLE5yrNFRRCOb4yL2+i85x02tukkXWk9jIHGlVh4CsD3+M7GVmCnP/AjIndgy4C0/SRdmUEDtaYoJajWlKhQrSlRonpToqLDtKaTdKUlabLnZC2wt+j5PuCyJvVFaTCd5G9SmotqTYkK1ZoSJao3JSo6SWs6SVdaD2MgM2f46YLLeRhjypXBmkm52+ydMyp0EpW1pij1QbWmRIVqTYkS1ZsSFR2mNZ2ktygf+7WXFD1b37R+AFx98Vpy/pWr7nj5UhB1xVS8Urbgch5Vso/Sg74OOFDjNluahpc6a1Uqa02pM+975elFz5qnu8tWTwPgShpXIijPpVqLnIuGemEoeNY8rZ3Wb0uwZfIek1GEaqrWIifmXN7sLoTYslgR/FYLUL1FSvB7Ld4Cqb+NcTCmqCNReNI7SGs6SVdaDmPANNdz8iCwRUQ2AfuBm4HfamaHlMbQAlpTOoRGa01E3gx8BDgH2GqMeWiW5a4DPgG4wO3GmNsa1imlKei4pkSJ6k2Jik7Tmk7SldbDmIaVUhCRNwJ/DywHvi0ijxpjfkVE1mB/sN5gjMmJyHuB72F/yH7WGLOjIR1SmksDtaYoJTReax1duUIpQsc1JUpUb0pUdJjWdJKuVMQzhp++cByAp144wdY3XdDwNhtYzuNrwNfKvB6W8/Cf3wXcNXM5ZfHRSeU8lAKTOVsGLmeS7BqOA3BFgyt0NVJrWrmidZnO2R+VU7k8O/YNA7OXjasXOq51uSTAmAAAC1hJREFULkGou2fsuOY0OgQZ1VsnI2LHt6hK/nWS1nSSrrQeHVZiQWkiqjUlKlpDa1q5ohNoDa0pnYLqTYmKDtNaC6QdUJQZ+IkhZvtTlLqhWlOiooLWfL0NichDRX/vKt6EiPxARJ4o83dTlb3QyhWdQHVaWzAi8mYR2SEinojMmsRVRK4TkWdEZKeIfKCmRpXWRc+jSlR0mNb0TrrSehgwHeQ5UZqIak2Jiuq0ppUrlNpp/Lim+Q+UAnoeVaKiw7Smk3SlIjeePlR4cvG6SNrsJM+JUqAZpeBUa53Jht6U/yjFqtSci9aNFtCaVq5oAmcNFAR20VBvJG1q/oPOxZUr7IMIvOgBLTC2KU3AkSsjb7OTtKaTdKXlMMaQ76ArZUrzUK0pUdForWnlCiWgRcY1zX/QIbSI3pQOoNO0ppN0pfXwPSeK0nBUa0pUNFhrWrlCCalOa0Mi8lDR888YYz4TPBGRHwCryqz3YWPMN6roheY/6BT0PKpERYdpTSfpSsthjMHroOyNSvNQrSlRoVpToqJKrWn+A6Uu6NimREUjtSYiS4EvARuB3cBvGmNOzrKsCzwE7DfGvKEhHUIn6coC8Mw2ABxyINc0pI1OulKmzI7h3vBxo/zqqjUlxPzY/q/jmtJgPLPNnkOhIXprAa1p/oNWwfshiF/MScc2pYFM5R4j5Z6wT9pPax8AfmiMuc2vRvEB4P2zLPs+4ClgSaM6A1qCTWlFDHhZb9Y/RakbqjUlKipoTfWm1I0Ga01E3igi+4CXY/MffM9/fY2I3AVgjMkBQf6Dp4Ava/6DRYqeR5WoaKzWbgL+zX/8b8CvlVtIRNYBrwdur7XBSuiddKXl6LTEEErzUK0pUaFaU6Ki0VrT/AdKMTq2KVHRYK2tNMYc9Ns5KCIrZlnub4E/B/oa1ZEAnaSXoTjENqBcqG255RZKM0pPLQTDvYRVV6bGoBGlizosMcRMHc2mhXrprZ20FkEjqrUqllsIYryGhbvVnSDMHTDiNKZykWqtquVqoR3GtmB/HTw8/ydY3UMaVWtVLVcL7aQ1EQfjh7vr2FYbqrXZMdxLyvWarbUFJ8SspnkReQNwxBjzsIhcXc06taCTdKXlMH44i6I0GtWaEhWqNSUqVGtKlKjelKioQmsLTogpIodFZLV/F301cKTMYq8AflVEbgC6gCUi8nljzFur3IV5oZ50pQUxGM+b9a8WROTNIrJDRDwRmfWLLCK7ReRxEXl0xlU5ZVHROK0pSilza031ptQP1ZoSJXoeVaKioVq7E3ib//htwCmlJo0xHzTGrDPGbMQmw/xRoybooHfSlVaksVdlnwDeBPxTFcteY4w51qiOKC2A3gFQokK1pkSFak2JEtWbEhWN1dptwJdF5B3Ai8CbwSbEBG43xtww18qNYJFP0sfq5gtptD92ru23gh+lbP9Sv1qf7cxcxoDXIH+TMeYpAJF6u2VUa/WkWt/XfLZRdpkGaq1xtIfWrC9t7u23gt4M9xbKE6FaK6U9tFZNGy2jteCxODhcWdM2Zl2mLbUG9dKbau1UrTVqXIN21ZtqrV4sFq0ZY44DrynzeklCzKLX7wHuaUhnfDTcXWk9jGmFch4GuFtEHhaRd0XVqBIxDdSaiCwVke+LyHP+/4OzLHediDwjIjv92pwz3/9TETEiMlRTh5TmUkFreidKqRuqNSVKWuM3m9IJdJjWFvmddKVdMfnGZG80xpziMZmFVxhjDvglGL4vIk8bY35S5bpKG1FBa7XwAeCHxpjb/Mn3B4D3Fy8gIi7wKeB1wD7gQRG50xjzpP/+ev+9FxvVSSU6Gqg1RSlBtaZEiepNiYpO0ppO0hchkZSuamAfjAEv15jsjdX3wRzw/z8iIl8DtgI6SZ9BB2itFm4CrvYf/xs2LOr9M5bZCuw0xuwCEJE7/PWe9N//G2w9zmovLi1e/DJpRpoXANbCWlPqiI5rykIQ4x/zebjpwjJpxmva2Far3lVv7YOObe2FTtKV1sMY8k0MWxGRHsAxxoz5j68Fbm1ah5TG0VitrTTGHLTNmIN+VMZM1gJ7i57vAy4DEJFfBfYbYx6rfw4FJXKaPK4pHYRqTYkS1ZsSFR2mNZ2kKy2HARpVtUNE3gj8PbAc+LaIPGqM+ZUZ2RtXAl/zJ0Yx4IvGmO82pkdKM6lCawu2VlTZhXKzbyMi3f42rq1yO0qL08hxTVGKUa0pUaJ6U6Ki07Smk3Sl9TCQyzVo08Z8DfhamdfD7I1+6PGFjemB0lJU1tqCrRUiclhEVvt30VcDR8ostg9YX/R8HXAA2AxsAoK76OuAX4jI1ksuOXPODistSgPHNUUpQbWmREkD9SYibwY+ApwDbDXGPDTLctcBnwBc7A2X2xrTI6WpdNjYppP0NqAVPCTlaFS/DNB21TwWCaq1unIn8DZs7c23Ud5X/iCwRUQ2AfuBm4HfMsbsAMLweBHZDVxqjDl26aVnNazDUTOvzzUiv2abam0+P2Z3A2NAHsjNdRFqMdGKY1u7ak0pT8FTPv/PtdF+9IaW26ShensCeBPwT7MtUCkB62Kmk8Y1u+3OGtt0kq60HKbDrpQpzaPBWrsN+LKIvAObnf3NAMXWCmNMTkTeC3wPewfgs/4EXVlkRDCuVfwxW8Q1xphjDe2N0jT0HKpESSP1Zox5CqBCXpZKCViVRUKnjW06SVdaD9NZnhOliTRQa8aY48BryrweWiv853cBd1XY1sZ690+JmAaPa1X+mFU6AT2HKlFSWW9z5napA7MmYFUWGR02tukkXWk5DJ11pUxpHqo1JSpaSGsGuFtEDPBPdf6xrLQALaQ1pQOoQm9z5naZKwGrMaaa8qNlE7BWsZ7SZnTa2KaTdKX16LArZUoTUa0pUVGd1hZcTaDKH7MArzDGHPBLAn5fRJ42xvykynWVdkDHNSVKatTbXAlYq2S2BKzKYqPDxjadpCstR6d5TpTmoVpToqJKrS24mkD1/TAH/P+PiMjXsH5OnaQvInRcU6KkBfRWNgFrU3ukNIQW0FqkRJMuV1HmiTFm1j9FqSeqNSUq5tJaFHoTkR4R6QseA9diE84pi4xGak1E3iwiO0TEE5G5wph3i8jjIvLojAgRZZHRQK29UUT2AS8Hvi0i3/NfXyMid/lt54AgAetTwJc1AevipZN+s+mddKXl6LQrZUrzUK0pUdForYnIG4G/B5Zjf8w+aoz5leJqAsBK4Gt+crkY8EVjzHcb1yulGWglASVKGpzd/WvA18q8Pu8ErEr702m/2XSSrrQcnZYYQmkeqjUlKhqttWp+zPolii5sXC+UViACrWklASVEz6NKVHSa1nSSrrQeHZYYQmkiqjUlKlRrSlS0jta0kkAn0Dp6UxY7HaY1naQrLUenhbMozUO1pkSFak2Jiiq1ppUElLqgY5sSFZ2mNZ2kKy2Jt/jyPygtimpNiQrVmhIVVWhNKwkodUPHNiUqOklrOklXWo5Ou1KmNA/VmhIVqjUlKlpBa371AMcYM1ZUSeDW5vZKaQStoDelM+g0rekkXWk5DJ3lOVGah2pNiQrVmhIVjdaaVhJQitGxTYmKTtOaLMa6cgEichTY0+x+KGU5zRizvNwbIvJdYGiOdY8ZY65rTLcWhmqt5SmrN9Wa0gAWqjVoMb2p1lqeRaM1UL21OPqbTYmKRaW1WljUk3RFURRFURRFURRFaSecZndAURRFURRFURRFURSLTtIVRVEURVEURVEUpUXQSbqiKIqiKIqiKIqitAg6SVcURVEURVEURVGUFkEn6YqiKIqiKIqiKIrSIugkXVEURVEURVEURVFaBJ2kK4qiKIqiKIqiKEqLoJN0RVEURVEURVEURWkRdJKuKIqiKIqiKIqiKC3C/w8coJnJXi/1IwAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 1368x504 with 24 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import time\n",
     "rel=0\n",

--- a/jupyter_ppe_scripts/generic_ensemble_script.ipynb
+++ b/jupyter_ppe_scripts/generic_ensemble_script.ipynb
@@ -6,10 +6,10 @@
    "source": [
     "<h1> Ensemble generation submission and analysis notebook </h1>\n",
     "\n",
-    "This script will:\n",
+    "This script uses a combination of bash and python cells to form a workflow for creating and analysing FATES (or any CLM) ensembles. It will:\n",
     "\n",
     "<ol>\n",
-    "<li>Clone github repo \n",
+    "<li>Clone the github repo \n",
     "<li>Make and build a default 4x5 CLM-FATES case\n",
     "<li>Make an ensemble of CLM-FATES cases \n",
     "<li>Generate an ensemble of parameter files with one at a time or latin hypercube  modification\n",
@@ -18,7 +18,8 @@
     "<li>Analyse output\n",
     "</ol>\n",
     "\n",
-    "<h4>n.b. This notebook is also set up to work with Cheyenne specific paths, but can be modified. "
+    "<h4>n.b. This notebook is also set up to work with Cheyenne specific paths, but can be modified. \n",
+    "<h4>n.b. The version here is relatively simple in that it just submits a one at a time sensemble and plots maps of the output. Obviously much more can be made of the ensemble design and analysis but this is here as a generic tool... "
    ]
   },
   {
@@ -30,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [
     {
@@ -57,20 +58,36 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "#import things. Not sure if all of these are still strictly necessary. \n",
-    "from multiprocessing.pool import ThreadPool\n",
-    "import dask\n",
-    "dask.config.set(scheduler='single-threaded')\n",
-    "import os\n",
-    "import netCDF4 as nc4\n",
-    "import sys\n",
-    "import shutil\n",
-    "import numpy as np"
+    "#### Define parameter space for senstivity analysis. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['fates_rad_leaf_clumping_index', 'fates_rad_leaf_xl', 'fates_rad_leaf_rhovis', 'fates_rad_stem_rhovis', 'fates_rad_leaf_tauvis', 'fates_rad_stem_tauvis']\n"
+     ]
+    }
+   ],
+   "source": [
+    "#aspiration to make this into a dictionary...\n",
+    "parameter_list=['fates_rad_leaf_clumping_index','fates_rad_leaf_xl',\n",
+    "                'fates_rad_leaf_rhovis','fates_rad_stem_rhovis',\n",
+    "                'fates_rad_leaf_tauvis','fates_rad_stem_tauvis' ]\n",
+    "\n",
+    "min_delta=[0.5,   0.01,0.75, 0.75, 0.75,0.75]\n",
+    "max_delta=[1/0.85,1.4 ,1.25, 1.25, 1.25,1.25]\n",
+    "print(parameter_list)  "
    ]
   },
   {
@@ -102,8 +119,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Import libraries"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import netCDF4 as nc4\n",
+    "import sys\n",
+    "import shutil\n",
+    "import numpy as np\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "import xarray as xr\n",
+    "from matplotlib import pyplot as plt\n",
+    "#import datetime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,16 +158,20 @@
     "#what do you want the case names to begin with?\n",
     "caseroot=ens_directory+'_case_'\n",
     "\n",
+    "USER='rfisher'\n",
+    "\n",
     "#path to scratch (or where the model is built.)\n",
     "defbuildroot='/glade/scratch/'\n",
+    "\n",
+    "#path to scratch (or where the model is built.)\n",
+    "output_dir='/glade/scratch/'+USER+'/'\n",
     "\n",
     "#how many members are in the ensemble?\n",
     "ncases=12 \n",
     "\n",
     "#where are we now?\n",
     "notebookdr=os.getcwd()  \n",
-    "\n",
-    "USER='rfisher'"
+    "\n"
    ]
   },
   {
@@ -137,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -187,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -242,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "tags": []
    },
@@ -294,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -337,14 +383,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Currently in /glade/work/rfisher/git/ctsmsep22/cime/scripts/fates_crops_smo_minlai_opt_vcmax50\n"
+      "Currently in /glade/work/rfisher/git/ctsmsep22/cime/scripts/fates_crops_smo_minlai_opt_vcmax50\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = nullparameterfile\n"
      ]
     }
    ],
@@ -377,11 +445,13 @@
     "then\n",
     "echo use_fates_sp=.true. >> user_nl_clm_default\n",
     "fi\n",
+    "echo fates_paramfile = \"nullparameterfile\" >> user_nl_clm_default\n",
     " \n",
     "echo \"Currently in\" $(pwd)\n",
     "cp user_nl_clm_default ../$ens_directory/user_nl_clm_default\n",
     "fi\n",
     "\n",
+    "cat user_nl_clm_default\n",
     "#n.b. i overwrote this with a file in the ensemble directory last time i did it."
    ]
   },
@@ -394,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,14 +561,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_default.nc\n"
+      "file does not yet exist: /glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_default.nc\n",
+      "default parameters in/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_default.nc\n"
      ]
     }
    ],
@@ -506,51 +577,13 @@
     "if(dosetup == 1): \n",
     "    paramsdir='/glade/work/'+USER+'/git/'+ctsmrepo+'/cime/scripts/'+ens_directory+'/parameter_files'\n",
     "    defparamfile='/glade/work/'+USER+'/git/'+ctsmrepo+'/src/fates/parameter_files/'+paramfiledefault\n",
-    "    !cp $defparamfile $paramsdir\n",
     "    filename_template = paramsdir+'/'+paramfiledefault\n",
-    "    print(filename_template)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Make function for copying fates parameter files. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def copy_clobber(filename1, filename2):\n",
     "    try:\n",
-    "        os.remove(filename2) #replacing file\n",
-    "    except: #'file does not yet exist\n",
-    "        shutil.copyfile(filename1, filename2)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Make function to modify FATES parameter files. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def def_pftfile( fileroot,i,variable,delta):   \n",
-    "    pfilename = fileroot+str(i)+'.nc' \n",
-    "    print('modifying parameter file',i,variable,'x',delta);\n",
-    "    fin = nc4.Dataset(pfilename, 'r+')\n",
-    "    var = fin.variables[variable]\n",
-    "    var[:] = var[:]*delta\n",
-    "    fin.close()"
+    "        os.remove(filename_template)\n",
+    "    except:\n",
+    "        print('file does not yet exist: '+filename_template)\n",
+    "    shutil.copy(defparamfile,filename_template)\n",
+    "    print('default parameters in'+filename_template)"
    ]
   },
   {
@@ -562,27 +595,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_0.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_1.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_2.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_3.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_4.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_5.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_6.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_7.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_8.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_9.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_10.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_11.nc\n",
-      "making:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_12.nc\n"
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_0.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_1.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_2.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_3.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_4.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_5.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_6.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_7.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_8.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_9.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_10.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_11.nc\n",
+      "make:/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_12.nc\n"
      ]
     }
    ],
@@ -590,93 +622,79 @@
     "if(dosetup == 1): \n",
     "    fatesparamfile= 'fates_params_'+ens_directory+'_'\n",
     "    vs=range(0,ncases+1) \n",
-    "    print(paramsdir)\n",
     "    for i in vs:\n",
     "        filename_out = paramsdir+'/'+fatesparamfile+str(i)+'.nc' \n",
-    "        #print('making parameter file',i,fatesparamfile+str(i)+'.nc');\n",
-    "        print('making:'+filename_out)\n",
-    "        copy_clobber(filename_template,filename_out) ; \n"
+    "        print('make:'+filename_out)\n",
+    "        try:\n",
+    "            os.remove(filename_out)\n",
+    "        except:\n",
+    "            print('file does not yet exist: '+filename_out)\n",
+    "        shutil.copy(filename_template,filename_out)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Modify parameters for senstivity analysis. "
+    "#### Make function to modify FATES parameter files. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 62,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['fates_rad_leaf_clumping_index', 'fates_rad_leaf_xl', 'fates_rad_leaf_rhovis', 'fates_leaf_vcmax25top', 'fates_rad_stem_tauvis', 'fates_rad_leaf_rhonir']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "parameter_list=['fates_rad_leaf_clumping_index','fates_rad_leaf_xl',\n",
-    "                'fates_rad_leaf_rhovis','fates_leaf_vcmax25top',\n",
-    "                'fates_rad_stem_tauvis','fates_rad_leaf_rhonir']\n",
-    "\n",
-    "min_delta=[0.9,0.1,0.8,0.8,0.8,0.8]\n",
-    "max_delta=[1.1,10 ,1.2,1.2,1.2,1.2]\n",
-    "print(parameter_list)  "
+    "def def_pftfile( fileroot,i,variable,delta):   \n",
+    "    pfilename = fileroot+str(i)+'.nc' \n",
+    "    fin = nc4.Dataset(pfilename, 'r+')\n",
+    "    print('modifying parameter file',i,variable,delta);\n",
+    "    var = fin.variables[variable]\n",
+    "    var[:] = var[:]*delta\n",
+    "    fin.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Modify parameter files (one at a time)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_\n",
-      "0 -1\n",
-      "modifying parameter file 1 fates_rad_leaf_clumping_index x 0.9\n",
-      "modifying parameter file 2 fates_rad_leaf_clumping_index x 1.1\n",
-      "1 1\n",
-      "modifying parameter file 3 fates_rad_leaf_xl x 0.1\n",
-      "modifying parameter file 4 fates_rad_leaf_xl x 10\n",
-      "2 3\n",
-      "modifying parameter file 5 fates_rad_leaf_rhovis x 0.8\n",
-      "modifying parameter file 6 fates_rad_leaf_rhovis x 1.2\n",
-      "3 5\n",
-      "modifying parameter file 7 fates_leaf_vcmax25top x 0.8\n",
-      "modifying parameter file 8 fates_leaf_vcmax25top x 1.2\n",
-      "4 7\n",
-      "modifying parameter file 9 fates_rad_stem_tauvis x 0.8\n",
-      "modifying parameter file 10 fates_rad_stem_tauvis x 1.2\n",
-      "5 9\n",
-      "modifying parameter file 11 fates_rad_leaf_rhonir x 0.8\n",
-      "modifying parameter file 12 fates_rad_leaf_rhonir x 1.2\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/ncar/usr/jupyterhub/envs/pangeo-2019.09.12/lib/python3.7/site-packages/ipykernel_launcher.py:6: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.\n",
-      "Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations\n",
-      "  \n"
+      "modifying parameter file 1 fates_rad_leaf_clumping_index 0.5\n",
+      "modifying parameter file 2 fates_rad_leaf_clumping_index 1.1764705882352942\n",
+      "modifying parameter file 3 fates_rad_leaf_xl 0.01\n",
+      "modifying parameter file 4 fates_rad_leaf_xl 1.4\n",
+      "modifying parameter file 5 fates_rad_leaf_rhovis 0.75\n",
+      "modifying parameter file 6 fates_rad_leaf_rhovis 1.25\n",
+      "modifying parameter file 7 fates_rad_stem_rhovis 0.75\n",
+      "modifying parameter file 8 fates_rad_stem_rhovis 1.25\n",
+      "modifying parameter file 9 fates_rad_leaf_tauvis 0.75\n",
+      "modifying parameter file 10 fates_rad_leaf_tauvis 1.25\n",
+      "modifying parameter file 11 fates_rad_stem_tauvis 0.75\n",
+      "modifying parameter file 12 fates_rad_stem_tauvis 1.25\n"
      ]
     }
    ],
    "source": [
     "#n.b. I (RAF) have other scripts that do LHC sampling or n dimensional arrays. \n",
-    "#just inclusing this one at a time example here for simplicity. \n",
+    "#just including this one at a time example here for simplicity. \n",
+    "\n",
     "if(dosetup == 1): \n",
     "    fileroot =  paramsdir+'/'+fatesparamfile \n",
-    "    print(fileroot)\n",
     "    if(sp == 1):\n",
     "        for p in range(0,6):\n",
-    "            print(p,p*2-1)\n",
     "            def_pftfile(fileroot,p*2+1,parameter_list[p],min_delta[p])\n",
     "            def_pftfile(fileroot,p*2+2,parameter_list[p],max_delta[p])\n"
    ]
@@ -690,72 +708,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Writing parameter file names into user_nl_clm files\n",
-      "pftfilename =  fates_params_RTM_ens1_0\n",
-      "pftfilename =  fates_params_RTM_ens1_1\n",
-      "pftfilename =  fates_params_RTM_ens1_2\n",
-      "pftfilename =  fates_params_RTM_ens1_3\n",
-      "pftfilename =  fates_params_RTM_ens1_4\n",
-      "pftfilename =  fates_params_RTM_ens1_5\n",
-      "pftfilename =  fates_params_RTM_ens1_6\n",
-      "pftfilename =  fates_params_RTM_ens1_7\n",
-      "pftfilename =  fates_params_RTM_ens1_8\n",
-      "pftfilename =  fates_params_RTM_ens1_9\n",
-      "pftfilename =  fates_params_RTM_ens1_10\n",
-      "pftfilename =  fates_params_RTM_ens1_11\n",
-      "pftfilename =  fates_params_RTM_ens1_12\n"
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_0/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_1/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_2/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_3/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_4/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_5/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_6/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_7/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_8/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_9/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_10/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_11/user_nl_clm\n",
+      "unl=/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/RTM_ens1_case_12/user_nl_clm\n"
      ]
     }
    ],
    "source": [
-    "%%bash -s \"$ctsmrepo\" \"$fatesparamfile\" \"$ens_directory\" \"$caseroot\" \"$dosetup\" \"$ncases\" \"$paramsdir\"\n",
-    "\n",
-    "\n",
-    "ctsmrepo=$1\n",
-    "fatesparamfile=$2\n",
-    "ens_directory=$3\n",
-    "caseroot=$4\n",
-    "dosetup=$5\n",
-    "ncases=$6\n",
-    "paramsdir=$7\n",
-    "\n",
-    "if [ $dosetup -eq 1 ]\n",
-    "then\n",
-    "echo \"Writing parameter file names into user_nl_clm files\"\n",
-    "unl=user_nl_clm\n",
-    "cd /glade/work/$USER/git/$ctsmrepo/cime/scripts\n",
-    "counter1=0\n",
-    "cd $ens_directory\n",
-    "\n",
-    "while [[ $counter1 -le $ncases ]]\n",
-    "do\n",
-    "  #echo $counter1\n",
-    "  newcase=$caseroot$counter1 \n",
-    "  pftfilename=$fatesparamfile$counter1\n",
-    "  echo \"pftfilename = \"  $pftfilename\n",
-    "  if [ -d $newcase ]\n",
-    "  then\n",
-    "   cd $newcase\n",
-    "   #get default parameter file\n",
-    "    cp ../user_nl_clm_default user_nl_clm\n",
-    "    sed -i \"s|fates_params_default|$pftfilename|g\" user_nl_clm\n",
-    "    cd ../\n",
-    "  else\n",
-    "   echo 'no case', $newcase\n",
-    "  fi\n",
-    "\n",
-    "  ((counter1++))\n",
-    "  done\n",
-    "#cat $newcase/user_nl_clm\n",
-    "\n",
-    "fi"
+    "if(dosetup == 1): \n",
+    "    root= '/glade/work/'+USER+'/git/'+ctsmrepo+'/cime/scripts/'+ens_directory+'/'\n",
+    "    fatesparamfile=root+'fates_params_'+ens_directory+'_'\n",
+    "    vs=range(0,ncases+1) \n",
+    "    for i in vs:\n",
+    "        pftfilename = paramsdir+'/'+fatesparamfile+str(i)+'.nc'    \n",
+    "        unlfile=root+caseroot+str(i)+'/'+'user_nl_clm'\n",
+    "        print('unl='+unlfile)   \n",
+    "        fin = open(unlfile, \"rt\")     \n",
+    "        data = fin.read()   #read file contents to string   \n",
+    "        data = data.replace('pyton', 'python') #replace all occurrences of the required string        \n",
+    "        fin.close() #close the input file       \n",
+    "        fin = open(unlfile, \"wt\") #open the input file in write mode     \n",
+    "        fin.write(data) #overrite the input file with the resulting data       \n",
+    "        fin.close() #close the file"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Check parameter files were correctly modifed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "actual ratio: [0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75 0.75]\n",
+      "target ratio: 0.75\n"
+     ]
+    }
+   ],
+   "source": [
+    "i=5\n",
+    "paramnum=2\n",
+    "pf= paramsdir+'/'+fatesparamfile+str(0)+'.nc' \n",
+    "find = nc4.Dataset(pf, 'r+')\n",
+    "vardef=find.variables[parameter_list[paramnum]]\n",
+    "pf= paramsdir+'/'+fatesparamfile+str(i)+'.nc' \n",
+    "finm = nc4.Dataset(pf, 'r+')\n",
+    "varmod=finm.variables[parameter_list[paramnum]]\n",
+    "print('actual ratio:',np.divide(varmod[:],vardef[:]))\n",
+    "print('target ratio:',min_delta[paramnum])"
    ]
   },
   {
@@ -767,9 +792,1721 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 78,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "submitting\n",
+      "/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1\n",
+      "0\n",
+      "RTM_ens1_case_0\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_0.nc\"\n",
+      "submitting job,RTM_ens1_case_0\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:23:11 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:23:11 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:23:13 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:23:13 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:23:13 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:23:13 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:23:13 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:23:13 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:23:13 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700331.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700331.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700332.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700331.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700332.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "1\n",
+      "RTM_ens1_case_1\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_1.nc\"\n",
+      "submitting job,RTM_ens1_case_1\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:23:18 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:23:19 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:23:19 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:23:19 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:23:19 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:23:19 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:23:19 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:23:19 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:23:19 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700333.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700333.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700334.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700333.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700334.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "2\n",
+      "RTM_ens1_case_2\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_2.nc\"\n",
+      "submitting job,RTM_ens1_case_2\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:23:23 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:23:23 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:23:23 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:23:23 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:23:23 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:23:23 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:23:23 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:23:23 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:23:23 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700338.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700338.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700339.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700338.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700339.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "3\n",
+      "RTM_ens1_case_3\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_3.nc\"\n",
+      "submitting job,RTM_ens1_case_3\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:23:28 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:23:28 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:23:28 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:23:28 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:23:28 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:23:29 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:23:29 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:23:29 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:23:29 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700354.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700354.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700355.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700354.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700355.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "4\n",
+      "RTM_ens1_case_4\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_4.nc\"\n",
+      "submitting job,RTM_ens1_case_4\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:23:32 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:23:33 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:23:33 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:23:33 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:23:33 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:23:33 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:23:33 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:23:33 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:23:33 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700359.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700359.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700360.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700359.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700360.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "5\n",
+      "RTM_ens1_case_5\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_5.nc\"\n",
+      "submitting job,RTM_ens1_case_5\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:23:38 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:23:38 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:23:38 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:23:38 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:23:38 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:23:39 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:23:39 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:23:39 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:23:39 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700365.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700365.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700367.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700365.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700367.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "6\n",
+      "RTM_ens1_case_6\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_6.nc\"\n",
+      "submitting job,RTM_ens1_case_6\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:23:42 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:23:43 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:23:43 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:23:43 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:23:43 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:23:43 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:23:43 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:23:43 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:23:43 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700374.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700374.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700375.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700374.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700375.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "7\n",
+      "RTM_ens1_case_7\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_7.nc\"\n",
+      "submitting job,RTM_ens1_case_7\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:23:48 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:23:48 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:23:49 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:23:49 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:23:49 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:23:49 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:23:49 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:23:49 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:23:49 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700385.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700385.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700386.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700385.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700386.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "8\n",
+      "RTM_ens1_case_8\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_8.nc\"\n",
+      "submitting job,RTM_ens1_case_8\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:23:52 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:23:53 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:23:53 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:23:53 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:23:53 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:23:53 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:23:53 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:23:53 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:23:53 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700387.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700387.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700388.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700387.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700388.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "9\n",
+      "RTM_ens1_case_9\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_9.nc\"\n",
+      "submitting job,RTM_ens1_case_9\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:23:58 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:23:58 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:23:58 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:23:58 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:23:58 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:23:58 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:23:58 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:23:58 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:23:58 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700389.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700389.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700390.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700389.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700390.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "10\n",
+      "RTM_ens1_case_10\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_10.nc\"\n",
+      "submitting job,RTM_ens1_case_10\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:24:02 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:24:02 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:24:03 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:24:03 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:24:03 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:24:03 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:24:03 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:24:03 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:24:03 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700391.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700391.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700392.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700391.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700392.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "11\n",
+      "RTM_ens1_case_11\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_11.nc\"\n",
+      "submitting job,RTM_ens1_case_11\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:24:09 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:24:09 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:24:09 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:24:09 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:24:09 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:24:09 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:24:09 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:24:09 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:24:09 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700393.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700393.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700394.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700393.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700394.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "12\n",
+      "RTM_ens1_case_12\n",
+      "!----------------------------------------------------------------------------------\n",
+      "! Users should add all user specific namelist changes below in the form of \n",
+      "! namelist_var = new_namelist_value \n",
+      "!\n",
+      "! EXCEPTIONS: \n",
+      "! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting\n",
+      "! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting\n",
+      "! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting\n",
+      "! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting\n",
+      "! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting\n",
+      "! Set co2_ppmv           with CCSM_CO2_PPMV                      option\n",
+      "! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options\n",
+      "! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases\n",
+      "!                        (includes $inst_string for multi-ensemble cases)\n",
+      "!                        or with CLM_FORCE_COLDSTART to do a cold start\n",
+      "!                        or set it with an explicit filename here.\n",
+      "! Set maxpatch_glc       with GLC_NEC                            option\n",
+      "! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable\n",
+      "!----------------------------------------------------------------------------------\n",
+      "\n",
+      "use_fates_sp=.true.\n",
+      "fates_paramfile = \"/glade/work/rfisher/git/ctsmsep22/cime/scripts/RTM_ens1/parameter_files/fates_params_RTM_ens1_12.nc\"\n",
+      "submitting job,RTM_ens1_case_12\n",
+      "For your changes to take effect, run:\n",
+      "./case.build --clean-all\n",
+      "./case.build\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "env_batch.xml appears to have changed, regenerating batch scripts\n",
+      "manual edits to these file will be lost!\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating batch scripts\n",
+      "Writing case.run script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.case.run\n",
+      "Creating file .case.run\n",
+      "Writing case.st_archive script from input template /glade/work/rfisher/git/ctsmsep22/ccs_config/machines/template.st_archive\n",
+      "Creating file case.st_archive\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "  2022-10-03 06:24:13 atm \n",
+      "Create namelist for component datm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cdeps/datm/cime_config/buildnml\n",
+      "  2022-10-03 06:24:13 lnd \n",
+      "Create namelist for component clm\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../cime_config/buildnml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: CLM is starting up from a cold state\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2022-10-03 06:24:14 ice \n",
+      "Create namelist for component sice\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sice/cime_config/buildnml\n",
+      "  2022-10-03 06:24:14 ocn \n",
+      "Create namelist for component socn\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/socn/cime_config/buildnml\n",
+      "  2022-10-03 06:24:14 rof \n",
+      "Create namelist for component mosart\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/mosart//cime_config/buildnml\n",
+      "  2022-10-03 06:24:14 glc \n",
+      "Create namelist for component sglc\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sglc/cime_config/buildnml\n",
+      "  2022-10-03 06:24:14 wav \n",
+      "Create namelist for component swav\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/swav/cime_config/buildnml\n",
+      "  2022-10-03 06:24:14 esp \n",
+      "Create namelist for component sesp\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/CIME/non_py/src/components/stub_comps_nuopc/sesp/cime_config/buildnml\n",
+      "  2022-10-03 06:24:14 cpl \n",
+      "Create namelist for component drv\n",
+      "   Calling /glade/work/rfisher/git/ctsmsep22/cime/../components/cmeps/cime_config/buildnml\n",
+      "Writing nuopc_runconfig for components ['CPL', 'ATM', 'LND', 'ROF']\n",
+      "Checking that inputdata is available as part of case submission\n",
+      "Setting resource.RLIMIT_STACK to -1 from (-1, -1)\n",
+      "Loading input file list: 'Buildconf/ctsm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/cpl.input_data_list'\n",
+      "Loading input file list: 'Buildconf/datm.input_data_list'\n",
+      "Loading input file list: 'Buildconf/mosart.input_data_list'\n",
+      "Check case OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submit_jobs case.run\n",
+      "Submit job case.run\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q regular -l walltime=12:00:00 -A P93300641 -v ARGS_FOR_SCRIPT='--resubmit' .case.run\n",
+      "Submitted job id is 6700396.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Submit job case.st_archive\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitting job script qsub -q share -l walltime=00:20:00 -A P93300641  -W depend=afterok:6700396.chadmin1.ib0.cheyenne.ucar.edu -v ARGS_FOR_SCRIPT='--resubmit' case.st_archive\n",
+      "Submitted job id is 6700397.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.run with id 6700396.chadmin1.ib0.cheyenne.ucar.edu\n",
+      "Submitted job case.st_archive with id 6700397.chadmin1.ib0.cheyenne.ucar.edu\n"
+     ]
+    }
+   ],
    "source": [
     "%%capture\n",
     "%%bash -s \"$ctsmrepo\" \"$defcase\" \"$ens_directory\" \"$caseroot\" \"$ncases\" \"$dosubmit\" \n",
@@ -799,6 +2536,7 @@
     "  if [ -d $newcase ]\n",
     "  then\n",
     "    cd $newcase\n",
+    "    cat user_nl_clm\n",
     "    echo 'submitting job',$newcase\n",
     "    ./xmlchange BUILD_COMPLETE=TRUE\n",
     "    #./xmlchange RESUBMIT=1\n",
@@ -827,42 +2565,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Import libraries for analysis"
+    "### Paths for analysis"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 118,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "%matplotlib inline\n",
-    "if doanalysis ==1:\n",
-    "    import numpy as np\n",
-    "    import warnings\n",
-    "    warnings.filterwarnings('ignore')\n",
-    "    import xarray as xr\n",
-    "    from matplotlib import pyplot as plt\n",
-    "    import datetime\n",
-    "    import cartopy\n",
-    "    import cartopy.crs as ccrs\n",
-    "    import os.path\n",
-    "    import xesmf as xe"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ychoose= 2001\n"
+     ]
+    }
+   ],
    "source": [
     "if doanalysis ==1: \n",
     "    output='/glade/scratch/rfisher/'\n",
     "    conv = 3600*24*365\n",
     "    yr='.clm2.h0.'   \n",
-    "    ychoose=2000\n",
+    "    ychoose=2001\n",
     "    delta=1\n",
-    "    pftnames=['BlEvTrTr','NlEvTr','NlCdDecTt','BlEvTmTr','BlDrDecTt','BlCdDecTr','BlEvSh','BlDrDecSh','BlCdDecSh','C3AG','C3G']"
+    "    print('ychoose=', ychoose)"
    ]
   },
   {
@@ -874,48 +2600,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "figs_RTM_ens1\n"
+      "dir exists already/glade/u/home/rfisher/fates_sp_ensembles/figs_RTM_ens1\n"
      ]
     }
    ],
    "source": [
-    "#fig dir\n",
     "figdirname='figs_'+ens_directory\n",
-    "print(figdirname)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "made fig firectory, figs_RTM_ens1\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%bash -s \"$figdirname\"  \n",
-    "figdirname=$1\n",
-    "\n",
-    "cd $notebookdr\n",
-    "if [[ -d $figdirname ]]\n",
-    "then\n",
-    "   echo \"existing fig firectory\",$figdirname\n",
-    "else \n",
-    "    mkdir $figdirname\n",
-    "    echo \"made fig firectory\", $figdirname\n",
-    "fi"
+    "current=os.getcwd()\n",
+    "figpath = os.path.join(current, figdirname)\n",
+    "if(os.path.isdir(figpath)):\n",
+    "    print('dir exists already'+figpath)\n",
+    "else:\n",
+    "    os.mkdir(path)\n",
+    "    print('made: '+figpath)"
    ]
   },
   {
@@ -927,153 +2631,225 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 168,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "range(1, 13)\n",
+      "/glade/scratch/rfisher/\n",
       "RTM_ens1_case_\n",
-      "1\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_1/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_1/run/RTM_ens1_case_1.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_1/run/\n",
-      "2\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_2/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_2/run/RTM_ens1_case_2.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_2/run/\n",
-      "3\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_3/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_3/run/RTM_ens1_case_3.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_3/run/\n",
-      "4\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_4/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_4/run/RTM_ens1_case_4.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_4/run/\n",
-      "5\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_5/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_5/run/RTM_ens1_case_5.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_5/run/\n",
-      "6\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_6/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_6/run/RTM_ens1_case_6.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_6/run/\n",
-      "7\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_7/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_7/run/RTM_ens1_case_7.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_7/run/\n",
-      "8\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_8/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_8/run/RTM_ens1_case_8.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_8/run/\n",
-      "9\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_9/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_9/run/RTM_ens1_case_9.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_9/run/\n",
-      "10\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_10/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_10/run/RTM_ens1_case_10.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_10/run/\n",
-      "11\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_11/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_11/run/RTM_ens1_case_11.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_11/run/\n",
-      "12\n",
-      "output in run dir\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_12/run//2000combined.nc\n",
-      "no file exists\n",
-      "fileroot: /glade/scratch/rfisher/RTM_ens1_case_12/run/RTM_ens1_case_12.clm2.h0.2000*\n",
-      "/glade/scratch/rfisher/RTM_ens1_case_12/run/\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_0/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_0/lnd/hist/RTM_ens1_case_0.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_1/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_1/lnd/hist/RTM_ens1_case_1.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_2/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_2/lnd/hist/RTM_ens1_case_2.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_3/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_3/lnd/hist/RTM_ens1_case_3.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_4/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_4/lnd/hist/RTM_ens1_case_4.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_5/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_5/lnd/hist/RTM_ens1_case_5.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_6/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_6/lnd/hist/RTM_ens1_case_6.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_7/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_7/lnd/hist/RTM_ens1_case_7.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_8/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_8/lnd/hist/RTM_ens1_case_8.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_9/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_9/lnd/hist/RTM_ens1_case_9.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_10/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_10/lnd/hist/RTM_ens1_case_10.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_11/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_11/lnd/hist/RTM_ens1_case_11.clm2.h0.2003-01.nc\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_12/lnd/hist/\n",
+      "is archive\n",
+      "file in archive\n",
+      "/glade/scratch/rfisher/archive/RTM_ens1_case_12/lnd/hist/RTM_ens1_case_12.clm2.h0.2003-01.nc\n",
       "end\n"
      ]
     }
    ],
    "source": [
+    "ychoose=2003\n",
+    "print(output_dir)\n",
     "if doanalysis ==1:\n",
-    "    vs=range(1|0,ncases+1) \n",
-    "    print(vs)\n",
+    "    hstring='.clm2.h0.'\n",
+    "    vs=range(0,ncases+1)\n",
     "    count=1\n",
-    "    ncol=3\n",
     "    print(caseroot)\n",
-    "    for i in vs:\n",
-    "        print(i)\n",
+    "    for i in vs:       \n",
     "        run=caseroot+str(i)\n",
-    "        arc = output + 'archive/' + run + '/lnd/hist/'\n",
-    "        f2= arc + '/'+str(ychoose)+'combined.nc'\n",
-    "        if(os.path.isdir(arc)):\n",
-    "            arc = arc\n",
+    "        os.listdir(output_dir + '/archive')\n",
+    "        arc = output_dir + 'archive/' + run + '/lnd/hist/' \n",
+    "        hpath = arc\n",
+    "        tfile = run+hstring+str(ychoose)+'-01.nc'\n",
+    "        print(hpath)\n",
+    "        if(os.path.isdir(hpath)): \n",
+    "            print('is archive')\n",
+    "            if(os.path.isfile(hpath+tfile)): \n",
+    "                print('file in archive')\n",
+    "            else:\n",
+    "                print('file not in archive',hpath+tfile)\n",
+    "                #os.listdir(hpath)\n",
     "        else:\n",
-    "            arc = output + run + '/run/'\n",
-    "            print('output in run dir')\n",
-    "        fileout = arc + '/'+str(ychoose)+'combined.nc'\n",
-    "        #os.remove(fileout)\n",
-    "        print(fileout)\n",
-    "        if(os.path.isfile(fileout)):\n",
-    "            print('file exists')\n",
-    "            arc=arc\n",
+    "            print('no archive')\n",
+    "            hpath = output_dir + run + '/run/'            \n",
+    "            if(os.path.isdir(hpath)): \n",
+    "                print('is rundir',hpath)                \n",
+    "                if(os.path.isfile(hpath+tfile)):\n",
+    "                    print('file in  rundir',hpath+tfile)\n",
+    "                else:\n",
+    "                    print('no file in  rundir',hpath+tfile)                    \n",
+    "            else:\n",
+    "                print('no  rundir',hpath)\n",
+    "\n",
+    "        #print(hpath)\n",
+    "        vars=['FATES_GPP','FSR','SABV','lat','lon','time']\n",
+    "        print(hpath +run+hstring+str(ychoose)+'-01.nc')\n",
+    "        allvars=list(xr.open_dataset(hpath +run+hstring+str(ychoose)+'-01.nc', decode_times=False).variables)\n",
+    "        dropvars=list(set(allvars) - set(vars)) #thanks to Ben for figuring this part out :) \n",
+    "        tmp=xr.open_mfdataset(arc +run+hstring+str(ychoose)+'*', decode_times=False, drop_variables=dropvars)\n",
+    "\n",
+    "        if i==0:\n",
+    "            dsc = tmp           \n",
     "        else:\n",
-    "            print('no file exists')\n",
-    "            print('fileroot:',arc +run+yr+str(ychoose)+'*')\n",
-    "            ds0 = xr.open_mfdataset(arc +run+yr+str(ychoose)+'*', decode_times=False)           \n",
-    "            ds0.to_netcdf(fileout)\n",
-    "            print(arc)\n",
+    "            dsc=xr.concat([dsc,tmp],'ens')\n",
     "\n",
     "print('end')"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Save data in netcdf file just incase"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['dataout.nc']"
+      ]
+     },
+     "execution_count": 112,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outfile=figpath+'/dataout.nc' \n",
+    "dsc.to_netcdf(outfile)\n",
+    "os.listdir(figpath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n",
-      "5\n",
-      "6\n",
-      "7\n",
-      "8\n",
-      "9\n",
-      "10\n",
-      "11\n",
-      "12\n",
-      "figs/ensemble_GPP_delta_abs_RTM_ens1_case_12.png\n"
+      "<xarray.Dataset>\n",
+      "Dimensions:    (time: 12, lon: 72, lat: 46, ens: 4)\n",
+      "Coordinates:\n",
+      "  * time       (time) float32 396.0 424.0 455.0 485.0 ... 669.0 699.0 730.0\n",
+      "  * lon        (lon) float32 0.0 5.0 10.0 15.0 20.0 ... 340.0 345.0 350.0 355.0\n",
+      "  * lat        (lat) float32 -90.0 -86.0 -82.0 -78.0 ... 78.0 82.0 86.0 90.0\n",
+      "Dimensions without coordinates: ens\n",
+      "Data variables:\n",
+      "    FATES_GPP  (ens, time, lat, lon) float32 dask.array<chunksize=(1, 1, 46, 72), meta=np.ndarray>\n",
+      "    FSR        (ens, time, lat, lon) float32 dask.array<chunksize=(1, 1, 46, 72), meta=np.ndarray>\n",
+      "    SABV       (ens, time, lat, lon) float32 dask.array<chunksize=(1, 1, 46, 72), meta=np.ndarray>\n",
+      "Attributes: (12/37)\n",
+      "    title:                                CLM History file information\n",
+      "    comment:                              NOTE: None of the variables are wei...\n",
+      "    Conventions:                          CF-1.0\n",
+      "    history:                              created on 09/30/22 09:01:33\n",
+      "    source:                               Community Terrestrial Systems Model\n",
+      "    hostname:                             cheyenne\n",
+      "    ...                                   ...\n",
+      "    ctype_urban_shadewall:                73\n",
+      "    ctype_urban_impervious_road:          74\n",
+      "    ctype_urban_pervious_road:            75\n",
+      "    time_period_freq:                     month_1\n",
+      "    Time_constant_3Dvars_filename:        ./RTM_ens1_case_0.clm2.h0.2000-01.nc\n",
+      "    Time_constant_3Dvars:                 ZSOI:DZSOI:WATSAT:SUCSAT:BSW:HKSAT:...\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dsc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot delta from default"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 188,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 1 0 1 0\n",
+      "8 2 1 1 0\n",
+      "2 3 0 2 1\n",
+      "9 4 1 2 1\n",
+      "3 5 0 3 2\n",
+      "10 6 1 3 2\n",
+      "4 7 0 4 3\n",
+      "11 8 1 4 3\n",
+      "5 9 0 5 4\n",
+      "12 10 1 5 4\n",
+      "6 11 0 6 5\n",
+      "13 12 1 6 5\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAvoAAAGQCAYAAADfmMR0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOy9eXgkV33v/Tm9aNdImtHsnsXLeMYrXsbGxgQbAsQ2JqwBMwkOTnLBkEBIeEkI903Cc8lNbpIbeEkI+HG4BAgxDlngGmzssDjY2MbgfRl7vI3Hnt2aRRqN1FK3+rx/VEvqXd2qbul0ne/nefqRuqv61Gl9+jtzqupXp4y1FiGEEEIIIUS0iC12B4QQQgghhBCNRwN9IYQQQgghIogG+kIIIYQQQkQQDfSFEEIIIYSIIBroCyGEEEIIEUES9aw8ODhoN27c2KSu+MEDDzwwZK1dnv/akv7TbSZ9vOr7xsdevN1ae3lTO5dDnhvDfFwvpGeQ60agTPuDMu0HyrQ/tEKmw1LXQH/jxo3cf//9zeqLFxhjdhW/NpU5zmlnf6Lq+x786YcGm9apIuS5MczH9UJ6BrluBMq0PyjTfqBM+0MrZDosdQ30RfMwcbPYXRALhFz7gTz7g1z7gTz7Q5Rca6DvAsZgkvHF7oVYCOTaD+TZH+TaD+TZHyLmWgN9FzBgYtHZexRVkGs/kGd/kGs/kGd/iJhrDfRdwBCpvUdRBbn2A3n2B7n2A3n2h4i51kDfAQwmUvVgojJy7Qfy7A9y7Qfy7A9Rcx1qoH+j2Tzz+za7I1Qb831/s8j/bPMhFoNstsaVDcSS7t7SIMqeoTmuK35OuV40lOlZouwZlOl8ouxamZ4lyp5BmQ6Djui7QMTqwUQV5NoP5Nkf5NoP5NkfIuZaA30XiNgV3qIKcu0H8uwPcu0H8uwPEXOtgb4DmIidJhKVkWs/kGd/kGs/kGd/iJrrugf6YeukKrV1U3wzsdzf9V3pha8Pa+Tnqhvj5oUfjfqb5Ldzowk8L5brRfUMTrpWppuAg56hOZm+KR78rky7gzLdBBz0DMp0U3DU9XzREf0mkX/RR/4FH79qyn95TCI6p4l8o5LrSsh1a6JM+4My7QfKtD/4nGkN9F3AROt2y6IKcu0H8uwPcu0H8uwPEXPd1IH+TfHNM3tRXZ3Bz1gMEnNs9eae2dM2k+nZ98HsXtk7JxpzKunf2jfXPr1WkzAtfuFHvmeYn+tiz9BY1y54hmi5djHT/9a+uaDNxSJKnkGZrkaUXCvTlYmSZ1Cmq9Hqroupe6DfyPlVB5dBJjP7Jctmg0cm07BNtAwuTuXUKNfFnqE1XG+zO5pSK+iaa2W6ObjmGZRpZbp+lOlZXPMMyrQvmQ6DSndcwJhIXeEtqiDXfiDP/iDXfiDP/hAx1xrou0DE6sFEFeTaD+TZH+TaD+TZHyLmet4D/YdO28LoKCzphayFVCp4ALx231PcsXpLo/pYlun2EwmYmLBMTsLkZNAXgLePB6ez/nNwM8mkKTgdNTFhaW93R6IxEHf0Cu9iz1DoeiG4Y/WWAs9Q6rqcZwjnuimnA1vItTI9f1rJMyx+pqdzrUw3lmqZXgiU6YVBmW4sLrueD009or+kF/r6DBMTFmMMbW1BrdfUVGA+HjdAIDiRCC7w6OgobOPoUejvD943/YDG1Yz198HIscLXyl0MEouVbnP6yxq+L4ZYC9eD5XsGSlznewbKus73DI13Xc4zlLou53m6z435zkXHtYuZ7u8LfobJtDzXl+npfweV6dZEma6V6HgGZbo6re26GJXuOIAxEI9QPZiojFz7gTz7g1z7gTz7Q9Rc1z3Qf/41Z8+5zqH3vnpenWkk953c3DKDeri1Pzi1dOXR8lfHGwOJhHtfqlpcu4Brrit5BjddK9P1o0w3F9dcRzHTLuCaZ1Cmm4Vrrlst02EIdUT/5POW0NaTJHVkgraeJNmsJdkZNHnmpUsxccPYwTGmMlkyYxnGjk3R2R0jkVsnm86SHg/Os0yfmmnvTsxcBJFNZ5mcnKItCaOj0NYGK5YbstnZWu3UBPT0GMbG4NgxSyZTeKpp7RpDW2ectp4kAEf3pWhbZkhNBMvb2oL22tsN2WxwCiuVCk7/TM8ZO92/jo5cfWGur21Bk2VPFW1YH5wiq61GzhCLzf9LZYxZB3wNWAVkgRustZ8rWscAnwOuBMaA91lrH6yl/XzPQIHrbDpb4BkocZ3vGUpdF3uGUtf5nqHUdbFnKHRd7BnKu873nN/XtmTlU4JRdd2KmW5ry20nRKZ98wzhMp1/Wn2+mT52LCgnUKYXLtPZdPCHUKaj5xmikenp8rGwmd5md3D3hi2RcV0vKt1xAGMgEe40UQb4mLX2QWNML/CAMeb71trteetcAWzKPV4JfDH3Uywgcu0H8uwPcu0H8uwPUXMdnXMTrYwJbs5Q7VENa+2+6T1Ba+0x4ElgbdFqbwG+ZgN+CvQbY1Y34+OIKszhei7kukVQpv1BmfYDZdofIpbpuo7oT+zYDuee0ox+eI0xppZ6sEFjzP15z2+w1t5Qpq2NwLnAfUWL1gIv5T3fnXttX7mNtUrdX6tRg+uaPOfa2khI18p0c1Cm/UGZ9gNl2h9cy3RY6i7dmZqYAmD91kGy6Szx9gSxZJruVd0kNiyZWc+mpjDJGN3DE2TH0hx76Rgdo5N09HfQ3tcebLyvnbE9x8hMTJEZy5DoSmBzNVkAo3tHWb62jY6BDkaOjQCQSgXL29qCdTq7Y4wfz9LVBePjFEwLBUHtlokZ0mMZjg9nGBuHpeu7yO4Nir3bkrBqYyeH96bIZGB01NDbG7zvyNFgWzEDmangZ37Z1lvHgos5bopvLqhpm74l9QObtwCzn6cSBojNfXOGIWvt1qrtGNMD/DvwUWvtSJnNFFO1c1MTUyWegQLXxZ6BEtf5noES1+U8Q6HrfM9Q6rrYM1DgutgzlLqu5BkC15U8Q0Ndz+kZGus6Spmevm4mTKZvim+e2c40ynTlTGfGgkCFyfT4eLBcmV64TNtUsI4yrUy7munR0eDP0YhMX7LrqZbOdBhUo+8CxpAIeXMGY0yS4Av1z9ba/yizym5gXd7zE4C9oTYq6keu/UCe/UGu/UCe/SFirlWj7wCGcLV/uau3/w/wpLX2MxVWuxm4xgRcBAxbaxt+ikhUZy7Xc75frlsCZdoflGk/UKb9IWqZ1hH9ENyxeguv3fdUzevvfcuF5ReEv8L7EuC9wGPGmIdzr30SWA9grb0euJVgGqdnCaZyujbMBn1j+lbutVDRM8i149TjGZTpVkaZ9gNl2h+U6fLUNdCPxQ3LTlsKQOfaXuyUJd7XTvc5y2HKYlNTMzVhU4dTxPrbMR1x7O5ROvo76FrWyVQ6S2IgmFQ1uWEJPX3tTB04zuRomsxYmtRoaqaWu2tFF1OpDJmxNCvXBcV+J935KE+es2Xm9sR2yjI2DjtfCEqb8mssAZ48ZwsmbmjrSdLe18bYjjFG94/R3h189FgyxtJTlxJLHqVreRfDu0ZIj6ZJpSxdXcE2jh+3jI5CTw90dhrGx4NbhU9z9VT5Gy+cv2N2J+Dob13G2MtjZdczhlC3W7bW/oTy9V7561jgt2tts2Ogg46B9lLPUOC62DNQ4jrfM1DiupxnKHRd7BkKXRd7Xnfbg9x74pYZ18WegRLXxZ6BAteVPMOs62qewT3XUct0LPePc5hM1+IZlOl8z0DoTM/lWZlubKanDgcTiivTyrSrmR7eFZS1+57psOiIvgPUeDW/iABy7Qfy7A9y7Qfy7A9Rcx2dT7JIPHL6Fh45PeStnQ3Ek/Gqj4Vk8untc6/kIaE9w5yuxeKzEJ6VaTdQpv1AmfYHZbqU+kp3kjFMbj6j7LFJxg6O0d7XTnJ1N9nDqeA0y0+Di4ZTR1J0regi2Zlg/yNDZDLBVEidvQlW5E7FZUcniQ92Qtxw+OnDjB1N09WfnLnYoa07SWJ5F9n0FG09s6eK4skYvSf0zjzf/OB9XFyhz209SRLtcbLpLBt++PDMJc67rwxmRupZ08Pk6CR9G/oY3jXMknW9HN9/nN6eNjK5aajS4xlGD6dJJIJbMHd1GnoH2zg2NFnz3659dTdtg53B5RdFGEyo00TNoGdVN1PpbIlnoMB1sWegxHW+Z6DEdSXPUOi6Hs8AF+8MTtPtvnJriWegxHWxZ6jf9YxnaAnXUct0z5oeAGW6DM3K9OGnDwMo045Qa6ZTR4LSHWV6FmXarUwvWRe06Xumw6LSHRcwROo0kaiCXPuBPPuDXPuBPPtDxFxroO8ABoiZ6Ow9isrItR/Isz/ItR/Isz9EzbUG+g5gjCEZob1HURm59gN59ge59gN59oeoua5roG+zls6Nuan2jqToXtvDyK4RJp49wtF9uXq/3uBChURXgqmJKYafHyY1EdSD9XTDsaMZVuTae+Bbe0gkYNW6JH0blrDqvE6Gnhgimav/6hzsJNYeJ9bXTjY33RNAeiLL8f3Ha+rzyT95rOzrgxetBiC2tJOpoTGGHx9iaNcYo0+MsaQXTn3bGmw6uI9yrK+d7PAEk4dTxOKGeHuciZEJBk6p/YvQ+elbGP/jN1Vc7lI9WHCL6jTdmwZKPAMFros9Q6nrfM9AietKnqF215U8Q+C62DNQ4rrYM1C367k8g1uuo5bp2NKg7lKZLqSZme7LTb+qTLtBrZlOdAX//SvTsyjTbmV69Ikg175nOiw6ou8AxkAiHp29R1EZufYDefYHufYDefaHqLnWQN8RorT3KKoj134gz/4g134gz/4QJdd1DfQTg93YbHDHs853nMOzv3cL6964kf337GFgbSfJnraZ5Q//eJiOjhQjI5CagLY2GOg3rFlt+Nm3gun6RkchMwWHDk3Cw0PBOgOGDecGd+R77kd7OOnSNSRO7J85PQdwxqNPEZaOP/kOAFM3XsPLt+9k4IxBJo6kGEzGiCXjHN1+aGZqpz337GHtFSfRfeoAsb52THcHyR0vM/nc0bq22fnpW+DPSr88xhiScXe+VImeJAPXbmXizmdLPAMFros9Q6nrAs9Q4rqSZ2ic62LPQInrYs/AvFx3fvqW4JdWcB2xTE/deA2AMl1EUzP98NDsOsr0olNrph/+cTAlqTJdiDLtTqYHc1O8+p7psOiIvgOYiE3lJCoj134gz/4g134gz/4QNdca6DtA1KZyEpWRaz+QZ3+Qaz+QZ3+ImmsN9BeIzFd/jeEfvFB+oTGR2nv0maqeQa4jhDLtB8q0PyjTfuBbpusa6B9/YZjE6uB21Ic+fzen/PeLGf/xi3Qu62TgwtUcunsP/ZuXAjDy3WFGjkFXZzA10rJlhiW9cHTYkrs7N2PjwS2YMxno74O+PsO6M5eQHg1quTdfvYn4yuB2zjP1VA3GDC5h7OAYu7fvZHjYcv4Vy+lc0cVzt79I6mhQ9zlyKE3HT/ey+tozMWedDkDbldfTVq3hevoAxB268MOms9z3m7ex9RPnlHgGClwXe4ZS1/meodT1YngGSlyX8wzRdh21TJvBYFo4ZbqQZma6vy9YR5l2g1ozPfLdoEZfma6xH7jl2YdMn3/F8mB7nmc6LDqi7wBRm8pJVEau/UCe/UGu/UCe/SFqrjXQd4QoTeUkqiPXfiDP/iDXfiDP/hAl1y0z0M/+5OMAxF7914vck8ZjjInU3mMYpj2DXEcdZdoPlGl/UKb9QJluLeoa6HefdSbJD9wEwPIPwJ43X8DQc8dYur6L7f/4JCMj0LV9BAhqwdpyBVOxGBw/bjlwIJinNZubgjWR2/qmUwypVHA75tSRFCY3f2l2NE129CidH/wl7J69Dfi4pYx/bwfLz1rO0A/3k0wa0uMZ4sOTnPbxrTAVdHTD+kHMGWfC5DgAZsPv1r2dyUcPcvCxobLLDG7tPcbWncrF998PlHoGClwXe4ZS1/megRLXi+EZKHHdbM/gnuuoZXr8ezuCz6JMF9DMTKeCEmll2hFqzXRXUMqtTOehTLuV6fR4cGGf75kOS8sc0Y8yxkAyQnuPojJy7Qfy7A9y7Qfy7A9Rc13XQP/wA49zc89mAJYvN6w/s7cpnfIP49Te45EHH+em+Ga6OuW58bjlWpluFm55VqabiVuulelm4ZZnZbqZuOU6LKGO6L/4+DEu3hnc+njsvNN45tksHe25hhNw+Ah0dEAiHnwRTzytnQfuSc28vy0Ja9catrz9JEx7HICX79lDojMJQOcH3gCAWbMZBlaF6WpFuj/7fcb+4HJeftly2hkJOvo7WPJr5xF7zZuwO34OgN1yCZPZTtI2ONfZM4/tdP3Nf3Jw7Zayy4IrvN39UuV7hkLXxZ6h1HW+Z6DE9WJ4BkpcN9sztJbrVsx092e/H/Rdma5KIzM97RmUaReplOnpUg1lehZl2q1Md/R3ACjTIVHpjgMYIBGhvUdRGbn2A3n2B7n2A3n2h6i51kDfEaJ0u2VRHbn2A3n2B7n2A3n2hyi5Dj3Qv9FspqMDzjgtOhcuNJI7Vgenh44ctSxbWv6LYwwkHd97nPYMcl2JO1ZvqeoZWsu1PJdHmfYHZdoPlGl/iEqm66Hugf5YMKMRu160M9NvATzyWJZsFkaP5xpOBPVgk5MwCQwPWxK7J3j1mwfYce9RAHp6YMPWZcEb4jHazlrByt42EicvBcA+8RSxX/4HAEz7/D5gLXT91W20fWkzG67ewu5vPcOSjnbS9JLoD/qRtUmyNkmcDJ2JV8x7O3v22orLXPpOWQuYwHWxZyh0XewZSl0XeIYS14vhGShxvRCewS3XoEwr0yEznZudQpl2h1oyPV2jr0wXokzjTKZ3f+sZAGU6JCrdcQCDIRHT3rcPyLUfyLM/yLUfyLM/RM11dD5JC2NMsPdY7TF3G+bLxpiDxpjHKyy/zBgzbIx5OPf4k0Z/DjE3c7me+/3y3Aoo0/6gTPuBMu0PUct03Uf0i08PQXCn00SicFk2y8zd1bo64cyLenl55ygTR1Kc/gvBqbbu9Uvo+p8fxR7ZS+bfb4f+PpJXX4AZWDOvDxOWiaePsOqCVWS37yJ++MtYIHbl9SQmbiWRnN+5qn37q58emqYBV3h/Bfg88LUq69xlrb2qlsYqeYZC18WeodR1vmdg0V1PPH0EoMR14hdPmLdnWDDXX6GBnkGZrhdlemmpZ1Cm589XWIRMT/9UppVpVzO96oJgGk9lOhwq3XEAQ/grvK21dxpjNjaiP6J5hHUtz62BMu0PyrQfKNP+ELVMq3THAYwxJGLVHw3iYmPMI8aY7xljzmhUo6J25nLdIOR5kVGm/UGZ9gNl2h+ilmkd0Z+Dib94K+2///6Z5z948TAAr1+/tKHbqWHvcdAYc3/e8xustTfUsYkHgQ3W2lFjzJXAt4FNdXbTG6Y9w4K7lucmo0z7iTIdXZRpP1Gma6NhA/1MpvB5fu3Y2DiMHxqnuydG25J2+l4V1HslNg5gH7wLc/6lJF6/FbN2E3boJezBnZj1H25U12ri8sM7ALAPfYrssy9gNm9i8pt3ATDxmRs48OFvMND+QlO2XeNd2IastVvnuw1r7Uje77caY75gjBm01g7V21a+62LP2+wOnnnlGQWu8z0Di+p62jOUcf1Icz1DTa6d9AzKdD34lOnE64OPoExXxHnPoEzPhTK98Jm2D30q6L8yHQod0XeAhbg5gzFmFXDAWmuNMRcSlG0daupGRQnNdi3PbqBM+4My7QfKtD9ELdMa6DtC2It8jDHfAC4jOKW0G/hTIAlgrb0eeCfwQWNMBhgHrrbW1nb5uWgoYVzLc+ugTPuDMu0HyrQ/RCnT7g7007dx7T/0AvCPH7pkkTvTXIKbM4S+mv89cyz/PMF0T85x7RfuBqLvGcK7bmXPynR9tLJrZbp2WtmzMl0frexama4d1zzXNdDv7jJ05fY5pm+xXdBY0bzbsdjsnK2b7nuCna99BUsvXkPipOA2yze9+b+4+juXYVKjMLCSbOcyWLeMWOb4vD5MQ1i5itiKlWAMz193IwDbh0Zh3zHesX4n563MfSBqu/DjzdetBSA9nublR4fgoTIr1XgThoWiowMuODvBE49lynqGQtf5nqHUdYFncNZ1ec9Qj+sZz9ASrpVpZXqaeWd6YCWAk66V6dLlynQpyrSjmV4ZzKPve6bD4u4RfY8wWOJGZ+d8QK79QJ79Qa79QJ79IWquNY++IxiTrfpYuH6YP1+wjXmKC56Dfsh1M1Gm/cEFz0E/5LqZKNP+4ILnoB/hXdd1RL9tsJM3vuckANrPXcHk40McfvggQ88dY9NVG7HpKR799ksAHDgQ7A1dNTI79dmqS9cR621j6qWjJD/4L2yzkJp6iPZDD2GWn4i95esA2Ku2AdA/2B3289WNWXPdzO+nTX0fgIGOc4MX2q+s8eTQLBOf/ScAxqf62fT9j8DbnirdJpa4Sc+rv03g8q6TB9n4G2exdudwiWegwHU5z1DoepvdMeMZKHG9GJ6h1HUYzxC4nvEMLeFamVamIVymzfITAZRpN6g509OeQZlWpt3MdL5n8DfTwCfDNKDSHSewGBZ2L7EK8cXuQLSRaz+QZ3+Qaz+QZ39wy7UxZoBgev8SrLWHy72ejwb6DuDY3uOWxe5AlJFrP5Bnf5BrP5Bnf3DQ9QOUH+hb4KS5Gli0gf6NZjMAb8/ctFhdqJuHh0bpTMQ5dfyf+G/fORuAL73/ovANGxa87qsK24FzGtngjWZzS3oG5LoOlOk8IuwZlOkCIuxamc4jwp5BmS7AMdfW2nPDNFDXQN8sHaDz1y8FwD63k46P/Ardfa9hzZNfh8HlTN1+FxueHwbgyI+HS9//x58mft9N3HTJt2de64ify/96vJs/HLiRfz35fwDwboKpnc7dsnd+n6pB3Jj4HQC2ZT7PD/acz2BX/W0sO/4jAA50XcGxK/8I+HKZtSwxkynz+uJgO5aQvPptJPbuLPUMBa7LeYZS19OegRLXi+0ZAtdhPEPgetYztIJrZbr+NpTpwkz/4UAwvaEy7Qa1ZrpWz6BMB7jlWZmeXxutmOmwaNYdB5g+TVTtsYB8biE35htzuV5g5LpJKNP+oEz7gTLtD1HL9KIP9D/3k+dLXvvN6+/lN6+/dxF6Uz8f+urP+dBXfx66HUO26mMBea4ZjZbzDLSMZ6AhnqG66wVmwVy3WqYbgTLtPsp0bSjTAcq0+0Qx08aYa2b6Zcy/GWN+lHu8rpYG6qvRn0xhNgTXgNgtl5Cx7RwYWc3LGz/O3S8c5tfP2kvHncFUfGddVDoVU0f8XO458STg2wWvv+fCDbzIH/HunnY+/h+Pzry+rLe9ru41mm12diqqs5cf4L59Wa7Y+Cz3jr+bU045wIsvlT8dls/3R98EwEVLhnh5fH3ZdQyWmDsXfnzKZFLY3c9hTjy9xDNQ4LqcZyjv+j0XbgAocb3YnmHWdb5noG7X1TyDe66VaWUawmX6Rf6IDT3tvBuU6cWn5kzX4xmUadc8K9MeZRo+nPd8M/A+oJtg2s0fzdWAZt1xAuvShR9LFrsD0Uau/UCe/UGu/UCe/cEt19ba7XnPn7HWPgBgjPmLWhrQQN8R4jhz4Uf/Yncg6si1H8izP8i1H8izP7jq2lr79rynK2tpYNFr9PP5+uP7FrsL8+bLD+2e93uNsc7cWhsovU1cE2hV12E8w9yuF5imu25lz8p0fbSy6zAo062BMl0/rew6DK5l2hjzptI+mquAHWXWL6G+I/qdq7FdAwDsOX4eP9t7nIGOFOevPMT7ztrFfZv+lfP+IJjaNZur6y3mVav7eFVeTd2f/+BpnjsyNvN8xUAnR4aC53/zv+8C4E1//9a6utkMlvz1b3HOx27i0UNncvdT+/jmH/2A3i3LAPj1j15S8X1v3DB9k+alLElWWsupmzP8PomlV5kzPonlxyWegQLXlTxDoetizzDr2lXPQIHrap5h2nU1z+Cc687VVynTZ87DMyjTs5439AT1u8r0olNzpmv1DMp0gGOelWl/Mg3fNca8E3gw99r5wKuAq2ppwKkj+j7jytX81tpnFmxjnuKCZ5DrZqNM+4MLnkGum40y7Q8ueIYZ12cDdwEbc487gbOttU/X0oYG+g4wfYV3tceC9cUY3Vq7iczlekH7ItdNQ5n2B2XaD5Rpf3At09baCWvtl4FPWms/Zq39srU2ZYyp6TbAdV+Me9sLwamSb/3gcX7nbWfyw+37uezJ/4/MwWEuvPv/gWxwAcOyN4NZc92c7X3y9afyrzsOct7qJTy5Z5hLT1/F7v2jwQeMGfpWdvPZu55j6GiKF54NTkn98++9pt5uh6bjkx9mcizOnmOjJBIx1r9pE+PHA+F33buLE09aNjN/6xd+/YI6W7fE3Lnw48bpX2574cwSz0CB63o9AyWuiz0Di+Y63zNQ4Dq8Z3DRtTI9WuIZUKbnIN/zcyMphkcnlOnFp+ZM1+oZlOkA9zyDMg1eZPq83O/35v0O8IWi52XRrDuuYJ2Zysksdgcij1z7gTz7g1z7gTz7g5uui73X9D3QQN8FrIXs1GL3Yhq72B2INHLtB/LsD3LtB/LsD+66LvZe0/egJWv079xzdLG7UJVbdh6q/002W/2xcJywkBubC5dd37LzUONdLyzOuHbZMyjTjcRl18p043DZMyjTjcRl1/PyDK54BjjBGPO3xpi/y/t9+vnaWhqo+4j+pX/3HgDGrvs6zxw+znsv6MA80ofdOcRLPb8KwPqezrra/NkT+1nX18Evn7Wcbz9ykIN7RwBYsbGfb3zsUq7/2S6u+YWTuH48zdsu2VhvlxvCQ2d9hEO330PMGF7cd4xs1pJsjwOw6dTlnLCih99//RQ/fmnVPFq3MOVMPdjHga9A4LrYMzBv1z97Yj9Aietiz8Ciuc73DBS4Du8ZXHStTJsSz4AyXQPTngFl2g2UaWUaUKYjlulp7i9aVvy8LCrdcQFrXaoHO77YHYg0cu0H8uwPcu0H8uwP7rn+rrU2Nd8GNNB3BXf2Hn91sTsQeeTaD+TZH+TaD+TZH9xy/QVjzG3AN4D/tNbWdQFBS9boRw+b24Os8lionlj7tgXbmJe44Rnkurko0/7ghmeQ6+aiTPuDG55hxvUpwIM64X0AACAASURBVA+BjwAvGWO+aIypeU7Tuo/of/szwXy02/7sp/zg5VczmPkJnHE+sQvfROfE9AUZ9dX+/fXbzwbgySNjXLN1ikceby9Yft2FG3jXX97B//tbF/KFm58A4DXXXlhv10Oxb59l6/I0xmSJXbiOyfPXMjYR7FTd9fOXeMfWdXTd8xmOLP1Y/Y1bZuYqd4lvf2ZXiWdg3q6nPUN519OegUVzne8ZKHAd2jM46VqZzpZ4BpTpGlCmcdK1Mq1MK9PRybS1dgT4KvBVY8wy4J3A3xljllpr1831fpXuOIHFulMPJpqKXPuBPPuDXPuBPPuDm66NMQPA24F3A0uBf6/lfU0r3fm7e3byd/fsDN3OcyMpfvTSkQb0yGFs7grvao85MMZ82Rhz0BjzeIXlJjcl07PGmEeNMWXvpmaM6a2n6/JcJ3O5noNGec6tK9fNQpn2wzO0bKanPct1jSjTfngG5zJtjHmvMeZW4EngAuDPgPXW2o/W8nHmfUTf7n+OkwffiM1MwNgwsR2P8Mya3wdg+er5tXnaQBdwCl96/ykA7Dg6PrPsI+89j3ueG+KcM1Zy3YUb5tvteXN0GLLvfQsr//Z99LW/h7Z4jE3rDgBwyfozaYsf5/7Nf8qpwIUr68pgQPibM3wF+DzwtQrLrwA25R6vBL6Y+1lMwb8GxZ6BAtcwvwvB810XewYWzXW+Z6DAdUM8Q1jXX6ExnmEO175m+pL1ZwIo03WiTM+br7AImW6EZ1Cm6+QrKNOh8TDTtwNfAA4AE8AOa2u/WEAX4zqBDX0jDmvtncDhKqu8BfiaDfgp0G+MKTd8O2l+n0HUxhyu53p34zyDXDcRZdoflGk/UKb9wblMv0yw03A9Qa3+88aYTwAYY86dqz+q0XeB6dNE1Rk0xuTfHOEGa+0NdWxlLfBS3vPdudf2Fa33Z3W0KeplbtcL5Rnkunko0/6gTPuBMu0P7mW6E9hgrT0GYIxZAvxvY8wXgcuBE6ttrCkD/SePjIV6f/a2DwW/XPQ3ZZffuecor1nbH2obzjH3XuKQtXZriC2Yclst89qVIbZRN9nbPlTRM3jpeqE8Qx2ulel5oEyXxUPXTmY6LMp0WZTpqOBWpjfll+pYa0eMMR8EhgjKgKpS90C/pzv4mb33IU580/+Fzj5SvVu4n5PAwrLOJADvPKev3qZL2LT9U5CaYOP+w8TOPZ0Tz/gQzx1dnCuht9kd3Nq/mcTZn+UN39vD6DnbuHP3CgCu7P1X9na+lX2juTq4emvCrIWp0LV/c7EbyJ+G6QRgb5n1Zv7APd2lnoEC183wDCya63zPQIHr0J5hIVzX6hlyrpXpz5Z4BpTpECjTDaUpmW6EZ1CmG4wyXQO+ZbpcPb61dsoY83Ku9KcqqtF3hZC1fzVwM3BN7mrvi4Bha22500TbG7ExUQU3PINcNxdl2h/c8Axy3VyUaX9wwzPAdmPMNcUvGmN+jWAWnjlxrkZ//zsvYsVvVZxpKJrUVvtXFWPMN4DLCGrHdgN/CiSD5u31wK0Ep4CeBcaAays09dsEF4o0HbmunwZ6hgVyLc/zQ5luEZRpP1Cm/cG9TP+HMeY3gAcISnwuIKjbr+kOyXUP9EePBz8f/fTPeMWqpdjXvouOzAFSmWB6pS2jXwfgD+74BQD++u1L690EE3e9AMD4nmMAZNNZUl/fzpr3P8PaX5r+bv9y3e2G5cqjO7jRbGZq+056Nt7HL20ITpHxzH7Wrr6dNYnpMy+/W3/j2XB7idba98yx3BJ8YeZqZ8/WrUHp2ejxUs9AgeswniFwXewZWFTX056BQteN8AyhXDfKc27dPVu3blWmizP9zH4AZVqZrp0WzPS0Z1Cma0aZVqZroNGZBl5pjHkdcAZBff/3rLU/rLU/zh3R9xJrIdP02j/hAnLtB/LsD3LtB/LsDw66ttb+CPjRfN6rgb4rhDxSIFoIufYDefYHufYDefaHCLnWQN8FrIVMuNo/0SLItR/Isz/ItR/Isz9EzHXdA/1tdgcAN/ds5oQbfsYywA70M94X1IvZ/S8CcO47fiV4Q279Wjn20jHsVDCTUKI9TmZiismRCZ7fnqLv9p10HLgRgOQHFr72b5rYsm5G+1/J+ERQ77ZizR5+dPR1EIPXrRuov0FHv1Tb7I4Sz0CB6/l6hlnXxZ4BJ12H9gxOulamSz0DyrQyXRsOuq4l0zOeQZmuBQc9gzINfmQ6DDqi7wrZSvdKEJFDrv1Anv1Brv1Anv0hQq410HeBiO09iirItR/Isz/ItR/Isz9EzLUG+o5gG3MTBtECyLUfyLM/yLUfyLM/RMn1vAf6XV3w1N2HOaPjAfrfeiqd5wU32Y296i8B2Gb/cl7tjo5M0b1q9pTJs/cPk05bli01pI6kSLw4AuTuPLAIdHXC1J5heobuonfpCbkXl/C6rvsh/ob5Nerw3mOxZ6DA9Xw9Q6HrfM/Aorvu6gx+FrgO6xlayrW3me5aAqBMzwNl2i2qZbpRnkGZXmyUaX8yPR90RN8VIlQPJuZArv1Anv1Brv1Anv0hQq410HeBiO09iirItR/Isz/ItR/Isz9EzPW8B/qvP7iDly4/j56tqzEXXsAv8k3MmutCd+jMj7yCQz/cBUD32h5OOifNxPAE40cnGd41wsAVJ4XeRhi6uuDlW59n6YHjtF9xzszr5oJPz79Ri7M3Zyj2DDTcdbFnYNFdd3UFP4tdh/IMLeXa50z75BmU6VC0kGtlOgQt5BmU6VA47Ho+6Ii+E0Rr71FUQ679QJ79Qa79QJ79IVquNdB3AWsjtfcoqiDXfiDP/iDXfiDP/hAx15EZ6NuXvwKAWf6+pm1j4q/e1pyGLZCZak7bEWPaMzTPddM8g1zXgTLtBy3tGeS6DlratTzXTEt7hsi5DjXQX3fbg43qxwzJD/4Lqz44+zxXgsXBd11M3ytXEz9vS8O3WQ/LlhkyY2nGXxjBfvuBmdc7LwjTqtuniZrhGQpd53sGFt31smXB9GHFrsN5Bh9dt2Km5Xl+KNPuoUzLcxiU6dYnMkf0WxoLdio6UzmJKsi1H8izP8i1H8izP0TMdWyxO9AI0l96z2J3IRzWQjpb/SFa3zPM7VoAEXCtTNdEy3sGZbpGWt61Ml0TLe8ZIpfpljmiv+Kb95K99TqmHnwKgMRZhcuz//VfAMR/5X1N60N2eIJMBp59bAweG+N1+3c0pF0L2AjdnCEMK755L0BF19OeoXmupz2DXDcTZdoPas30QngGuW4myrQfKNOtRcsM9CNNFpiMzoUfogpy7Qfy7A9y7Qfy7A8Rc62BvhPYSO09imrItR/Isz/ItR/Isz9Ey3XLD/TTX3w3JFv8UgNLS9Z9LSSR8AxyXQORcC3PcxIJzyDXNRAJ1/I8J5HwDJFz3VID/diV15e9etgk4/zLu4KasW1N3Akb3nGYI0cssUZ/jyN2hXcjKOc63zM0z/W0Z0Cum4wy7Q9zZXohPIMy3WyUaX9QpluDlhroRxZrIR2dejBRBbn2A3n2B7n2A3n2h4i51kDfEaJUDyaqI9d+IM/+INd+IM/+ECXXGui7gLUwGZ16MFEFufYDefYHufYDefaHiLlu+YF+8oP/AsC2X2/+tp77+VFisSbcGdmCjdBpomawGJ5BrhcDZdoPlGl/UKb9QJl2kwhcHt36WBucJqr2mAtjzOXGmB3GmGeNMZ8os/wyY8ywMebh3ONPmvJhRFXmcl0Lcu0+yrQ/KNN+oEz7Q9Qy3fJH9CPB9O2W54kxJg78PfAGYDfwc2PMzdba7UWr3mWtvWr+HRWhkWs/kGd/kGs/kGd/iJhrDfTroK0NeroNyzctaXjbIadyuhB41lr7PIAx5ibgLUDxl0rUwLRnQK4jjjLtB8q0PyjTfqBM145Kd1xgeiqnag8YNMbcn/d4f14La4GX8p7vzr1WzMXGmEeMMd8zxpzRxE8kKjGX6+qeQa5bA2XaH5RpP1Cm/SFimdYRfRewNU3lNGSt3VphmSnfagEPAhustaPGmCuBbwOb6uuoCM3crqt5BrluDZRpf1Cm/UCZ9oeIZVpH9F3Agk1nqz7mYDewLu/5CcDegk1YO2KtHc39fiuQNMYMNvJjiBqYw3UNyHUroEz7gzLtB8q0P0Qs0zqiXwcXPPNU09oOWQ/2c2CTMeZEYA9wNbAtfwVjzCrggLXWGmMuJNjJOxRmo1GlmZ5Brl1CmfYDZdoflGk/UKZrRwN9B7DWMhXiCm9rbcYY8zvA7UAc+LK19gljzHW55dcD7wQ+aIzJAOPA1dba6Nz6rUWQaz+QZ3+Qaz+QZ3+ImmsN9OfJjWZzwfNtdse827IWsplwN2fInfq5tei16/N+/zzw+VAb8ZR812E8g1y7jDz7g1z7gTz7g1xXRgN9F7A27Gki0SrItR/Isz/ItR/Isz9EzLUG+i5gIRviNJFoIeTaD+TZH+TaD+TZHyLmWgN9R6j1tsqi9ZFrP5Bnf5BrP5Bnf4iS66YN9KvVsBcvq5ew9VdhCdv/YsJe+LGYzHWtglwXElXX8lxIVD2XW14vcu0G5f4OynRlWtUzKNP10squy6Ej+i5Q2404RBSQaz+QZ3+Qaz+QZ3+ImGsN9B3ARqweTFRGrv1Anv1Brv1Anv0haq410HcCi81G50slqiHXfiDP/iDXfiDP/hAt13UN9A8/8Pi8a6EaWUNVqa2FqBNryud3bO/RFc+V2mtZzyDXdbbVsq7lua72WtYzyHWdbbWsa3muq72W9QzOuQ6LjuiHpBFfZmshG6F6sKgi134gz/4g134gz/4g16VooO8C1kZq71FUQa79QJ79Qa79QJ79IWKuvRroN/p0VcO2E7HTRIvNQnme17bkuqEo036gTPuDMu0HznqGyLn2aqDvKpZoTeUkKiPXfiDP/iDXfiDP/hA11xrou0DEbs4gqiDXfiDP/iDXfiDP/hAx1xroO4AFIjSTk6iCXPuBPPuDXPuBPPtD1FxHaqC/kHWcDd2mhUwmfDO+sBieG7Zdua4LZdoPlGl/UKb9QJl2h0gN9FsVC0SoHExUQa79QJ79Qa79QJ79IWquNdB3ABuxvUdRGbn2A3n2B7n2A3n2h6i51kDfBWy06sFEFeTaD+TZH+TaD+TZHyLmWgN9B7BEa+9RVEau/UCe/UGu/UCe/SFqrjXQd4GI7T2KKsi1H8izP8i1H8izP0TMtQb6DhC1ejBRGbn2A3n2B7n2A3n2h6i51kDfASwwNRWhS7xFReTaD+TZH+TaD+TZH6LmWgN9F4jYaSJRBbn2A3n2B7n2A3n2h4i51kDfAaJ24YeojFz7gTz7g1z7gTz7Q9Rca6DvAhHbexRVkGs/kGd/kGs/kGd/iJhrDfQdIGoXfojKyLUfyLM/yLUfyLM/RM11bLE7IAKytvpjLowxlxtjdhhjnjXGfKLMcmOM+dvc8keNMec143OIuQnjGeS6VVCm/UGZ9gNl2h+ilGkd0XeAsHuPxpg48PfAG4DdwM+NMTdba7fnrXYFsCn3eCXwxdxPsYDItR/Isz/ItR/Isz9EzbWO6DuAJagHq/aYgwuBZ621z1trJ4GbgLcUrfMW4Gs24KdAvzFmdaM/i6jOXK5rQK5bAGXaH5RpP1Cm/SFqma7riP5OJoZ+lad3NaMjHrGh+IWdTNz+nuzTg3O8r8MYc3/e8xustTfkfl8LvJS3bDele4bl1lkL7CvTH3luDPNxXc0zyLWLKNP+oEz7gTLtD85nOix1DfSttcsb3QEB1trLQzZhyjU7j3Wm+yPPTUKu/UCe/UGu/UCe/cE112FR6U402A2sy3t+ArB3HusI95FrP5Bnf5BrP5Bnf3DKtQb60eDnwCZjzInGmDbgauDmonVuBq7JXel9ETBsrW34KSLRdOTaD+TZH+TaD+TZH5xyrVl3IoC1NmOM+R3gdiAOfNla+4Qx5rrc8uuBW4ErgWeBMeDaxeqvmD9y7Qfy7A9y7Qfy7A+uuTbWNqUkSAghhBBCCLGIqHRHCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiiAb6QgghhBBCRBAN9IUQQgghhIggGugLIYQQQggRQTTQF0IIIYQQIoJooC+EEEIIIUQE0UBfCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiiAb6QgghhBBCRBAN9IUQQgghhIggGugLIYQQQggRQTTQF0IIIYQQIoJooC+EEEIIIUQE0UBfCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiiAb6QgghhBBCRBAN9IUQQgghhIggGugLIYQQQggRQTTQF0IIIYQQIoJooC+EEEIIIUQE0UBfCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiiAb6QgghhBBCRBAN9IUQQgghhIggGugLIYQQQggRQTTQF0IIIYQQIoJooC+EEEIIIUQE0UBfCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiiAb6QgghhBBCRBAN9IUQQgghhIggGugLIYQQQggRQTTQF0IIIYQQIoJooC+EEEIIIUQE0UBfCCGEEEKICKKBvhBCCCGEEBFEA30hhBBCCCEiSKKelQcHB+3GjRub1BU/eOCBB4astcvzX1vSf7rNpI9Xfd/42Iu3W2svb2rncshzY5iP64X0DHLdCJRpf1Cm/UCZ9odWyHRY6hrob9y4kfvvv79ZffECY8yu4tcy6eNsOfMPq77voZ/99mDTOlWEPDeG+bheSM8g141AmfYHZdoPlGl/aIVMh6Wugb5oDsZALKkqKh+Qaz+QZ3+Qaz+QZ3+ImmsN9F3AGEwyvti9EAuBXPuBPPuDXPuBPPtDxFxroO8CBkzMLHYvxEIg134gz/4g134gz/4QMdca6LuAIVJ7j6IKcu0H8uwPcu0H8uwPEXOtgb4DGAwmHp29R1EZufYDefYHufYDefaHqLkONdC/0Wye+X2b3RGqjfm+v1nkf7b5EItBNlvjyo5f+BFlz9Ac1xU/p1wvGsr0LFH2DMp0PlF2rUzPEmXPoEyHQUf0XSBi9WCiCnLtB/LsD3LtB/LsDxFzrYG+C0TsCm9RBbn2A3n2B7n2A3n2h4i51kDfAYwhUvVgojJy7Qfy7A9y7Qfy7A9Rc133QD9snVSltm6KbyaWK4l6V3rh68Ma+bnqxhgn68Ea9TfJb+dGE3heLNeL6hmcdK1MNwEHPUNzMn1TPPhdmXYHZboJOOgZlOmm4Kjr+aIj+k0i/6KP/As+ftWU30s0ieicJvKNSq4rIdetiTLtD8q0HyjT/uBzpjXQd4GInSYSVZBrP5Bnf5BrP5Bnf4iY66YO9G+Kb57Zi+rqDH7GYpCYY6s398yetplMz74PZvfK3jnRmFNJ/9a+ufbptZqEafELP/I9w/xcF3uGxrp2wTNEy7WLmf639s0FbS4WUfIMynQ1ouRama5MlDyDMl2NVnddTN0D/UbOrzq4DDKZ2S9ZNhs8MpmGbaJlcHEqp0a5LvYMreF6m93RlFpB11wr083BNc+gTCvT9aNMz+KaZ1Cmfcl0GFS64wIRu/BDVEGu/UCe/UGu/UCe/SFirjXQd4GI1YOJKsi1H8izP8i1H8izP0TM9bwH+g+dtoXRUVjSC1kLqVTwAHjtvqe4Y/WWRvWxLNPtJxIwMWGZnITJyaAvAG8fD05n/efgZpJJU3A6amLC0t7ujkRjIO7oFd7FnqHQ9UJwx+otBZ6h1HU5zxDOdVNOB7aQa2V6/rSSZ1j8TE/nWpluLNUyvRAo0wuDMt1YXHY9H5p6RH9JL/T1GSYmLMYY2tqCWq+pqcB8PG6AQHAiEVzg0dFR2MbRo9DfH7xv+gGNqxnr74ORY4WvlbsYJBYr3eb0lzV8XwyxFq4Hy/cMlLjO9wyUdZ3vGRrvupxnKHVdzvN0nxvznYuOaxcz3d8X/AyTaXmuL9PT/w4q062JMl0r0fEMynR1Wtt1MSrdcQBjIB6hejBRGbn2A3n2B7n2A3n2h6i5rnug//xrzp5znUPvffW8OtNI7ju5uWUG9XBrf3Bq6cqjFa6ONzi591iLaxdwzXVFz+Cka2W6fpTp5uKa6yhm2gVc8wzKdLNwzXWrZToMoY7on3zeEtp6kqSOTNDWkySbtSQ7gybPvHQpJm4YOzjGVCZLZizD2LEpOrtjJHLrZNNZ0uPBeZbpUzPt3YmZiyCy6SyTk1O0JWF0FNraYMVyQzY7W6udmoCeHsPYGBw7ZslkCk81rV1jaOuM09aTBODovhRtywypiWB5W1vQXnu7IZsNTmGlUsHpn+k5Y6f719GRqy/M9bUtaLLsqaIN64NTZLXUyBkMiRD1YMaYdcDXgFVAFrjBWvu5onUM8DngSmAMeJ+19sFa2s/3DBS4zqazBZ6BEtf5nqHUdbFnKHWd7xlKXRd7hkLXxZ6hvOt8z/l9bUtWPiUYVdetmOm2ttx2QmTaN88QLtP5p9Xnm+ljx4JyAmV64TKdTQd/CGU6ep4hGpmeLh8Lm+ltdgd3b9gSGdf1otIdBzAGEuFOE2WAj1lrHzTG9AIPGGO+b63dnrfOFcCm3OOVwBdzP8UCItd+IM/+INd+IM/+EDXX0SlCamVMcHOGao9qWGv3Te8JWmuPAU8Ca4tWewvwNRvwU6DfGLO6GR9HVGEO13Mh1y2CMu0PyrQfKNP+ELFM1zXQn9ixfe6VRN0YY0gkYlUfdbS1ETgXuK9o0Vrgpbznuyn94s3QKnV/rcZcrutsayMhXSvTzUGZ9gdl2g+UaX9wLdNhqbt0Z2piCoD1WwfJprPE2xPEkmm6V3WT2LBkZj2bmsIkY3QPT5AdS3PspWN0jE7S0d9Be197sPG+dsb2HCMzMUVmLEOiK4HN1WQBjO4dZfnaNjoGOhg5NgJAKhUsb2sL1unsjjF+PEtXF4yPz055Gcu5yGaDPbP0WIbjwxnGxmHp+i6ye4Ni77YkrNrYyeG9KTIZGB019PYG7ztyNNhWzEBmKvgZy3P81rHgYo6b4psLatqmb0n9wOYtwOznqYQBYnPfnGHQGHN/3vMbrLU3FLRjTA/w78BHrbUjZTZTTNXOTU1MlXgGClwXewZKXOd7Bkpcl/MMha7zPUOp62LPQIHrYs9Q6rqSZwhcV/IMDXU9p2dorOsoZXr6upkwmb4pvnlmO9Mo05UznRkLAhUm0+PjwXJleuEybVPBOsq0Mu1qpkdHgz9HIzJ9ya6nWjrTYVCNvguYmi78GLLWbq3chEkSfKH+2Vr7H2VW2Q2sy3t+ArC33q6KkMztuqrnoAm5dh5l2h+UaT9Qpv0hYplWjb4DGMLV/uWu3v4/wJPW2s9UWO1m4BoTcBEwbK3d19APIuZkLtdzvl+uWwJl2h+UaT9Qpv0hapnWEf0Q3LF6C6/d91TN6+99y4XlF4S/wvsS4L3AY8aYh3OvfRJYD2CtvR64lWAap2cJpnK6NswGfWP6Vu61UNEzyLXj1OMZlOlWRpn2A2XaH5Tp8tQ10I/FDctOWwpA59pe7JQl3tdO9znLYcpiU1MzNWFTh1PE+tsxHXHs7lE6+jvoWtbJVDpLYiCYVDW5YQk9fe1MHTjO5GiazFia1Ghqppa7a0UXU6kMmbE0K9cFxX4n3fkoT56zZeZmBnbKMjYOO18ISpvyaywBnjxnCyZuaOtJ0t7XxtiOMUb3j9HeHXz0WDLG0lOXEksepWt5F8O7RkiPpkmlLF1dwTaOH7eMjkJPD3R2GsbHg1uFT3P1VPkbL5y/Y3Yn4OhvXcbYy2Nl1zMhb85grf0J5eu98texwG/X2mbHQAcdA+2lnqHAdbFnoMR1vmegxHU5z1DoutgzFLou9rzutge598QtM66LPQMlros9AwWuK3mGWdfVPIN7rqOW6VjuH+cwma7FMyjT+Z6B0Jmey7My3dhMTx0OJhRXppVpVzM9vCsoa/c902HREX0HmL7CW0QfufYDefYHufYDefaHqLmOzidZJB45fQuPnB7+1s4mFqv6WEgmn9b0bOVohGeo7losPgvhWZl2A2XaD5Rpf1CmS6mvdCc5+yGzxyYZOzhGe187ydXdZA+ngtMsPw0uGk4dSdG1ootkZ4L9jwyRyQRTIXX2JliROxWXHZ0kPtgJccPhpw8zdjRNV39y5mKHtu4kieVdZNNTtPXMniqKJ2P0ntA783zzg/dxcYU+t/UkSbTHyaazbPjhwzOXOO++MrhgumdND5Ojk/Rt6GN41zBL1vVyfP9xenvayOSmoUqPZxg9nCaRCG7B3NVp6B1s49jQZM1/u/bV3bQNdgaXXxRhjAlbD9ZwelZ1M5XOlngGClwXewZKXOd7BkpcV/IMha7r8Qxw8c7gNN3uK7eWeAZKXBd7hvpdz3iGlnAdtUz3rOkBUKbL0KxMH376MIAy7Qi1Zjp1JCjdUaZnUabdyvSSdUGbvmc6LCrdcQFDpE4TiSrItR/Isz/ItR/Isz9EzLUG+g5ggJiZ/4UfonWQaz+QZ3+Qaz+QZ3+ImmsN9B3AGEMyQnuPojJy7Qfy7A9y7Qfy7A9Rc13XQN9mLZ0bc1PtHUnRvbaHkV0jTDx7hKP7cvV+vcHdxBJdCaYmphh+fpjURFAP1tMNx45mWJFr74Fv7SGRgFXrkvRtWMKq8zoZemKIZK7+q3Owk1h7nFhfO9ncdE8A6Yksx/cfr6nPJ//ksbKvD160GoDY0k6mhsYYfnyIoV1jjD4xxpJeOPVta7Dp4D7Ksb52ssMTTB5OEYsb4u1xJkYmGDil9i9C56dvYfyP31RxeZipnBpNcIvqNN2bBko8AwWuiz1Dqet8z0CJ60qeoXbXlTxD4LrYM1DiutgzULfruTyDW66jlunY0qDuUpkupJmZ7stNv6pMu0GtmU50Bf/9K9OzKNNuZXr0iSDXvmc6LDqi7wDGQCIenb1HURm59gN59ge59gN59oeoudZA3xGitPcoqiPXfiDP/iDXfiDP/hAljFG9gwAAIABJREFU13UN9BOD3dhscMezznecw7O/dwvr3riR/ffsYWBtJ8metpnlD/94mI6OFCMjkJqAtjYY6DesWW342beC6fpGRyEzBYcOTcLDQ8E6A4YN5wZ35HvuR3s46dI1JE7snzk9B3DGo08Rlo4/+Q4AUzdew8u372TgjEEmjqQYTMaIJeMc3X5oZmqnPffsYe0VJ9F96gCxvnZMdwfJHS8z+dzRurbZ+elb4M9KvzzGGJJxd75UiZ4kA9duZeLOZ0s8AwWuiz1DqesCz1DiupJnaJzrYs9Aietiz8C8XHd++pbgl1ZwHbFMT914DYAyXURTM/3w0Ow6yvSiU2umH/5xMCWpMl2IMu1OpgdzU1z6numw6Ii+AxiitfcoKiPXfiDP/iDXfiDP/hA11xroO0DU6sFEZeTaD+TZH+TaD+TZH6LmWgP9BSLz1V9j+AcvVFwepb1Hn5nLM8h1VFCm/UCZ9gdl2g98y3RdA/3jLwyTWB3cjvrQ5+/mlP9+MeM/fpHOZZ0MXLiaQ3fvoX/zUgBGvjvMyDHo6gymRlq2zLCkF44OW3J352ZsPLgFcyYD/X3Q12dYd+YS0qNBLffmqzcRXxncznmmnqrBmMEljB0cY/f2nQwPW86/YjmdK7p47vYXSR0N6j5HDqXp+OleVl97Juas0wFou/J62qo1XE8fHJuz1aaz3Pebt7H1E+eUeAYKXBd7hlLX+Z6h1PVieAZKXJfzDNF2HbVMm8FgWjhlupBmZrq/L1hHmXaDWjM98t2gRl+ZrrEfjnn2IdPnX7E82J7nmQ6Ljug7QNROE4nKyLUfyLM/yLUfyLM/RM21BvqOEKXTRKI6cu0H8uwPcu0H8uwPUXLdMgP97E8+DkDs1X+9yD1pPMaYSO09hmHaM8h11FGm/UCZ9gdl2g+U6dairoF+91lnkvzATQAs/wDsefMFDD13jKXru9j+j08yMgJd20eAoBasLVcwFYvB8eOWAweCeVqzuSlYE7mtbzrFkEoFt2NOHUlhcvOXZkfTZEeP0vnBX8Lu2duAj1vK+Pd2sPys5Qz9cD/JpCE9niE+PMlpH98KU0FHN6wfxJxxJkyOA2A2/G7d25l89CAHHxsqu8y1qZxi607l4vvvB0o9AwWuiz1Dqet8z0CJ68XwDJS4brZncM911DI9/r0dwWdRpgtoZqZTQYm0Mu0ItWa6KyjlVqbzUKbdynR6PLiwz/dMh6VljuhHGWMgGaG9R1EZufYDefYHufYDefaHqLmua6B/+IHHublnMwDLlxvWn9nblE75h3Fq7/HIg49zU3wzXZ3y3Hjccq1MNwu3PCvTzcQt18p0s3DLszLdTNxyHZZQR/RffPwYF+8Mbn08dt5pPPNslo72XMMJOHwEOjogEQ++iCee1s4D96Rm3t+WhLVrDVvefhKmPQ7Ay/fsIdGZBKDzA28AwKzZDAOrwnS1It2f/T5jf3A5L79sOe2MBB39HSz5tfOIveZN2B0/B8BuuYTJbCdpG5zr7JnHdrr+5j85uHZL2WXBFd7ufqnyPUOh62LPUOo63zNQ4noxPAMlrpvtGVrLdStmuvuz3w/6rkxXpZGZnvYMyrSLVMr0dKmGMj2LMu1Wpjv6OwCU6ZCodMcRIrTzKOZArv1Anv1Brv1Anv0hSq410HcAAyRi0akHE5WRaz+QZ3+Qaz+QZ3+ImuvQA/0bzWY6OuCM06LzR2kkd6wOTg8dOWpZtrT8LqIxkHR893HaM8h1Je5YvaWqZ2gt1/JcHmXaH5RpP1Cm/SEqma6Hugf6Y8GMRux60c5MvwXwyGNZslkYPZ5rOBHUg01OwiQwPGxJ7J7g1W8eYMe9RwHo6YENW5cFb4jHaDtrBSt720icvBQA+8RTxH75HwAw7fP7gLXQ9Ve30falzWy4egu7v/UMSzraSdNLoj/oR9YmydokcTJ0Jl4x7+3s2WsrLnPpO2UtYALXxZ6h0HWxZyh1XeAZSlwvhmegxPVCeAa3XIMyrUyHzHRudgpl2h1qyfR0jb4yXYgyjTOZ3v2tZwCU6ZCodMcBDCZSp4lEZeTaD+TZH+TaD+TZH6LmWgN9BzAmWnuPojJy7Qfy7A9y7Qfy7A9Rc133QL/49BAEdzpNJAqXZbPM3F2tqxPOvKiXl3eOMnEkxem/EJxq616/hK7/+VHskb1k/v126O8jefUFmIE18/owYZl4+girLlhFdvsu4oe/jAViV15PYuJWEsn5navat7/66aFpEiG/VcaYLwNXAQettWeWWX4Z8H+BnbmX/sNa+z8qtVfJMxS6LvYMpa7zPQOL7nri6SMAJa4Tv3jCvD3DwrhutGdQputFmV5a6hmU6XmyWJme/qlMK9OuZnrVBcE0nsp0OHRE3wEMEDOhdx+/Anwe+FqVde6y1l4VdkNi/jTA9VeQZ+dRpv1BmfYDZdofopZpDfQdwBgT+kiBtfZOY8zGhnRINI2wruW5NVCm/UGZ9gNl2h+ilunoXG3QJCb+4q0Fz3/w4mF+8OLhhm8nZkzVBzBojLk/7/H+eWzmYmPMI8aY7xljzmjwR4gU054X2jXy3HSUaT9RpqOLMu0nynRtNOyIfiZT+Dy/dmxsHMYPjdPdE6NtSTt9rwrqvRIbB7AP3oU5/1ISr9+KWbsJO/QS9uBOzPoPN6prNXH54R0A2Ic+RfbZFzCbNzH5zbsAmPjMDRz48DcYaH+hKdsObs4w597jkLV2a4jNPAhssNaOGmOuBL4NbJpPQ/muiz1vszt45pVnFLjO9wwsqutpz1DG9SPN9Qw1uXbSMyjT9eBTphOvDz6CMl0R5z2DMj0XyvTCZ9o+9Kmg/8p0KHRE3xHipvojLNbaEWvtaO73W4GkMWYwfMuiXuTZD5Rpf5BnP1Cm/SFKnlWj7wDGNP92y8aYVcABa601xlxIsJN3qKkbFSU027U8u4Ey7Q/KtB8o0/4QtUy7O9BP38a1/9ALwD9+6JJF7kxzCW7OEHrarm8AlxHUju0G/hRIAlhrrwfeCXzQGJMBxoGrrbW1zTPVZK79wt1A9D1DeNet7FmZrrONFnatTNfx/hb2rEzX2UYLu1am63i/Y57rGuh3dxm6cl2ZvsV2QWNF827HYrNztm667wl2vvYVLL14DYmTgtss3/Tm/+Lq71yGSY3CwEqynctg3TJimePz+jANYeUqYitWgjE8f92NAGwfGoV9x3jH+p2ctzL3gVhaU3Nvvm4tAOnxNC8/OgQPlVmpATdnsNa+Z47lnyeY7mlOOjrggrMTPPFYpqxnKHSd7xlKXRd4Bmddl/cM9bie8QxNcd1Iz6BMK9OzzDvTAysBnHStTJcuV6ZLUaYdzfTKYB593zMdFneP6HuEwRI3Tuy0iyYj134gz/4g134gz/4QNde6GNcRjMlWfSxcP8yfL9jGPMUFz0E/5LqZKNP+4ILnoB9y3UyUaX9wwXPQj/Cu6zqi3zbYyRvfcxIA7eeuYPLxIQ4/fJCh546x6aqN2PQUj377JQAOHAj2hq4amZ36bNWl64j1tjH10lGSH/wXtllITT1E+6GHMMtPxN7ydQDsVdsA6B/sDvv56sasuW7m99Omvg/AQMe5wQvtV9Z4cmiWic/+EwDjU/1s+v5H4G1PlW4TS9yk59XfJnB518mDbPyNs1i7c7jEM1DgupxnKHS9ze6Y8QyUuF4Mz1DqOoxnCFzPeIaWcK1MK9MQLtNm+YkAyrQb1Jzpac+gTCvTbmY63zP4m2ngk2EaUOmOE1gMC7uXWIX4Yncg2si1H8izP8i1H8izP7jl2hgzQDC9fwnW2jnvFqaBvgM4tve4ZbE7EGXk2g/k2R/k2g/k2R8cdP0A5Qf6FjhprgYWbaB/o9kMwNszNy1WF+rm4aFROhNxTh3/J/7bd84G4Evvvyh8w4YFr/uqwnbgnEY2eKPZ3JKeAbmuA2U6jwh7BmW6gAi7VqbziLBnUKYLcMy1tfbcMA3UNdA3Swf4/9u79yg56/qO4+/vbkKu5J5ACCEECVC5CCEJCBUsFeVWEUQusVysHhsoUiv1Aqetnuppa71VQcjheDjgoYjQWsrRSFpAJUKEABaEwEJCgNwhkGzIbZPd/fWPmU1md2fn9szs/J7n+3mdMyc7O7PPPMt7v5zfzDwzM+LK0wEIK1cx/LpPMGrsaRz04l0waTJdi5cw49V2ADb/pr3/z//912l94h7uOfX+vd8b3noC//L8KL48/m7ue88/AnAJubd2OuGodbX9VnVy95BrAZjfeTMPrT2RSSOr38bE7Y8AsHHk2bx7zg3A7UWuFWixziLfb44wfAxDL72AIetW9e8MvVoX6wz9W/d0Bvq1bnZnyLVO0hlyrfd1hjS01kxXvw3NdO+Z/vL43NsbaqbjUOlMV9oZNNM5cXXWTNe2jTTOdFJ6151IGF0lT4Po+4N5Yx5F0hnUuqE0035E0hnUuqE0035E0hnq0LrpC/3v//bVft/79MKlfHrh0ibsTfWuuXMZ19y5LNE2cseDdZY8DaKVjdhosc5AajoDiTtD+daDbNBap22mk9JMp4NmujKaac10WmRxps3sir37ZvYfZvZI/nRGJRuo7hj93buwGbnXgISjTqUzDGPj1qm8degXeey1d7jy2HUMfzT3VnzHntz/rZiGt57A4zMPA+7v9f3L5s3gDW7gktHD+OLPntv7/Yn7D6tq9+ptftj3VlTHTd7IE+u7OfvQFSzdeQmHH76RN1YXfzqs0P9uOxeAk8ds4q2dhxS9jhFoieeFH1+zzl2ENSuxme/t1xno1bpYZyje+rJ5MwD6tW52Z9jXurAzUHXrUp0hvtaaac00JJvpN7iBGaOHcQloppuv4pmupjNopmPrrJl2NNPwuYLzRwJXAaPIve3mI+U2oHfdiUKI6YUfY5q9A9mm1j6osx9q7YM6+xFX6xDC8oLzr4QQngYws3+uZANa6EeilWhe+DGu2TuQdWrtgzr7odY+qLMfsbYOIVxYcPaASjbQ9GP0C931/Ppm70LNbv/9mpp/1ixE89HaQP+PiWuAtLZO0hnKtx5kDW+d5s6a6eqkuXUSmul00ExXL82tk4htps3s3P77aOcBbUWu3091j+iPmEoYOR6Atdtn8+S67YwfvosTD3ibq459nSdm3cfsL+Xe2rU7f1xvX6dMHcspBcfU/dNDL7Ny846956eMH8HmTbnz3/n2EgDO/eHHqtrNRhjzrc9w/PX38Nzbx/DYS+u594aH2P+oiQBc+flTB/y5D8/o+ZDmCYwZOtC1ovpwhi8wZMJ5dvSNBH7TrzPQq/VAnaF3676dYV/rWDsDvVqX6gw9rUt1huhaj5h6nmb6mBo6g2Z6X+cZo3PH72qmm67ima60M2imcyLrrJn2M9PwczO7CHgm/70TgVOA8yrZQFSP6HtmdJc8DZYQwiuDdmNOxdAZ1LrRNNN+xNAZ1LrRNNN+xNAZ9rY+DlgCHJo/PQocF0J4uZJtaKEfgZ5XeJc6Ddq+mOmjtRuoXOtB3Re1bhjNtB+aaR80037ENtMhhI4Qwu3AjSGE60MIt4cQdplZRR8DnIoX435vyUo2bdnFaytyT0n9+9+c1uQ9Kq7n/VtvuXJulT8Z1Su8727WDfd0BqJuXXtnUOsczfSganjnlVt3Ff2+ZnrQaabL0ExXRjMdVevZ+a+XFnwNcEuf80VVvdB/8LXcMVH/9dDzXHvBMTy8fAMffPHf6HyznXmP/S10516pPPHPwA5aUHZ7N37oCO5re5PZU8fw4tp2Tn/vgazZsA0AazHGHlD8/V8H2/AbP8fuHa2sfXcbQ4a0cMi5s9i5PXfPbsnS15l52MRE27fuaF7hbT1fPPjaMf06A71aV9sZ6Nc61s5Ar9b16AzxtdZMb+vXGdBMl1HYGaB9W4dmuvkqnulKO4NmukdsnUEzDT5musjXxc4XlYpH9LMvQIjm3mNo9g5km1r7oM5+qLUP6uxHtK37dq/o7yCVx+g/unZLs3ehpF+seru6HwhAd1fp0+A5eDBvrJyYW/9i1dv1bz24omkdc2fQTNdTzK010/UTc2fQTNdTzK2r7gzRzbSZ/cDMbir4uuf8tEo2UPUj+qffdBkAOxbcxSvvbOfyucOxZ8cSVm1i9ehPAnDI6BFVbfPJFzYwfexwPnrsZO5/9k3eXLcVgCmHjuMn15/Owidf54oPHMbCnXu44NRDq93luvj9sdfx9uLHaTHjjfXv0t0dGDqsFYBZR0zm4Cmj+cKHuvjN6gNr2HqArmieJvoicAfkWvftDNTc+skXNgD0a923M9C01oWdgV6tk3eGGFtrpq1fZ0AzXYGezoBmOg6aac00oJnO2Ez3eKrPZX3PF6VDd2IQonqaaHuzdyDT1NoHdfZDrX1QZz/ia/3zEELxV0dXQAv9WMRz7/GTzd6BzFNrH9TZD7X2QZ39iKv1LWb2IPAT4H9CCFUdP5TKY/SzJ+TvQZY4DdaehHDBoN2YS3F0BrVuLM20H3F0BrVuLM20H3F0hr2tDwceBq4DVpvZrWZW8XuaVv2I/v3fzb1N1fxv/I6H3vpjJnX+Fo4+kZZ55zKio+cFGdUd+/etC48D4MXNO7hiThfPPj+s1+UL5s3g4m/+ir/7zDxueeAFAE771Lxqdz2R9esDcybvwayblnnT2X3iNHZ05O5ULVm2mo/Pmc7Ix7/L5gnXV7/xwN63MIzJ/d99vV9noObWPZ2heOuezkDTWhd2Bnq1TtwZomytme7u1xnQTFdAM02UrTXTmmnNdHZmOoSwFbgTuNPMJgIXATeZ2YQQwvRyP69Dd6IQCPEcDyYNpdY+qLMfau2DOvsRZ2szGw9cCFwCTAD+s5Kfa9ihOzc9voqbHl+VeDsrt+7ikdWb67BHEQv5V3iXOpVhZreb2Ztm9vwAl1v+LZlWmNlzZlb009TMbP9qdl2dq1SudRn16py/rlo3imbaR2dI7Uz3dFbrCmmmfXSG6GbazC43s0XAi8Bc4BvAISGEz1fy69T8iH7YsJL3TPowobMDdrTT0vYsrxz0BQAmT61tm380fiRwOD/67OEAtG3Zufey6y6fzeMrN3H80QewYN6MWne7Zlvaofvy8zngB1cxdthl7NfawqzpGwE49ZBj2K91O08d+VWOAOYdUNUM5iQ/7usO4GbgxwNcfjYwK386Cbg1/29fvf5v0Lcz0Ks11PZC8MLWfTsDTWtd2Bno1bounSFp6zuoT2co09rrTJ96SO5TRTXT1dFM1+wOmjDT9egMmukq3YFmOjGHM70YuAXYCHQAbSFUvoN6MW4UQu54sFKnclsI4VHgnRJXOR/4ccj5HTDOzIot3w6r7XeQypRpXe6n69cZ1LqBNNN+aKZ90Ez7Ed1Mv0XuTsNCcsfqv2pmXwEwsxPK7Y+O0Y9BALrLHg82ycwKPxzhthDCbVXcyjRgdcH5Nfnvre9zvW9UsU2pVvnWg9UZ1LpxNNN+aKZ90Ez7Ed9MjwBmhBDeBTCzMcC3zexW4CxgZqkba8hC/8XNOxL9fPeD1+S+OPk7RS9/dO0WTps2LtFtxCVUci9xUwhhToIbseI33M85CW6jat0PXjNgZ3DZerA6QxWtNdPV0kwPxGHrKGc6Kc10UZrpTIhupmcVHqoTQthqZlcDm8gdBlRS1Qv90aNy/3Yv/T0zz/1vGDGWXfsfxVMcBgEmjhgKwEXHj6120/3MWv412NXBoRveoeWE9zLz6GtYuaU5r4SeH9pYNO5Ihhz3Pc785Vq2HT+fR9dMAeCc/e9j3YiPsX5b/ji4ao8JCwG6qvr8g1qsAQrfhulgYF2R6+39Dzx6VP/OQK/WjegMNK11YWegV+vEnWEwWlfaGfKtNdPf69cZ0EwnoJmuq4bMdD06g2a6zjTTFfA208WOxw8hdJnZW/lDf0rSMfqxCN2lT8k9AFyRf7X3yUB7CKHY00TL63FjUkIcnUGtG0sz7UccnUGtG0sz7UccnQGWm9kVfb9pZn9O7l14ytIx+jHoeSunBMzsJ8AHyR07tgb4KjA0t/mwEFhE7imgFcAO4FMDbOqvyL1QRBohYes6dga1bhzNtB+aaR80037EN9M/M7O/AJ4md4jPXHLH7Vf0CcnRLfQ3XHQyUz4z4FuKZlf5F/mUFEK4rMzlgdwfTLntrJ0zJ8mhZ5VT6+rVq3P+uoPSWp1ro5lOEc20D5ppPyKaaeAkMzsDOJrc8f2/DCE8XOn+VL3Q37Y99+9zX3+S9x04gfAnFzO8cyO7OnPvo3rUtrsA+NKvPgDAty6cUO1N0LHkNQB2rn0XgO493ey6azkHffYVpn2k507sR6veblLnbGnjbjuSruWrGH3oE3xkRu5YOF7ZwLSpizloSM8hVn9d3YZDgM6GH/tXtW3b+3cGerVO0hlyrft2Bprauqcz0Lt10s4QZWvN9JH9OgOaac10ZSJsXclM93QGzXRFIuwMmmnwMdMhhEeAR2r52ege0Xcr4SMFkiJq7YM6+6HWPqizHxlqrYV+DEKAzmTH/klKqLUP6uyHWvugzn5krHXVC/35oQ2AB0YfycG3PclEIIwfx86xuePFwoY3ADjh45/I/UD++pV6d/W7hK7cOwkNGdZKZ0cXu7d28OryXYxdvIrhG+8GYOhfDv5Tgj1aJo5i27iT2NmRexpsykFreWTLGdACZ0wfX9tGI7z3OD+09esM9Gpda2fY17pvZyDK1nXpDNG11kz37wxopjXTlYusdSUzvbczaKYrFVln0EyDj5lOQo/oxyDC48GkQdTaB3X2Q619UGc/MtZaC/0YZOxpIilBrX1QZz/U2gd19iNjrbXQj0Soz4cwSAqotQ/q7Ida+6DOfmSpdc0L/ZEj4aXH3uHo4U8z7mNHMGJ27kN2W075JgDzwzdr2u62rV2MOnDfp/2ueKqdPXsCEycYuzbvYsgbW4H8Jw80wcgR0LW2ndGblrD/hIPz3xzDGSOfgtYza9toxPce+3YGerWutTP0bl3YGWh665Ejcv/2ap20M6SqtduZHjkGQDNdA810XErNdL06g2a62TTTfma6FnpEPxbdofx1JBvU2gd19kOtfVBnPzLUWgv9GGTs3qOUoNY+qLMfau2DOvuRsdY1L/Q/9GYbq8+azeg5U7F5c/lT7sUOWpB4h4657n28/fDrAIyaNprDjt9DR3sHO7fspv31rYw/+7DEt5HEyJHw1qJXmbBxO8POPn7v923u12vfaCDat3Lq2xmoe+u+nYGmtx45Mvdv39aJOkOqWnueaU+dQTOdSIpaa6YTSFFn0EwnEnHrWugR/Shk696jlKLWPqizH2rtgzr7ka3WWujHIIRM3XuUEtTaB3X2Q619UGc/MtY6Mwv98NYdANjkqxp2Gx3/ekFjNhzI1IczNFJPZ2hc64Z1BrWugmbah1R3BrWuQqpbq3PFUt0ZMtc60UJ/+oPP1Gs/9hp69U858Op95/OHYPHmxe9n7ElTaZ19VN1vsxoTJxqdO/aw87WthPuf3vv9EXOTbDXue4+N6Ay9Wxd2BpreeuLE3NuH9W2drDN4bJ3GmVbn2mim46OZVuckNNPpl5lH9FMtQNiTnXuPUoJa+6DOfqi1D+rsR8Zaa6EfgxBgT3buPUoJau2DOvuh1j6osx8Za93S7B2ohz0/uqzZu5BIAEJ3KHmS9HeG8q0lJ+2tNdOVSXtn0ExXKu2tNdOVSXtnyN5Mp+YR/Sn3LqV70QK6nnkJgCHH9r68+9e/BqD1E1c1bB+62zvo7IQVf9gBf9jBGRva6rRhYHd2niZKYsq9SwEGbN3TGRrXuqczqHUjaaZ9qHSmB6MzqHUjaaZ90EynS2oW+tmWznuJUgu19kGd/VBrH9TZj2y1Tv1Cf8+tl8DQlB+BFMjU8WCNkInOoNYVyERrdS4rE51BrSuQidbqXFYmOkPmWqdqod9yzsKiLyqwoa389OLcU0nzG3gnrL3tHTZvDrTU++84QOjKzr3HeijWurAzNK51T2dArRtMM+1HuZkejM6gmW40zbQfmul0SNVCP7NCgAy9lZOUoNY+qLMfau2DOvuRsdZa6EciS8eDSWlq7YM6+6HWPqizH1lqrYV+DEKA3dk5HkxKUGsf1NkPtfZBnf3IWOvUL/SHXv1TAOZf2fjbWrlsCy0t7H1Lp7oJ2br32AjN6Axq3QyaaR80035opn3QTMcpAy+PTr+Q/7jlUqdyzOwsM2szsxVm9pUil3/QzNrN7P/yp39oyC8jJZVrXQm1jp9m2g/NtA+aaT+yNtOpf0Q/ExJ+3LKZtQI/BM4E1gDLzOyBEMLyPlddEkI4r/YdlcTU2gd19kOtfVBnPzLWWgv9Kuy3H4weZUyeNabu2074Vk7zgBUhhFcBzOwe4Hyg7x+VVKCnM6DWGaeZ9kEz7Ydm2gfNdOV06E4Met7KqdQJJpnZUwWnzxZsYRqwuuD8mvz3+nq/mT1rZr80s6Mb+BvJQMq1Lt0Z1DodNNN+aKZ90Ez7kbGZ1iP6MajshR+bQghzBrjMim+1l2eAGSGEbWZ2DnA/MKu6HZXEyrcu1RnUOh00035opn3QTPuRsZnWI/oxCBD2dJc8lbEGmF5w/mBgXa+bCGFrCGFb/utFwFAzm1TPX0MqUKZ1BdQ6DTTTfmimfdBM+5GxmdYj+lWY+8pLDdt2wuPBlgGzzGwmsBa4FJhfeAUzOxDYGEIIZjaP3J28t5PcaFY1sjOodUw00z5opv3QTPugma6cFvoRCCHQleAV3iGETjO7FlgMtAK3hxBeMLMF+csXAhcBV5tZJ7ATuDSEkJ03ik0JtfZBnf1Qax/U2Y+stdZCPwZ1+HCG/FM/i/p8b2HB1zcDNye6EUlOrX1QZz/U2gd19iNjrbXQr9HddmSv8/NDW83bCiHQXeGHMMjgK2ydpDOodczU2Q+19kGd/VDrgWmhH4ksfdyylKbWPqizH2rtgzr7kaXWWujHIEB3guPBJEXU2gd19kPQExrKAAAEkklEQVStfVBnPzLWumEL/VKHtvS9rFpJn5ZJKun+95X0hR/NVO4QJrXuLaut1bm3rHYudnm11DoOxf47aKYHltbOoJmuVppbF6NH9GNQhxd+SEqotQ/q7Ida+6DOfmSstRb6EQgZe5pIBqbWPqizH2rtgzr7kbXWWuhHIRC6s/NHJaWotQ/q7Ida+6DOfmSrdVUL/Xeefr7mY6HqeQzVQNsajOPEGvL7R3bvMZbOA20vtZ1BravcVmpbq3NV20ttZ1DrKreV2tbqXNX2UtsZomudlB7RT6gef8whQHeGjgfLKrX2QZ39UGsf1NkPte5PC/0YhJCpe49Sglr7oM5+qLUP6uxHxlq7WujX++mqet5O6MrOvcdmG6zOtd6WWtePZtoHzbQfmmkfYu4M2WrtaqEfqxCguzM79x5lYGrtgzr7odY+qLMfWWuthX4MMvbhDFKCWvugzn6otQ/q7EfGWmuhH4EAZOidnKQEtfZBnf1Qax/U2Y+stc7UQn8wj+Os620G6OxMvhkvmtG5brer1lXRTPugmfZDM+2DZjoemVrop1UAMvROTlKCWvugzn6otQ/q7EfWWmuhH4GQsXuPMjC19kGd/VBrH9TZj6y11kI/BiFbx4NJCWrtgzr7odY+qLMfGWuthX4EAtm69ygDU2sf1NkPtfZBnf3IWmst9GOQsXuPUoJa+6DOfqi1D+rsR8Zaa6EfgawdDyYDU2sf1NkPtfZBnf3IWmst9CMRQoZe4i0lqbUP6uyHWvugzn5kqbUW+hHI2r1HGZha+6DOfqi1D+rsR9Zaa6Efgay98EMGptY+qLMfau2DOvuRtdZa6McgYy/8kBLU2gd19kOtfVBnPzLWWgv9CGTtaSIZmFr7oM5+qLUP6uxH1lq3NHsHJKc7lD6VY2ZnmVmbma0ws68UudzM7Af5y58zs9mN+D2kvCSdQa3TQjPth2baB820H1maaT2iH4Gk9x7NrBX4IXAmsAZYZmYPhBCWF1ztbGBW/nQScGv+XxlEau2DOvuh1j6osx9Za61H9CMQyB0PVupUxjxgRQjh1RDCbuAe4Pw+1zkf+HHI+R0wzsym1vt3kdLKta6AWqeAZtoPzbQPmmk/sjbTVT2iv4qOTZ/k5dcbsSOOzOj7jVV0LL6s++VJZX5uuJk9VXD+thDCbfmvpwGrCy5bQ/97hsWuMw1YX2R/1Lk+amldqjOodYw0035opn3QTPsR/UwnVdVCP4Qwud47IBBCOCvhJqzYZmu4Ts/+qHODqLUP6uyHWvugzn7E1jopHbqTDWuA6QXnDwbW1XAdiZ9a+6DOfqi1D+rsR1SttdDPhmXALDObaWb7AZcCD/S5zgPAFflXep8MtIcQ6v4UkTScWvugzn6otQ/q7EdUrfWuOxkQQug0s2uBxUArcHsI4QUzW5C/fCGwCDgHWAHsAD7VrP2V2qm1D+rsh1r7oM5+xNbaQmjIIUEiIiIiItJEOnRHRERERCSDtNAXEREREckgLfRFRERERDJIC30RERERkQzSQl9EREREJIO00BcRERERySAt9EVEREREMuj/AZbaLrDyYqCTAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+kAAAGeCAYAAADohUAvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAEAAElEQVR4nOy9d5wkR333//52T9zZ2byX8+kknbJQRAhlZCEEAtkEEU14yDbGGCOwDZjHsoV5bJlgG/QTGEQQYKIAgQIoIoRyOp2ku9Pl20ubw6Sert8f1dMzu7dhdifszE69X6+9m5mu7qru+XRVV803iFIKg8FgMBgMBoPBYDAYDPOPNd8NMBgMBoPBYDAYDAaDwaAxk3SDwWAwGAwGg8FgMBhqBDNJNxgMBoPBYDAYDAaDoUYwk3SDwWAwGAwGg8FgMBhqBDNJNxgMBoPBYDAYDAaDoUYwk3SDwWAwGAwGg8FgMBhqhBkn6SJyjIg8LiLDIvKX1WhUpRGRHSJyyQxlPisi3ylTfR8QkQMiMiIinXPYv2xtmWW9q7w22xWs41MicuMc971ARPaUu00Gg8FgMBgMBoPBMF8U80v63wJ3K6XiSqkvTVdQRNaIiBKRQHmaV/+ISBD4d+BSpVSzUqp3vttULEqpXV6bsxWs45+VUu+p1PErgVm4Kkt9JS1ceceYsc21hNFNWeqbk24qtaAnIi8XkefLfdy50Kj6qgcqtdBeyiJ3mdvRkNqrhb6tknhtWTfPbWhIbTUytTSuzjfFTKZXA9+vdEPmiojYlZxEloHFQATYNN8NMcweEflz4AKl1J8XfJxbuDq1iP3XANuBoFLKqUQb642ChauzlVJPznd7qojRTQnUom6UUvcBx8x3OzyMvgpohHNUSv3zfLfBw2ivBGbTt4mIAjYopbZWul1KqeZK11EERlsFzNc5isgFwHeUUisqXVeNjavzyrS/pIvI74ALga94K2pHi8irvFWtIRHZLSKfLdjlXu//Aa/8S73jvEtENotIv4jcJiKrvc9FRK4XkYMiMigiT4nICTO06Zsi8t8icquIjAIXztAmRORtIrJTRHpF5O9mdYXyxzhbRB4QkQERedITbG7bO73zGxaRF0Xkfd7nRwO51aAB73pOV8fxInKHiPR5K6qfmqTMEb8IFa7KeSu7/ysi3/Ha87T3vX3Su867ReTSgn3vFpF/EZGHvO/g5yLS4W0bZxnhlf2/IvJ779i3i0hXwbHeXnCd/2G2K9EF9b1DRHaJyOHC70tEot733y8izwJnTDjWMhH5sYgcEpHt4q26ikiHiOwRkVd775tFZKuIvH26tk3Damp40UUq6J5QJqq6cOXdM3dXo64ZMLopjTnpRmrcsquM+jT6qkHqQH+fnfjMNAeM9kpjwf6YI3pRoRSMtgyzpoae+0pi2km6Uuoi4D7gw57Z8wvAKPB2oA14FfABEXmtt8t53v9tXvk/eNs+BVwFdHvHu9krd6m3z9He8d4IFGMO/mbgWiAO3D9dm0TkOOC/gbcBy4BOYFYrQSKyHPgV8E9AB/A3wI9FpNsrchC4AmgB3glcLyIv8a7X8V6ZNu96TlVHHLgT+I3XzqOA386mnQW8Gvg20A48DtyG/q6XA58Dvjah/NuBd3n1OsB0bg1vRp/jIiCEvha56/xfwFuApUCrV99cOBe9inYx8GkR2eh9/hlgvff3J8A7cjuIiAX8AnjSq/di4K9E5E+UUn3e+f1/IrIIuB54Qil102wbJmbhqvAYFV24EpFzvIWald77k726jp1Le+cTo5txx6jGgqcSkQ+JyBZgS8HnH/OuUY+IvLPg81YRuUn0At9OEfl7EbFEJOy184SCst0ikhCRRTJh0VREPiEie732Py8iF8/lGs2WRtaXiJwpIo94xzwgIv8+l3P0tikR+aCIbPG+w/8rIutF5A/e8X8oIqEZ2nOB6EXhT4jIfuB/vE0hT2PDIrJJRE4v2Gej6EXwAW/ba7zPzxaR/VIwERCR14nIU97rwkXuiOjF+V7vOA+LyOJirmEpNLL2Jqm30mNi7to96V27N4pIu4j8UnTf1e+9XlGwz7gfSyZo5jci8uEJdTwpIld5r5WIHOW9vlxEnvXav1dE/mYu12g2NLK2pIb6NRGJAb8Glnl1joj+UexM7xgDosfUr+SOI5O4P4vu494jdTKu1gRKqWn/gLuB90yz/T+A673XawAFBAq2/xp4d8F7CxhDr45dBLwAnA1YM7XF2/+bwE0zlCls06eB7xdsiwFp4JIZjvFZtGkHwCeAb0/Yfhvwjin2/RnwkamuyRT7XA08XkRbLgD2TNi+I3c+Xtk7Cra9GhgBbO993GtPW8H3e11B+eO862NPbLtX9u8Lyn4Q+E3Bdb65YFvTHK5zrr4VBdsfAt7kvX4RuKxg23tz1wI4C9g14difBP6n4P2XgaeBfUBnkXr7c+Cb090T3ndyIlrbJwEHgNdOc0+8FtgKbES7nPw98IC37U+AR9ELTuKVWVrEPTEIvMxrQ2SGNh3naeI8IIw2s3Nm+V0tRy+oXe7V8Qrvfbe3/VXoxRQBzkff8y+ZzT3hlb0W+B0QBZ5CLxgeofsZjnEB2lxuxu+7kn9GN1XVjQLuQC+qRr3zctCLlEGv/jGg3St/E/BzdP+4Bj0uvdvb9g3g2oJjf4h8v3cB+T7oGGA3sKygveurpc8G1tcfgLd5r5vRJsOzPscC3dyCXnA/HkihF8vXoReen2WKcX/CdXeAz3vnEUXfA0lPdzbwL8CDXvmg16ZPoRe+LwKGgWO87duAVxQc/3+Baya5t96HXqhu8uo4DWgpQjefBT5rtFdXfdtRBe87gT/1vve4p4+fFWzfUXgeE9r8duD3BduOAwaA8MS6gB7g5d7r9lzbi2mv0daC6dcmzj1OQ8/fAl67NgN/NU07/e+SOhlX5/tv1inYROQsEbnLW7UbBN4PdE2zy2rgi96qyQDQh74Zliulfgd8BfhP4ICI3CAiLUU0Y/cs2rSssLxSapTifq2feA6vz52Ddx7non8xRkReKSIPijZTH0B30tNdk8lYiR6My8GBgtcJ4LDK++0nvP8LfY0Kr+dO9EPDVO3fX/B6rOA4E6/zGLO/zrOqw2trjtXoVb7C7+hTaDOyHDcAJ6An7lO2TUT+q+AY/wW8ueC4T00sr5S6Wyn1tFLKVUo9hbYUOX+a83sf8C9Kqc1K+xT9M3CKt/KZQQ+0xwLilemZ5lg5fq6U+r3XhuQMbfoz4JdKqXuVUingHwC3iDoKeStwq1LqVq+OO4BH0NpHKfUrpdQ2pbkHuB14+SzrAP1A0YperNmH7isWBEY3FdUN6GvVp5TK9XkZ4HNKqYxS6lb0g9Mxon+lfCPwSaXUsFJqB/BvaOsrgO+hF1FzvNn7bCJZ9EPYcSISVErtUEqVq0+fNQ2krwxwlIh0KaVGlFIPzvEcc3xeKTWklNoEPAPcrpR6USk1iP7RYUbfWK/dn1FKpQr0d7+n+yza0u1k7/Oz0WPcdUqptPdc9Evymrs591q0xd3l5K0RJ16HTvSkKquUelQpNVREW8tOA2mvkGr2bT5KqV6l1I+VUmNKqWH0wvZ017qQnzJe/28BfuJdg4lk0H1bi1KqXyn1WKltnwsNpK1a7NfG4fUxDyqlHG/c/BrFa68ux9VqM5c86d9Dr8isVEq1Al9FT7pBr5pMZDfwPqVUW8FfVCn1AIBS6ktKqdPQqztHAx8vog0T65muTT3oCTAAItKEHshmw270L+mF5xBTSl0nImHgx8D/AxYrpdqAWwvqn00d64soN4peMQV8f5juqYsXxcqC16vQncPhWR6jhwI3AhGJMvvrXEwdE9uaYzewfcJ3FFdKXe61x0Z3IDeh3SGOmqoSpdQHc8dAWwt8r+CYJ00sbxauKrZwhVIqg165PgH4N6XUZH3MEYjINQXt+iVw7oS2zjtGN5XTjcfuCe971fhAO7kFwC70L5iFi347ybvr/A6IetdmNXAK+uF2HEoHcvor9MLSQRH5vogsm6xh1dBnA+nr3ehnh+dEm3hfMZdzLCgzcZF74vtigmkdUkolJ3w2cfE5ItoUdBmwWylV+OBeqL/vAVd5zxpXAY8ppQq1muPbaAu/74vIPhH5V9EByY5AtEl07hpcA1xToL9fFnF+09JA2pt4DtXq23xEpElEvibanHoIbQ7dJkX4SnuT+l8Bb/I+ehPw3SmK/6nX5p0ico94ZtaTtOeIvqzwvYicO7szPOL4jaKtWuzXxiHa/eCXol1yhtCLA8Vqui7H1Wozl0l6HOhTSiVF5Ez06keOQ+gVosKUDV8FPikix4Pv+/d67/UZ3hcURE8+k+hVk3K26UfAFV7HEUKbO872vL8DvFpE/kREbNG+XxeI9vsJoVd5DgGOiLwS7Ws/W34JLBGRvxLtrxEXkbMmKfcCenB/lXfd/t6rvxTeKiLHiV7A+BzwIzX7iPk/Ql+jc7zr/I/MfqFiJn6I1lK7d+3/omDbQ8CQaN+VqPc9nSAiueByuSB870IvqNxUzCBWJGbhqjILV4iOB/EZtF/nv3nHnhGl1HUFCy1XoH/Faiv4rBYwuqmQbjyKWtBBL0hm0A86OVYBewG8ydMP0av+b0b/KjI8aYVKfU8pda53LIU2eZ6sXDX02RD6UkptUUpdjY6T8nngR6J9KGd9jmWkWO2BthBaKTquSo5C/T2LnrS/kql/bUJpC5F/VEodB5yD1tWkwVGVUlcUaO069K/4uesx3WSgWBpCe5OcQ7X6tkI+hjYJPksp1UI+NlTu2ON+2AGWTNj/ZuBqb9IdBe6arBKl1MNKqSvR99nP0H3iZOWO6MsmXJP7Z3uCE2gIbdVgvzZZvf8NPIfONtCCfs4u1B1Mob06Hlerylwm6R8EPiciw2g/ZP9GVdrE+Vrg997KxdlKqZ+iL+j3vZWWZ9CDDWj/iP8P6EcPQr3oTqycbdqE9nX4Hvpm6QdmlS9XKbUbuBItwEPoG+LjaD/6YeAvvTr70WK7ZbYn4B3nFWgf8v3oYEcXTlJuEH2+N6IH8dHZns8kfBv9a+V+tH/NrHNRetf5L9Dp+nrQPnUH0b4v5eIf0TrZjjYV+3ZB/Vn0tTvF234YfY1aReQ04K+Bt3vlPo++0a8pU7vMwlUFFq5ERNC6/Dp6VbkH+L+zPU4NY3RTmQXPWeH1CT8ErvUWR1ej+4vC/MffQ5vEv4UpJkmi8/le5D2QJ9G/TsxnetCG0JeIvFVEur2HvgHv4+xsz3Ee+SP6mv6tiARFBxt7NeNT334PPS6fh/Y5PgIRuVBETvQWn4fQC0/zpb+G0N4EqtW3HWD8tYuj+5oB0Zl5PjOh/BPAmzxtnY42vy7kVvTk53PAD9R4iw4ARCQkIm8RkValrduGMNoqtk0LpV87AHSKSGvBZ3G0FkZEB/T9QG6DUuoQeo7yVu9+eBdHWgvX47haXVQNOMabv/n7Y4bAgCUctxkdHGPtfJ9jpa8ZetDbiV6Y+CXafOo7Bds/h+5YB8gH/3gbOojdEHrR5xve5xejA6SNoBcavgs0z9CebwL/NOGzmdr0DmAXemHs7ygiCBsFAWe892cB96BNqw6hzeZWeds+hO7UB9CLKd/PtZHigyl+xLsWIe/9Mq+eXPCaGdvslbuAGgggYnRTHd14ZRXjgytdwPQBN9vRD9m5RdhPMyGYKTowT19OjxOPiw4Y9JB37fq867esWvpsYH19B70gPIJO1fTauZzjFLq5H/jzgvf/BNxYxPc5UWufnXCe47SM/hXvHnRAqmeB103YfxX6wfxXUx0X/YvU8+jJxgF0lpZi7pXPUv7AcY2ivYnfazX6tvejF6wHgDegx8W7vevzAto/uVBb69ALQSNee75U2GavzNe9fc6Y8LlCZxoKoTMP9Xvfz8PAuUVqQxlt1X+/5pX7hncOA57uzkP/kj6Cztz1OfSv17nyr0T/aDaAjvNyDxPmG9T4uDrff+KdjKFBEZ1H8DtKqRvLcKxXoyNGCvqGPAsdAdSIzGAwGAwGg8FgMBiKYC7m7hVHdJ7QkUn+3lLmen49RT2fmnnvOdX38inqG6lEffPAlWj/un3ABnTqNFXt62wwGAwGg8FgMBgM9Yr5Jd1gqANEZBPjA1vleJ9SaqporHOp59dMnhbmn5VS/1yuegrqezk6/ccRKKVmHW3UMB6jG0MlWaj6KqI9nyIfjLSQ+5RSr5zkc0OZWajaM33b/LNQtVVEe0y/VmOYSbrBYDAYDAaDwWAwGAw1Qk2auxsMBoPBYDAYDAaDwdCIBOa7AZWkq6tLrVmzZr6bYZiERx999LBSqnuyba1txyvHmdpNf2x0121Kqcsq1rg5YLRW20ylN6M1Q7mZq9ag9vRmtFbbLCStgdFbLWOe2QzVYqFprRQW9CR9zZo1PPLII/PdDMMkiMjOqbY5zggbT/nklPs++vsPdFWkUSVgtFbbTKU3ozVDuZmr1qD29Ga0VtssJK2B0VstY57ZDNVioWmtFBb0JN1Qp4ggQXu+W2FoBIzWDNXCaM1QLYzWDNXE6M1QLRpMa2aSbqg9BMSS+W6FoREwWjNUC6M1Q7UwWjNUE6M3Q7VoMK2ZSbqh9hAaaqXMMI8YrRmqhdGaoVoYrRmqidGboVo0mNbMJN1QcwiC2I2zUmaYP4zWDNXCaM1QLYzWDNXE6M1QLRpNa2aSbqg9BKygyQ5oqAJGa4ZqYbRmqBZGa4ZqYvRmqBYNprXGnKS7vwXxvmS5sDzHVHeV93jzgfvb8e+9a6TEQlzniM8LURM+E+VCOqHfhKLjygnnT9+OEn1ORCQC3AuE0Rr/kVLqMyLSAfwAWAPsAN6glOqfc0XFkL0jf72si8tzzIWkNeUW3IuWryNxHb3NOrKLmqg1AMl4WguEx5WrtNZqCcU9/usZz3uWxy3n8apN4XUpRJSrt0+mJ2/bVGQJY0lm/D5V0JqIfAO4AjiolDphku0XAD8Htnsf/UQp9bmSKp0Eo7WpmUxv02ktt33SMRRwVBTbSo3fZvq1shx3IWhNKW/MlHyfldPTZNty2ycjo2IErMQRnzei3sqttXIfs9pMN45O1a/ltsP4vk+UO+kYCo2ltWJozEm6obYpPXpjCrhIKTUiIkHgfhH5NXAV8Ful1HUicg1wDfCJ0htsqFsaLFKoYR4pj9a+CXwFuGmaMvcppa4otSJDHVMGrdXKgpChDjDjqKFaNJjWzCTdUHNIieYsSikFjHhvg96fAq4ELvA+/xZwN2aS3tCUqjWDoVjKoTWl1L0isqY8LTIsVMrUr30TsyBkKAIzjhqqRaNpzUzSDbWHlB4YQkRs4FHgKOA/lVJ/FJHFSqkeAKVUj4gsKr2xhrqmDFozGIqielp7qYg8CewD/kYptakalRpqiDJozSwIGYrGjKOGatFgWmucSXqhb/A0/hNzQt0FOZ9tdbv2pQXIOhCpwUXmQt/zqa5Fga+wFPoNM7Vf3bjdxYJwrGB/7T9d7K0lgWnNWbpE5JGC9zcopW4YV79SWeAUEWkDfioiR5jrVYzsHfp/sfJ/5aJQa/LbvNbcLAQvK1895WRirAPIt1usca/H+cpZgaK0BqCCOu5BBbRW00zlJ1buY7vqvnHbLHl5xeothdlcj6l80VVBbISpsFUKRRExDyYef2atzdi3zcBjwGrP1edy4GfAhlk1cgqy6gGASf0ISyX3vSllobjP+8z2fWoD1tllr7NUitGaUhYi0/tswuRazH0WIIHCG4tnobcqaA0quCCU63OkAs/jGfchbLFwecCrK4DraS1sn17+CktkKq3l9HXE69yzm/d+ot/wVHoMMjonrUF9j6OO++ARcR/KRVY9gHjX1OUBv0+D+urXZtLalMebom+zyI8jjaS12dI4k3RD/SDMtFJ2WClV1EiqlBoQkbuBy4ADIrLU+xV9KXCw9MYa6pqZtWYwlIfitFZ03zYZSqmhgte3ish/iUiXUurwXI9pqEOqoDUquCBkqDPMOGqoFg2mNTNJN9QcUmJgCBHpBjLeBD0KXAJ8HrgFeAdwnff/z8vQXEMdU6rWDIZiqYbWRGQJcEAppUTkTMACeitaqaHmqIbWzIKQIYcZRw3VotG01jiTdPsVs98ndeu49GGM9PkvVSapTYxzWAWiKTRBHv6mv10CIQh6KaKy2bzZshXI23Q1XzX7dhbL0P/q88m1odDUuJCciXahSXIu3ZdzO2IH/aLFpF7QpvOza2qJKRaWAt/y/NIt4IdKqV+KyB+AH4rIu4FdwOtLqWRK5qI153YouK4+2QxjLAVg1OkinT0NS7RuRFwyrtZnOmsTSetnJkscYkH9nNRi7YRMimy4A6B6plaJW/Lp0wLB8Sb/hZordAcYZ+p+8ay0Nu7Y1dXavDKXlC55M1IvxZOb7+OyKuiVCQAdXh3570X5ZnvaqtXCxRZtJmiLc0S53L6V1JrjPuibYM/FNFY4P2/OP8P+M6XSmrGu0lOw3YwOftklInuAz6ADY6KU+irwZ8AHRMQBEsCbvECaJWPLObPeJ+M+BDAurVPSaQPAUSFAm7ULOjyIiDuuj8oqPVZZ8gJC1tdsQNJ+GUeF/PdCtqLmygnnSQJWTu95k8+pOCL1FedX1G1gXF0V7tcqvSA0W5eaybQ2lF7ufwfpbMwfL0XWYUvG15pL/vkt6w4RskcBsCVFxB7G9fqzrBv2j2dJhubA8XM5taIYzmwGIGSNErCCCNlpyxfeOyIuwvk47oMAM5pyF7qZud4YMNsfK+t5HJ3L+JTKPuLrBHS/lhv3CrEkesRnub4PdxNB0Xp1VXCcOXmWAGFr1NtmVbRfG3OeBiBoJbAnuErk2lPIZP0azN5tIK/X2bW3nrU2Wxpnkm6oH0RKje7+FHDqJJ/3AmVKVm5YEJSoNRFZiY5+vARw0X6dXyxT6wwLiRK1BqCUunqG7V9BR+Q2NDJl0Np8LggZ6owy6M1gKIoG05qZpBtqjwbzOTHMI6VrzQE+ppR6TETiwKMicodS6tnyNNCwYDD9mqFalEFrZkHIUDSmbzNUiwbTmpmkG2oOEbAbKHqjYf4oVWteSr9cWr9hEdkMLAfMJN0wDtOvGaqF0Zqhmhi9GapFo2mtoSbp7v0fB0CWLgHH8+9xXUgm9evmGLLh46jt1+v30TgM9+vX4ch4v1rXAcfzwWyK533X0wlwPF8z5cLgoL+LioShrVu/ObgPQp6/bajAV/3Q9WAHIOW1yVXQpFOZEYn55aQtv8itHv8stLXm21a4fyAAI57fTGcXEu/W2wHcTN4POBCa4IMueZ97y9bpvnLk/NOTv0S8NGtz9dGcHMFaAD4nyezjZNyI7+MVtodJZeP+9tbQUQAMprcSshYzmFwOQEBSjDnaHzgaGPBfBySlfYYs7X+ZzsY832EYzTj0J/U1i4eiOEofK2XH2dLfhOU5/XQ3hWgKjAHQMzpCV1R3dgqLwZSD42prxXWtB4kH9wPjfVEf6BlkeTwCwEha67/Fk27UHmDXsNbh0ti5dAdf0O1Ww1pL4+I2eFaR2UzeIUmpfJlc2rac1tzfTpvKTiaLrVAU5dOal1P4VOCPZTngLNg9OkoscAjQvm06PZi+JkErMU5rQasNgLQbQ3An9T3LqkDeLxN3nP+wriPg/W9hie4DQtYoaddLu0jebxNAZV/wXztudNz2oJX09hnvT9yX2kHQ8y/VfstZr21hLHH8NoStKDnrt8K0LhOZ6O/s+/9xjy/BnM9wZfyFF0a/9tCBYVa1aL9Di6zvz9ufbKIpaLO6WXcIe0eHCFqrAUi5zQT82AX62ub2S2djNAV0vJeQPUo6qzWU+34BhjOtBCzx9RALHGYwrfs4Edf/3JYM6aQfzwwAx/NrD1mjfj2WZIgHN/plHjs0Qmc0F49BEbHH/H0tT3cDKZvu6BK/XxQrrydXWQSsvJ98DiGLq4J5Pck9eBbjCOdP6kc9kbmNrQtDa08cHqE1rHWQdFwC3jmlsy4BS1+XY9qibBtKEg0cDcBwOkxokl/a3AJD/KbAGCKu31/lNAIwlskCehyzRGgNNzOY0uUCBdc0aCl68e4DcUg6+e8pZFvEAoe9fVK0hdb52zb3a23FgjLOhznpuEQ9yScc6Ii0+dsscck9rrvKGhf/I9eX6vSF+ngWDpbcg0hea8ns4wCE7fH3RyFKLERN7/s+OfWvt9z3srjpIJa4fnyWoXQ3Ie/eXh5r4VCyx9tjOZbj+ONSwEr7fZYtKT/+Qcge9WNmOCqkfc+9fVLZFtIS8/cPovuBlBtHcEmo3PeXJZF9UR/DDfv9XVYFPG3gx4Yp7Nf2jQ3oY0vKj2WUi6mRa5/jhonl5hWui1j6eFk33/8GrLROu8aRzwqWZLx+DUSCCOeTyj7in/t0zBTTY4q9StaaiFwGfBGwgRuVUtdNUe4M4EHgjUqpH5VU6RxpqEm6oT4QAbuBfE4M80cRWisql7CINAM/Bv6qMOqxwZDD9GuGamG0ZqgmRm+GalGq1ryA0v8JvALYAzwsIrdMdFH0yn0euK2E5paMmaQbag4RCARMh2+oPEVobcZcwqJ/rvgx8F2l1E/K2T7DwsH0a4ZqYbRmqCZGb4ZqUQatnQlsVUq9qI8n3weu5EgXxb9AP9edUUplpdIwk3T3lv+DHH8sAGr33gJT9SikPVO0/gFUz9+M20+inhl7oMBsIxSCdBqV0mYjYg/kTdddN3+8QADV75nLO442p/dsrtTwMNLdpbeNJVCD+/39JRjS7codL2faEY1rc3pA7fwiHNameyqThm3bddncPi3arFpiMW3yDtB7GBUIQd8e7zyieRP3plYk4Jl8hZtAkTcvHhuCphb9usBkWY0N6rRyAN6+vtmxXIh65p/068XLIPBd/XHHW5gZwbLqt8PPmZXZkgELbBn2t4Vt/dpVgQLzM72tLbQb0GZEOZO0rArTGdmqj4fWbLbgts2ZVy1qyptaNgd3+Saj/akltEdcIgWdWs7MaVnzKMPpmNcGl0VNeZNLSxzGnHbv3WbSbjMAJ3aN+CbPbSELSzL+e8cNsTKuzy9kjZJ0tQaH0scSkBTJrNZQa2ivfx0KTe9EuWTJpVzKIAVmnq6ExplaFe6DXIiLl1bMcgHP9Kqo9GSlaU1EBPg6sFkp9e9zPtAceapX90vLYgP0p5YAkHSyNAVt37zTEhhI677KVSt814eglSAgqYKUQnkT8qwK+umvbEn537FSOu1U1g355XLmc5Y4OK5nWmyPopRFyvvOFZZvbmdLhqxXj8LCVjnTzQDDmc3+Phm3heHMUq/deVvViD1G0Er47R51uogEBgBtSl9oOhyQtG9mPdEUPusWai2vrYwbJWRpc0QRd7wrhed+0Z/aQdQeRORxr01HJJOYhPru17YM6uu6tnWEhJdGTWH51zdkW4ykHbYM5lL7BXCV7jeagjZJr9+xpImQncVxc+buitFMu3eMTv+7dlzl91tJJ0vAskh6/YNSi0h4somHMiQcXc9wOost+BpvDin/eIWmxRk3yu5Rfe8MpSAasDwzZ81YJuztH8D1+tuWsEPGjZLy+rX+9GpCXookhUXEHgAgaCXHuWlYkvH7z5A1Ms6VIum5PzWJc4SLRa7/2jKYoC084O2/1XddmZ761hrA3XsG2NBuMZDS30vuO82R8FwWN/WNErItRr3vLGCJ77Y1msmO2y9vBd9EwIqRdLRWU1mHsK2vVyRg0ZvQ30XItkhl46SyWmzRgEVW6YMMpFzsXEpAy8IS/HotUb4JvZsNsHNE3yP9yfx3PJrRZXP9dCRg4XrHtkToS7YB0BGBvtS6AhPnoO/aFLJH/TRdkDd9T2RbidqD4zQ16ujnzaCVyKesLHheA3i2b5Tu6Ih3TjvoCK+hOOpbb/sTh1nRrK9pKttCVuXHq1hg0Dd97xnr810IQI95uXFSubbfF6bdZn8sTTr5MRL095dz+YkHexhxFgP6WS5D1HttEbRSvqtkRuXTuFmS8Z+fUtm4/10GJI2jQvSM6XmBiEvY1prJFLiYJZw2QvZoPnWqnfKfF61AhrSnk8JUam5Wu+wUpr70Uxu6zYSsEb9the0NqPSkrmPC+WzqG6UjoutoChTbr+m9S9TacmB3wfs9wFnjahBZDrwOuAgzSTcYxiMCAWM6ZagCZdDay4C3AU+LyBPeZ59SSt1aatsMCwvTrxmqhdGaoZoYvRmqRRFam8lFcTKH9ompI/8D+IRSKiuzTeJeZswk3VB7CEidByEx1Aklak0pdT+Td/oGw3hMv2aoFkZrhmpSot7qKZCXYZ6ZWWszuSjuAVYWvF8B7JtQ5nTg+94EvQu4XEQcpdTPZt/g0jCTdEPNISLGv8lQFYzWDNXCaM1QLYzWDNWkFL3VWyAvw/xShr7tYWCDiKwF9gJvAt5cWEAptbagvm8Cv5yPCTo0wCTdvfMv9Yu2VtSTzwCQPTCGfYz2dRQ7gHI8H8ahYVTGRWW0r4WEbQh7/ieWBc2x/IGdfAo2lUz5ft9qKIFK5tNjKM/hSCyB0DBs0+kbJGjl/d1dFwmHC46dRR3S6TskGs37z7v7fd93WftR1Ji32Li7FyIRJN6cP4bXVrXpOViySH82loCdu5HV3iJSug9yfvGDB317D2lfhnIdJJT3gyHj+acEQuRc+6TjLeDcrl8rV/u3Wxf7u8iJf6/b8PQ/QauXIq6DGRHAmiSFSj2QcJ700znZkjoixVUOWzK+z9NEUtm4v09Yhn0fdBEXWzIEvLQvEWuYlqDW08S0LDk/tXjwIBk36qcrCtmjtAb3+uVag/o79n2IPD8lF8v3P4rYpzLibAJy6ZJ0nAUh66f/AMhaeV8twE/b1RneSlaF/dRxCovhzBK/vnx6InC9tB9CFlGO/xu1JS8HdZfeX6wjfOkseTmgr3/O/6sY67t61tq2oSRtYX2Su4ZbOTymU8gsj+u+JOn5bI5mXNJZfb1cpQjZudQpNvFQnNZw3s8s51Oeymp/ToBYsM3fx3EVQUv5fpm2KN/3LuG0+boNWCncgnRn4/zd3ZCvfYXrx0iwrRTx4EZctdVrQzyftstO+6mwAlaC3uRiYsGU3+bBdCcA8eDguDrTKkgaL+6CNeTrVXB9H2WF7Ru7iWi9u+o+/zi5FFiFMQ46wmvoTe32/UQjRaRtrWetbeobJR46Mn1d1B7wfRstaSFkhwnI5OnEhrI5f0uFqyzSWf19RgK2f68qhJF0Lj2RIuONn2OZLE1BCHq/oPQmbRw3t3/U9w1uC1t+OkmAvcNZWsN6n6QTIuGs8NuzvkWnktziJDgwmqa7SfdXIVuwRXmvh+lPNgHQEtL1HRjTzw7xUMr3O7bIMpLJ+5a2h3cCOrVXqMBnOKvC2F7/LZJPl5RVD+jz99MavdzfZ0NrlM39uj2t4SitoUkv7zjqWWuPHNT+tt1NQdKuzYFRLxZCW9T/XvRDiJcqSum+KqeNkG2RcHL9HX7fF7AE27smrlKMZVxS2cJyjl8ul2rNFu1HXpi+Led3bgu+PjNuFldB2M6niLMk/zy21uuTHVcx7KUuDdmWr1fQY+HOIX289kjQP4feRBPdTS79Sd1/toZtP1YHGXytKWX5/ZGrgmTcfGpKW6AzvNJrw15/XHUJjNPa8R0xNmmXZuKhFjoKHkuno0S9zVsgr10j+no1BVL5lHmSHjd+ZVV4XMrQ3BjiuGFEXPpSej5X6PedVUIsoMeicCAfk8iSDI4T9v29syrsx+VRyvJ90C1xdao2r66QjPjbHBX24wsASM73XbVxcKyF4zti/rnlfM0j9pDft+SejxJeat+wPezXM5JZ7I+5qWycqJeyMkMU140TVvpc0m7M94vPpZnUr11sgebA8d41etDXmlLWEVrb3J+7HxcV1a/pOkrr25RSjoh8GL3YYwPfUEptEpH3e9u/OueDV4AFP0k31CEiBAJFPPUaDKVitGaoFkZrhmphtGaoJqXpra4CeRnmmTL0bV7MoFsnfDbp5Fwp9eclVVYiZpJuqDkE409nqA5Ga4ZqYbRmqBZGa4ZqUoTepgvmVVeBvAzzS6P1bWaSbqg9TKRQQ7UwWjNUC6M1Q7UwWjNUk5n1Nl0wr7oK5GWYZxqsb1vwk3TVm/dRlNacT/lY3p98cBCSnr91VycyMoI0aR80kkntxw0QCev3gBoeQ405iOeIqJJZ8PzM1FgGlfX80CM29hIvT/BQQjvJev7uKumg9up+yLo8b2Xh/u6v9IsRz4+ttQVO1X63E/M+y8Zr9LG2vx9cF7Vd+yZZV/2PzqMO0NUBQ8PeuY7g9iVRO7RPcWBFHBLaj5VAALG1HNye/Ugshlq2Wm9LjULCa09THIb+Vdd/zN9C4NKCBjEpOd90AOcbb8ZaFJ+8YK68gLUAVsoUtu9vC4zLF+mqIEHL821SYZSyCNn6GrvkfZMKc/u6BPx8lDlyvkRKWVheHvWMihEUfayUG8eWFF1ervWgdSb+eKjuIpDeD0A6cAIiru+DNFFrOR+jQ04PaVffR0FJELZPJuM+BGg/+5xPlohLkIK868r1/eX0tdBtTWdjvt+c4Po5rnX+c4uE8yQA0cDJvv+5+P8cSTRwsv/6YOKA7wc/FfWsteG04+f5LfSjtEQYTmd938nupiD9XpyMWND2/TDzOYK1b+5gysFx836ZubzRI+ms798eCdgsjoWIBb2+sMDvPGCl/PdjTgfLmtr8bfvGBnxtBKyUr/V4sOcIreXypY45fX4+2f1jzZzUqXXXm9pNyLb8e2sk7XBgVH/PrgqytFn7BreEGZcHPkmrr69Y4LCv46wK+37VWfUibaF143znpiLn4wnw/ECC0Ax+cvWstYyryLi67VFgJK1fj9DqxysA7XNriRffoiBfdci2GE7r78gSGbcNsrh+jmqH9oj+zpWySLvaUTFsW6Syrp/z2haF1xwOjaU5vWBMuXfvgH/szXsHOWaZHoMvXvX0EVoD7fN934u9JDubvDbYnLtMx1DZN5YaF7MhICmavdAbqWyEkNe/WFbC76sdFWb3yFHesSw6wi/6edKzbsj35RzKjLIyFvPO5xwApvqRcGO790xCE7/e0ev7z09FPWstF5PAcRWRgD0uHoblvU5nHT9GQlbpGAK56+8qRSxo+/s4bi4/tOvH0tA6yv9Ya0k+X7mr9DH8OiXft/Yls5zSlfc1f6rX68dCur5cn3ps+8OTam19S4THDo34+wykspzUqe+Xw8nDdDd1eOfnkvv6IgHb779B99P5tioOeTESogGLpTGd63vU6SadtWkK6Oe7MSfpx2AIWGf7x5pMbzmfZoCbntLPqKs6mo4sWECJepu3QF6F8YJy48mo04WI6z9ruSrox54I20OkHS/eEzaxwOH8Mw/5Z5xAwXNbk91H1vMbt8QlEhr268qoKOLFWtExh1J+nUmnlUXRxf5xcvnPAbYPar31jKS4asNmr/7z6Y7kz21Vc5SfbtV6WN/e7Mds2NjexMHEASKez7yQJR48COgc7rlYQo4b1fFaAMcNobA5mDwWgKCV8J9nbXHyz4RWkoOpPpZ6Op5Ja/l+DR7o0e3pjC7cvm0uLPhJuqH+MJFpDdXCaM1QLYzWDNXCaM1QTUrRW70F8jLML43Wt5lJuqH2ELCDcw8MISIrgZuAJegQsDcopb4oIh3AD4A1wA7gDUqp/pLba6hfStSawVA0ZdCaiHwDuAI4qJQ6YZLtgs43fDkwBvy5Uuqxkio11B9Ga4ZqUqLe6imQl2GeabBntoU9SR/di4S1+assX4bKpdi4aA14pndqcBDJpQdricPiRZBLjTY66puKs6gg5UEgBMkxVK9nGjwwSHaPnutZHRHcYX1se1krzlad1sEd1qYhORN5u6sJNTB2ZJsdBwIBrNf8f8Wfp6tQh/qwX//NfBtXf8T7HzJfe5Mu1pfEXhnHXqbTFUk8rs39AZJDZL3UJxILQnsccmng2tsg4tnRjOxHHdCmMWrTO7Gu+p/i25lr7mTnXYAgpZqzOMDHlFKPiUgceFRE7gD+HPitUuo6EbkGuAb4RCkV5ci4DvsTh0llj6XZMx3KmUvlTIZEhcaZp2f8lET6Nky5ce9Y0XyKqgJz4qCV8MyM8tty2x037KdRC1tDJNx8rruAlSKZjXvHyLdZiYVEtfZb5Sjv06OnPU/HDTOQagO0mag+5pn+9lzqKoU9ru2AbxamsPzUIACDGZ0eLmoP0GQd9ApbuAR887ERZ5Nvcl8s+8eamSlTRxm0VnUcleFwci8dkQ4intl4xo2ytlXrLeumybhR36TclpSf3iRoJcaZ3jYFD/vf0+Ko45v1jWQWMZrRrwdTjm9eO5x2CNvaLA5gLGP5pqEBSwh7Y+dwymVZgYVkYQq27shSwEshNI3eCl09cqbuoM3MO8Nw954BQJt8toT1seOhAM1B3deOOUEg6puKhmxhUVMuxVyLb0pviUOGqLdPB73JvGnobHAnhjqaQJm09k3gK+hFyMl4JbDB+zsL+G8mREqeDaMZl4cODJN08imuoJ1mLx0ZwFBKv864eTNjGG9S3J/MjDOLjwYshj2z5oTj+tvGMhajmUBBOd1nbO0fozMaZPtY2vvcZklzLj/U+At/YCTN8ha97UNnrynYcqT5cY50JsuvHtwFwPVvOMX/vNBl42DigHdeOZcQ2+/PXfLnHZAUkYB3H6UdRtKr6IzqfsyWDCmvL7Yl45tLF+p7JmJBm4FkZtoy9ag10FrImad3RvU1XNvqpWnCJZ0Vb1vC77dCBWMq6PRQIS/NlBXIm4mLuOPKjGYUUS9K9GgmS9T7dS6X+gzyLhthW5fL9XU5WsO5lKEuq5oLUtZOo7Vcmrb+ZGacm0ZXZDldXrdz954B/zosioXpitp+fzWSCfguS9oVKZdGLsDWAf1sFwtCyFaMZHSbhtOOb058ztLWKds2kfZm3e8nnOy05epxHB1zXA6N5VIbdvom27m0uUlHXyfbSpP13G7GnA5/HBNcDie66E/mx5HcfZ/OunR7fcdQZomfHjftxrDE8fuAwVSIpTHtcph0Wnx9RgMD/licI5nVA2pzsJ9zli4t2LJoynMcHtNtu+XFPfz9pcfk9ygwo084T/rp5lwV8F0tXWURsPT+QSvrm/cDHEq0k3HXAdAWygfmT2WDNAX62Duqr9HyWMuUbZtIc0jvk0v9OhX1qLVSWNiTdEN9IpRkzqKU6gF6vNfDIrIZnebjSuACr9i3gLsp0yTdUKeUqDWDoWjKoDWl1L0ismaaIlcCNymlFPCgiLSJyFKvTzQ0CkZrhmpixlFDtWgwrZlJuqHmEPADBJV8LP2QcSrwR2Bx7gFCKdUjIlMvQRoagnJqzWCYjippbbKcw8vxFi0NjYHRmqGamHHUUC0aTWtmkm6oOUSE4PQrZdPl3Cw8TjPwY+CvlFJDJr+mYSJFaM1gKAtFaq2ovm26aib5bAZDfMNCw2jNUE3MOGqoFo2mtQU/SZelSwBQiQTipTthZBQ62vT2pijEPB8dy4JUAsZG8wfI+aK7eT8lxka17/hhzyd98SICi/WPsmpvD+KlWctsPkhwfbt+va0fe3EM5fmrYwvZA57PaGGDAwHcfb3MRoLWFV+bdnt6k/YjCaxuIbO5l5DnOCprVyNrN+hCqVHk/gcByB5KwL4RlOdkabUe8FPHOftGsLu1n5OEA7NqJ0DgXd8jc+PVM5/T9D4n0+Xc1G0TCaIn6N9VSv3E+/hAzhxPRJYCB4ts9owodEqo5uDBcak7bCtFUPLpqvw0PQR9v2xXBXBUeFyKslyKDqWsvM96Nk5WBbA8H7zRTJfvE9kU6GMwrX27BZeIPQRA2B5GYRGQI1ORHUocSzyo/aGiRfYEudQaU+GnNFH4qTwyKspweinRwAAAIWs0n+rNdfxUHgobZQXyn6skWdF+WUFJMFtO6oz5Pp/TUY/+TQqdsi/l+ZcHrYTvNxewEoTsUcLWsF8+W9DV5/Rp256/pu9Xm7+blbLojGgf3M4Ivp9aJNDFQMphaUzry1V5PYxlsuTcOQ+Mpsel8rHI+jETiqXQH3gyXujRbVja2eT7aMaCNu1hnYqyK5Iio6IMplYBOj3SVi9MZMCyCdn6nNJZl8FULkVdwveNmw3HtEXZMjizRovQ2ox92wwUk3O4aER0eqrClF+WgOPqMSQaGKE9oq9XLt1dwmkDYCDl+KnQYkHb9+e1RMb57+8cTPhpdxbHQjyyQ/cNoZBNtxcbYOveQX7XM0xTVH9ny7pjsFT7O7ZFguPaHAoI927W2i3W//b9Z66GM1dPWyargigsHFf3SbZk2Deir0Mu1kGOnO+m0EEqm/eXdlTY78/TbshPeTgbzlvexu92zxzvtN60BnqGvzyuv3Odgk0K0l8NY0tea7klgkS2jXTW9rUWDbh5f14V9j93CkQXshWt4YB/3wPsHdZ+7G2RoJ9yrTUcGJeSLZUdvwaRj8fhUiyF/eJUHBhOsTiuz2H/SAoIEwvqe2RJ0x4/pVfPaLdftyX4sQq0xrK+v3TQkjn9+vjqdfr593+fn/lRqd7GUQE6vf4kaCXGpY8NWSP+s4dSFpb3bDaYbuHQmH6ec1xF07gYHHosAT3WbB9IeOVaWOrFz/jdcwfpaouy3OuW7t20279uy7pTrOvS2ljdupyoPTCuvbk0o9vSYS5ZVdw5vv2kZfrFSVOXCVoJ/3kz7cZ8//SnDrWxskXPnyJ2mtbwbrqCz+r3gWU4btTfPxenA3Q8m/yzbPE+6bm4HA8dGJ6hZP1prRQW/CTdUH+IQMCe+0qZF3X268BmpdS/F2y6BXgHcJ33/89Laaeh/ilVawZDsVRJa7cAHxaR76ODeA0aH+HGw2jNUE3MOGqoFo2mNTNJN9QkJa6UvQx4G/C0iDzhffYp9OT8hyLybmAX8PpSKjEsDBppVdYwv5SqNRG5GR38sktE9gCfAYLgpyy6FZ0Says6LdY7S6rQULcYrRmqiRlHDdWikbS2sCfp2SzOE9sAnRote1jHOAmceSxqr7bKklWrIOGZVyRTMJZAjtFp21SqwFRWKciZplkBOLQPOclLHRpr02nZABYvwRa9ymO7WdivzYkDYxmsjetwX9gOgLNnWJuVA3lDQrAu+o9Zm5DPROxLdwKQ+IdXYXdFST91CIBwfAs07QVAuruw1mkbGlmaQFYuR21+HgC3bxSV1WZTdkeE7AEvhVrQYryhYXEE33Mz/J/vT7ldRAjOlDtrGpRS9zO5vxzAxXM+8HR1IjiuzUCqm24v3U5ToA/HDftm364K+qaOIWuUQ2l9vVc1P+WnSNPHsnE802VLXA6M6XQbreFRAlY6b/odHJ/WLMe+kQxrWrUZVtBK0KT2Qsr7zppP9svpNBz5VBzlQLzUMyn3cfpSawFtmpjMNnEooU2+YkGb5bHNAERGXiBse2kAsxk/TaJKJ5DmDgIpff9I25I5tWem1Ealam0+cJVNMtvCUAoiXgqhA6NhVrdoM/ZUtoXm4AHfvLzQzSIWOOybs+XIpQi0yZL2trWHd/oma5Y4vjlcc/Agi6OQcfMpynKuC5as4cCo5xYzIR9ZYcqXcvHeM/T9843H93DCMm0/eGgsTVtYu32E7FFC1ghrWwcAnT4nauu+/sBYG6OZXOoiCHsr80nHxZLpU8BMRS4l4VSUQ2tKqWl9hbxI2x8qqZJJ2D2U9NPc9YxkWRzzUhJlorSF9fUazbaSzip6RrTZ8OlL9pLKanNHIevrLGf6PZrR39kJ3XE6IgMA2DLAxcfoez1kZ/3+0hLY8mIfx6zR7mOHB5L0tqS942Rhcb7/vHJ9N1eu7y73JWBpUwdbBhN+6riAZZP2+qvnehM0h3JpuqAl3AbA8ubDiHSwdyQ/UuZMqQ+OjjHXZ82LVrZPu71eteaqvH5awgF6Exlfa+lsjKaAfg4ZznT65tuDKYd1rdvGpfXMp5EKYAe1TvqSXf7+seBhbEnRFGjzzsViaUzvM5CyfTP4kJXGUWFGvO88Z86cY2189qkai+GNGxf7KdMOjToMpx0Wx/T4eWhskW8+3RZO0eZZ9kcCg4w0abfLXP+7rFmf04sDKd/0fS68/pjpY+zW4zgqgn9N2iPRcebuOdcx0Kk8cykin+sd5sJV2pVmzHM3zPVnWRX03f1e6Av4/eXSWJqQrcfIlx/dTTwUIOmltFu1JM4dd3lzlBMX++49AUlhW+NdFM9eUrzp+GwIWGczln0BgJ7RJcSCue8xxWOeS1lz2GZd2zr/HonaA/5zaLYgVVzQSnjp6+be1jML+vLJqEetlcLCnqQb6hJpsBQLhvnDaM1QLYzWDNXCaM1QTYzeDNWi0bRmJumGmqPRUiwY5g+jNUO1MFozVAujNUM1MXozVItG05qZpBtqD5GGWikzzCNGa4ZqYbRmqBZGa4ZqYvRmqBYNprWFPUnPuow+rH1ag/Eg4VO0X2Tm95sIHKVTS6S/+1vsZTqNkbNnmNBpy5FTta+c2AFUzl89k4BB7VdCMgndi7SfOiCxdlCeP0s4BhntU6VG+1EJ7QssKxaRffwFnD36eJFP/6KSZz4phx7cx4q/OJ3gZet1+3p7Ie35KQ0Nw2rtQyyjgxBrRVZ7PurDz5PZpX1TotfeWlIbel53Ft2vXj9tGQHsOgsMYUuGltAhhtLdjGS0/9ahxCosgeagTpfTHX6OIUf7y1ri+P6IAStBkzi+T11UDrJp+BwAMq5iSUzHRghaCcLWkO/bGQscJuv53o057YxltJ9TazjAktAfAVDDh6HtauYUPKAEHBUildX+VQkVIZ11GUlrP7+RtENrSF+jkfAimjyf5iZ6YEDfr4Si0HwV0jz3Njx0YJgV8en9i+tRa0pB0rHY2j9CwNKD1VHtTRxO6H6rOaTY1LvcTy8zmHJYFdf9UGtoN1kvhVRWBciqsJ/OB/BT9SmscWlVcv7pSln+frnP+5LrADicyHL6oun9ySrBtj2DXOj1552RnnGpDV0V9NNhhawR//yWxFwOjnUCsLU/5acamivffHIvZ62awU+Y+tMaaB/qgCUcGtPXLha0eWq/HsdWt0d5rlePd61hh+f3DbHG8ylssvv8653KxnGU7rd2DLWQdFxWt+prkXSgOaBTPGUJ+PEqMm6EkYwes0dSWV5ywhL2HdJ9YSqT5erj5hanohRcBfFQPu3SWEYKXuu+ZnVr1PdbT2XjpLM2Owd1u3sHkn4sBeYoud/t7h+X+mky6lVrWVfxwGathUXtURZ3ROlNaA0tjoV5rF/3Q82RjJ/+bHk8QpPdh+X5FCeybaRd3QeMZsJ+DIC2cL8/Xka8OChBS483jgqR9FIHprIhIt4k4FACgpZTVNq0crN3SN9XnU1BVrZEfE2NpB3fZ35Fcx/JbJu/T0D0PmkVZDST5ZQuPYCuap5d+sscX35Ax1BaMlNsF+pPbwKkvZR6PSMpX08j6SzL4+GCdHtZhlL6ukYDFk2ef3lA0iSzrb4v+6bebgZTep/juqL+80481OPHSDi6bYCMG2UgrTMXOlmXk07S/dgJazs4vqsJgOWxKLNJX1YuApbQl9Q6swQCnu+3Tq/qsnVAp3RbGusalzI4R1dkOZ1h6AwfsWlGnvdS1iWchffMVgoLe5JuqEsaLcWCYf4wWjNUC6M1Q7UwWjNUE6M3Q7VoNK2ZSbqhJmmkFAuG+cVozVAtjNYM1cJozVBNjN4M1aKRtGYm6YaaQ0QaaqXMMH8YrRmqhdGaoVoYrRmqidGboVo0mtYW9iS9fQ1tN959xMc9rzuL1j06p3DkkqOQ9doX2w4EwHUh7flapBPgaF8UUqPg5SSWdcdDMAy2d/myju+TrvY8D3HPN7FnD7LU85tLppADh31f9LGPXUroJO2XG3jHd8p51lOSHEjh9iewQ9o/RsIR1EHtr8niRajHHtGvQyFU/9M4Wwf0ObmqZF/0HF2vWod94sw+6fW2UhaQEJ3hlZ4vTj536u07+2gJa3+uZPxMIrb27R/NjHdItN1Rojkfn9EhWjyfntbQPsKW3sf2fIRzvp17Rk+iNaR96vpTS1jUdEjX47SCpbUpbVfD4A9QB3fp9xs+XsaznpoDY+uJBpIALIs+TiLbQSqrv3dXwXN92lfulEV7cHM53tNjDLacC0BbaF3JbYgFLYLWyLRlStWaiHwDuAI4qJQ6Yc4HmgVh22JDa/SIvNw/3aq//+6mEGtbhZbQDgCWx/K+5Vk374OeVWEcFfb9GMP2MMKR/mAK2/fzFnFJZeMEPK26KujnYH9Jd5T/fV77k65tj1bNPz0WDZJ0cjnPA357ktkWwvYwQ2ntR5dVQd9XtWck5edDL9UfHeCsVe10RQenLVOP/VpTwPL9Wgv5wWadK7g3keE4b3tLyGFRrJtcCtuMG8VROt9wVgUYczoACFiKk7oP+Hl2rUimIK91kEcOrgBgfVuWLf36u1zdFiXZHCLmxVm4+rglfh7pkG1VTWu7hxK0RXQbVsXHsETHgUg6rp/P+9nD+VgR2/qy9A4O0tykt/n+6CUQCVi0R6YPMlKPWgMdT+XvLz1m3Gcf/8lTgD6fC07R9/KxnTFCXh5pFyHtNpNxdX+YcaN+PJSwreiKbAHAlpQ/hma9eBU53+CAlaIv2QbAoqaUf6z+ZIbjO2LcvWcAgMWxEBvbmypx6kfw/E4dy+aY1e0sbQ77OdqH01lfg8/2ttPsxUhIZ9t8v+rexBivWttZchuiXq7vla3T54OvR72FbWvSnNy/2t7LiwMJ1rVpDcRDlp93HmxfG0pZCK7/3hLhrKVezCl7H4si+vvKEsDx8q7/vqeT47uaeOaQfi45bmkLQx1aTy3hgB87oC+1g6CVIB7cWIEzP5K9I7rPzbguK+NadyORRf642hYJ8uJAguVxrYOe0RCd0fxYWo4c7rnYEwu1b5srC3uSbqhLRCDYQCtlhvmjDFr7JvAV4KayNMiwYDH9mqFaGK0ZqonRm6FaNJrWGudMDXWEYFlT/xkM5aM0rSml7gX6Kt9OQ/0zvdZM32YoH0ZrhmpitGaoFqVrTUQuE5HnRWSriFwzyfa3iMhT3t8DInJy2U+jSBb2L+lOL4z8RL+2A6hBbYq59Kd/HFdMbb4OAFmxETV0EDWin7kl3oWIXsdQACkvDdH+F5GVG8HR5hlkHdTO53SV9z+FxHLm5DbWmafqMs0BkvftIfZ6r1LbwtmpzfWq9SUc/fCzpP7tKmzXM83v7YUubRKl9u4j+dsXAQge3UHmhT7w0rw4/UmmN3YqnuB7bkbt+vK0ZaQg9UPdoAYhdStYFgS0rfpYtotLV584rtiYo6+xLSlCtpdOKNuCkCWc0fpU8S7aMruOqEJEm1Y903sUAL98dDt/eZE2j1of+A1D1nEAZK0QrqcqC7RrxoYzy3u+M7C+JQKJ2wFQ+/YSGRnmlKPPAODmzRvZ0OWlm7MHSWS1yehg4AT6U9qcsS1UehuO74iRym6etkw9as1VCRLOkwSslJ/+JeNGed1R48eRvpTux2Kh3aSy2hzNUWFCORcAFwSXrKeVkcwi4sEeAD/NH0A6G2PE0a45Q+l2XKVY0rQDAEsybOnTOl7dHCblpaHaPZSsmgnypy45micO63PKqqBvVh22h0ll4zzXp+/HpqDNobG8+0MuZdZkJo+zZWN7E8OZndOWqUetZVWSocwLhKxRbNHpOocyS3njxpVHlN05kuK49scZzOg0k6NOF/Gg7tNsHF9TdlOc4fQSOiPbALDEJav0OPvgvi5+dIceS9/0J0fTFNSft0cCOK7N1oP576/VM8XNmZZXg0tWdfDrHb0ArGnJu5F0NwU5MKqfB/pH0izzTGWdrMtRS+JkfHPZ0jlnaSs9Y9OvC9aj1gAclWEo8wKg04kNppfzhatOOqLcU72jHNOmyw2mV47ruwAsz20n5TbTm9KuU4sim3G81JFKWQykV/ruFCE75qecbAm5fnqpzQeTnNLV7JuRHxpLV83cPWf2/0+3P8/6jiZ2eunn2puCbB/QKTWTaZeVbfrprD/p4HjPdmmnPHp7z2n6Pt8+nJy2XD3qzVUJMu5DgB4Hc64Pr1q7fFy5nSMpTu3WzxGjThcjjk4L2RLswZKM7z62Mg6jTjcAEXsYy+svHTfEz57VZW75xWN8+gMv5ZRFeo6QdkN+OsWhVL4/CVhpP81pNchp+qEDw4Q9l0xXBVjfrl13nzk0TDRg++knE47rm8JHypSz/Jyl+jmw0n2biNjAfwKvAPYAD4vILUqpZwuKbQfOV0r1i8grgRuAs+ZcaQks7Em6oS4R8HObGgyVpAitdYnIIwXvb1BK3VDZVhkWIqZfM1QLozVDNSlVbyJyGfBFwAZuVEpdN2H7W4BPeG9HgA8opZ6cc4WGuqUMfduZwFal1IsAIvJ94ErAn6QrpR4oKP8gsKKUCkvBTNINNYkl5gHDUB1m0NphpdTp1WqLYWFj+jVDtTBaM1STueqt3n7ZNMw/M2htph9WlgO7C97vYXotvRv49awbWSbMJN1Qc4hA0PwKYKgCRmuGamG0ZqgWRmuGalKi3urql03D/FKE1mb6YWWynSf1DxGRC9GT9HOLb2F5WdiT9EAImrSfA24W6dLpTxT3+EXEdZB1ns9TIIh0rkT17dXvU6P+/hKNQ0r7AZHN4D5wJ7JR+wAzNozarv0RnZ4Rwmd79fSNoDY/r6s/METsS3f69Tb962/KfrrFEP7YT1DbrwfA2XyAwEuP1q+f2OGXGfljD4neBM6Y9qlZdcfjJderHv4H/WL9scjSDTOWr7vnC7FQ4RiuCuJ6PkpBKzFOa64KEvZcfZWyUJ4fZiSxHSLNZII6FZStUsStPbpgOoE6rBf9sstPY/vQMZzQqTUVOGMDHUEdX0Ed3AtLtB4XhZ4CeUW+bU2vnbRXqjjR1+j/k/9G5o5HCGzfAUDkqH/0/YH3jJ5Gs+e3OpDq1r7sJaIGbgZA7BDh5o4Zy5eiNRG5GbgAvXq7B/iMUurrcz/izFjiEAkMAPgaCtuZcVoDaA3lU5nkyiedNj9ljPa7TPi+bw4Ou0d17ILuyAu+v/uh5NEMp/XrpiCMZlz6PD/P3kSGS1blU3S99YSlZTzT4smlCetLHfa1FbIs+lJtuEqnmNs5mGDXfp0iJ5XJcs1FR5dc7/6ETmHZGtxLLDA0Y/l669dsyRAP9uj+yvMpbwvtRvGiXyanweVNQURcOsJ621B6ua+1sD3s+/lm7ChZAmwf0j633dF+tg7ouABtEeGcM/Tz98qWiJ/6KJ11sUR416n5Z/PjO2IVO+/peOUaHcelN7Wb+7Zr//SXr+1k2Evd2t4cYtTTYFtTkIyr/H1KZe/oEK3h3SyaId0f1J/WAAKSJBbQ95SrAnRFtqJI+NtzWjumLeqnU+uKvMDh5NEksrqvbw4cpCmg/VqT2bif3u/xQ0dzVJu+/9NujB2DQs+Q9rVe25H3Mz+UCPv+wVcfp1PoXrSyvTInXAR/f+kxPHF4hP29OvZHS7SVx1/Q12hJZ5MfB6R/KMngiI6L8OnLji253rv3DHB8l772K2K7Zyhdkt7m5ZdNSxxsL/2oq4K0hXQTFFv1/xP6NYCW4F7GPJ1lVZCApGgJ6jS4TYF+P4Vpb+ooP7XpEweDnL5Kj7Ghq05gWXPST8XrpJezpEnH2Tipc7HftpZg6WPTXDhzcZwRzzV+70icVXF9bo7bRMi2GPTui3go4Mc/mCxF52w5lOwh7l3HRdHEDKVL7tv2AIVBVVYA+yYWEpGTgBuBVyqlekuqsQRMdHdDzSEIAcua8m/G/UW+ISIHReSZgs86ROQOEdni/T9/o66hZihVa0qpq5VSS5VSQaXUikpP0A31y0xaK7Jvmykq7QUiMigiT3h/n67IyRhqGqM1QzUpYhztEpFHCv7eO273I5npl81PTLbdsPAp9ZkNeBjYICJrRSQEvAm4ZVwdIquAnwBvU0q9UPaTmAUL+5d0Q10iUvJK2Tc5Mnf1NcBvlVLXeQ8c12A6+oanDFozGIqiVK0V6bsJcJ9S6oq512Sod4zWDNWkCL1NZ4JcV79sGuaXUvs2pZQjIh8GbkMHKvyGUmqTiLzf2/5V4NNAJ/Bfov3fnfmKTbTgJ+nK8k7RmvxUlRVAguM/kw4vBUNyGCzPPjmdRjnafIWsg5x8GuzTJu5q7z6S9+rXhx8/wJJWbdoikQDuTm3Wkh1M1c7FjmgzwcyuIbKHdYBMe2kz4bN1+qum13+T5OvOomlR+VKNyGkXAPp6F5McpJTojUqpe0VkzYSPr0SbJQN8C7ibCkzSLcn4qTcm25YzvSss48a6cVXQTwFjuUmUrXOQjQRW0LTCM4Pf/xTHHr6TxHd/D8BJ565Cneudkm3T4ujURYSi5T6t0ghFCL78BJwH9fPd687/Az/d+1IAzlvexid+NgBAwB7i2lcfX3J1qtUzifVM1GainqMgyzTnOJkOI4EBsm7Y3zfrhnE9sz5LMnRH9KLxQHol+0d1j3Xjrc+wYZ028btw42KSjsvOQW2SNpbK8pLu0s3dykXQSvgmeb0Jm+ZQlnVt+nwvWNHGrwK6Py/XV744umlW5SsdlbZSiLi++8Nk2wAsMuP0GA/2+ObuQtZPC5lRUcacDhY16efs0UwXS5u1BvcOJ2mN6b7vhb4xljbr7y5gCalscfdztQhIihf3aPPicNCmrUn37a3hoJ9O6AebD9DeFJzyGLNlWax417N61Vqu35qs/8rpK+c6kaMr8oJvhizikslq3WVVvn/b0D7I7mFtQDeQdOhPptm8Q5vFJ9KOnzYP8N0VaoX2SJD9vdrdcn/vmJ8P2hLh7Sfp57Z3f/UPtHWV75ntvOVPTzu+TKQEvfm/bAJ70b9svrmwQKV+2cydX87sfbJthf2aUhZNttZMxo2Oe6bLuBGG0nruEAkM+ubyZy3Nu/q0R9axb0SxzBsyo/YAWVW+/qEc2Ojxc/PBEUA/ey6OZUlnXT+t6k+3HvJTYJbD7agzvLVaWgNAKXUrcOuEz75a8Po9wHtKqqRM1My80WDIIVQkMu1ipVQPgFKqR0QWlbsCQ/1RIa0ZDEdQBq0V67v5UhF5Ev1r1N8opWa3kmCoe4zWDNWkFL3V2y+bhvml0Z7ZzCTdUHOIiMldbagKRWjNYCgLRWptur6tGN/Nx4DVSqkREbkc+Bkwc6ROw4LCaM1QTUodR+vpl03D/NJoz2xmkm6oSSqQu/qAiCz1fkVfChyce+sMC4lGWpU1zC9FaK0k302l1FDB61tF5L9EpEspdXgu7TXUL0ZrhmpixlFDtWgkrZlJOoB4EQGdFCpY4M/b1I64Xj6CyBXQ99V8+V07UcrzoQgESB7U6THEFrKHtf+JvbQZ5aWQabqu5IwRZUOW6sCasevfywtn6LRdK85bgbN9AID9Xz6Jdfc+xeG3vAyAJ487lo5V2tdp5W8em1OdaoqYAJO2j4r4Cd8CvAO4zvv/5+WuoBhyKToK/c5B+0TlfJuwX4HrpQWN2MPYyvO/616DGhog8hqdMtB5bDuB5ocBSJ77TsL2sHesc6pxKkUjKz8EKyGw8rsAqJE+nKy+L9TAzXz+tVcDcP++Qb5w1xYA7vzNFm77/OVzq28Wvk0V0lpNoeMd5P07bSvvfxewziaR2ey/H8noNDBKWb7f9tpVbTz2mH4+b2+JcFSBD/obN+bTxtQC8eBGztZZk/jmk3tZ1dHE4THtN/zh/3cft3z2UkD7Cl/3O+3auHF1O1eu765428qgtWJ8N5cAB5RSSkTORGdwqUqQJRF3nNZEXEK2HheVsghaOr1fb+owWTfEjkHd/zUFXaLe8LD10Chxz4c7HrIZSGa8MjZnL2mpxmkUTWvoKD73Kv36Ldffy8UX6LSE4a4YNz2l75e3n7SMH285yFcf0jFrArbFe05bOenxykkjaC2d1b6wOY3lU7cFiQZOBqBvdAjb0vf/nuEw6WzWK6PYtX/Y11o6nWX/oE7Hlkw5vPeMVdU4jaJZ3RzmX648AYC3ffE+upZq3+DDg0m+/MB2AL7+/pfykZt1zII3fP4uAH74iQvnXKcZRzUiru9fXnhNQvYoSlkErLMBGE0d9rcfHOskEtD7xIO97B/Tvurt4SGWxMLsGdaxNlrDATa01lYMody9c/Vx8E+363S/px3dRWc0xN5RvS73uqO6+d3ufkD7px/q18+oc71vjNamxkzSDTWHCARLuAkny12Nnpz/UETeDewCXl+GphrqnFK1ZjAUS6laK9J388+AD4iIAySANymlionVaVhAGK0ZqokZRw3VotG0ZibphpqkFHMWpdTVU2y6eM4HNSxYGsl0yjC/lKq1Inw3v4JOP2locIzWDNXEjKOGatFIWjOTdEPNITRWYAjD/GG0ZqgWRmuGamG0ZqgmRm+GatFoWlvYk3TlImPab4JIfGq/aM+3XI32I3E7/7mbBUf7MxEFWfZ+XW7nF1GJBNnNewEIfOCDhG/R6UPdjIvy/G0H799D9/e1b/HeV5/B1seGOX/vc+U8w5Lp7/PyRP6xhyVnaGfO1tUtfE+O4c1K+6PsPOZYnFSJeUN7d+n/7QASniGvopQvj3G1cFWAhNNB2o0RD+4HJs/zqvD05WYRpX2DHauFrAqQdvV1iQfzfuV24mdkozpbnDWyE445C9n1FADBxYtgQPsIHUhsYG08og/9s3eT+J32gYx96c5KnO6ckID2QX3CvZJzV3r3VW8f7/7+HwDtU5fLcX3s+86ccz25XKWpbJym4AwxjOpQayC4KohS1jj/8qnIuFFClr5/C/3rFDa2aD9ugMPJvX5e6z3DaV669FEAHmpey7LVbQD0Dmjfsz8/WV/jt1x/L1tv2wbAH3/zzjKdX3l4cc8gAdsiGtb3XCgU4B1fuR+Ab334XP5uq9bGrgMjMEef9JxfrCUuljjTF65DrSksHDdKVgUJWSPA1P6DSlmksnEi9kDB/vraO24I72tgSbSLnrE+co8fe4eTXLbmGQAeCx7rx6sIWELPkNb3Gzcu5tc7eukd0f3GW09YWtbzLBXXVdz3B93nLn7lsaxo1/fRdb97gWsuOpr/fHAHAK3NpeVEHkyvxBKHkDU6fcE61BpovYw6Ojdzk903rdaGM1oD7Za+7q7SenLcsB/jYHmshS2Dus8aSiXZtHsAgA+fs4sXetZgOfoihUI2jz+nY8le/4ZT/HgVh/oS/NufnVzmsyyN9q4mEqP6Pogta2FRu44X9JrP3u7H3Hjnf/2eWDxcUj19qXXY3jNMxB6cvnAd6k1hk3TaAAjbQzP0azoeRiQw4I+frgriqDCRgn7tULLH2ytEf1KPB2viW9k3quMzJrJthO1hvG6M0xfFOZg4AOh+tTtSW/3aisU6/swfNh3gqrNWEQ3okBO/2p7hVWs7AbhzVx+dy0qLF9KfWu2/ji5ArZXCwp6kG+oSQWGLcW0zVB6jNUO1MFozVAujNUM1MXozVItG05qZpBtqktlEezQYSsFozVAtjNYM1cJozVBNjN4M1aKRtLawJ+ljo6h+z/wk2AeD2lRDbdmGLF+mP2+O4W7X5lKyfBmF6zPSdjVMYp2mnn4W2bCe4AX/7n/27K/fB8Dxf7qW1MExALJOXkh22GbtcbWVagHgrG1Hmt/3vuJULnl9h//+tOdLN9FP3/BjAJyeESIvXzFtWb1SdqSpeC0zmAryq22LOa47RnNImwJvH0jwwHMHuegE7UbguIp0VmvivOXPExjTaXoOWmeyrKnNNwctRI0NsV9dBMDyNm0Cr3JZLnqeRxavBWBN6n+BtwEgG9bTdOJxlTjN0mjRAfVPKfgoGT6HL78n3w3lTKhK4eM36fv8hT88wVmvPmbasvWotawKMOp0EZQEjtImjY4K+abXASuNJRkSjr6Hg1bC31fIErYnT428Z6SVVXFtenfO0jXA+QD88dE/cNZpWtOJlMMjT/X45u6di2JkL15b9nMsB5971fh74LETFxMO5m+ya199fMl17E+cCOiUTs3B/mnL1qPWhtNh7tlzFEd3RAl4rhW7hiweflHfY+cfs4jWsL5/73j+IC9f38Xy5hf9/ZsD+hrbE/q2vmSYZc3abFSnVtNa23d4G2es1+bOB0bTRELWuP06m0PUIjd/7Pzx75/VLk8nev3Zh85eU5Z6rvnuYTbfu5Mr3n7KtOXqUWsACSfiuyslrA7GnA62ey42HdEgMe/+3TucpC2SfzgTcekM69R2wfGS4Yn9OjXpMV0x/uKcXF+1lmeef4STjtWuZL0DCdataPX3sb3AVDlz31riS285bdz7z/1GP59dfMlR/mf/88GXlVzPj59SpDL6OqxavPCe2QaSQXaNHA1AJGDxfK92IbnriX287uzVfr/2m2d6uPxEbYa+IvYCjtJ9UDy48YgJVNIzi48FhY3tOe2cTzqrNWiJQ3+yifXt+ZlGzsWscJyuFXLjPN7/m/q0Ho7rynfol6zqOGK/2fKhr+xk6y+1i8l5H5re1bEetVYKC3uSbqhTFELjrJQZ5hOjNUO1MFozVAujNUM1MXozVIvG0pqZpBtqjkZbKTPMH0ZrhmphtGaoFkZrhmpi9GaoFo2mNWvmIgZDlRFtvjbV33wjIn8jIivnux2GMlAjWjOaagBm0Fot9G2FiMjfzHcbDHOkDrVm+r86pkbG0WIwWqtzGkxrC/qXdLdvhPRNtwEQPHkJ6ce1f/qun22h4+h2AALRIKMHtC/Kkqs36lWLRcunPW7/DzbR/ro0HHMPAML5nLFF+wXtu/JMOs/W/u7Jh3r8fZb86EH2vvqMsp1bJVl5x3+w57KPsvWlJwAw2OcQb9HrOS88n2XlCu2XcvKzxfuqP/dtXXZoGFZv7p2htJo5ndH8shx4QES2AzcD/9uyZAPfvOkxjj55iV/oucd7GNs3xF2dOkXK2O4hjr14HQC7XrqKtyd+DkDL6ccAbZNWpO69C+fSN+rX3INwPuL5b9KVQA1o38cXgm8k530tx38Ktfm6Mp5u5QjbQ34qHdzfctFfaN+tP33bKWx6/hD/ee69AMj6jxV9zFRSr7J2rG3joVtfmKF0zWjtCE0ppSbNH5dxQ+wdWUHAEtrCAwAknDZ2DGqf4bZIkLBt0ZvQeV5Wt8RwXO273hw8OGUDvnvvi/z5BesBaA/f4+vs6+9/Ke//n4cA+JOXr8VVeX+6L73lND5y8+NzPulq8k+vPsw1P9P+c++98Y+ceJz2Rw0GLA4PJAG47ZuPcd/3ri76mHdty39FazpnSC1ZO1orluX9Qyl+9NutrFrZxopF2sfyrvu38+S3ngTgJycvJjum7zcrHMD68Nlccaz2KY8G+qY88KGxDBlXP36sbM5r7aMvX8+vtuvxYXk8wva+MX+fV67p5He7p/f7rxXedJxOX/qTLRv5weYDbPFSf8Wbgjy/TZ/fy89YydXHLZnqEJMSCtksO2ERz2w6MEPJ+tMa8MBQIs2Pn9Df8cYVrezqPcQTz+pz7eqM+ekUM1nFqiVxAJLdLaxpGZv0oAA79umUTomUw4mdjwD6me0rbzudrz6k4xG1NofZc3DE3+fjF24A4J/vnGn8mH/+4TJ9fb50/0rfP71/KEliNM22p/W2y193HB99+fpZHfcPD+9msE/7ScfbIjOUriu9LQceGBxO8YMHc99/iHvu1rE0dvziBe5d1UrGO/fWkxcTCOjn37edFkWYOh1xzq+8NxFFkZ8fnL5Ia7VnrI9YMMreYX2tVsZ0mkCAfWO1NcGcjOM69P2za+Rstg/rMfOx/UN+3vLNO/t59znxWaeSe8lLlrHIS+N22IshMTX1p7VinuumwvySbqg5cuYsU/3NN0qpjwKrgH8ATgKemt8WGeZKrWhtMk2JyK9F5O0iEq9aQwwVYyat1ULfVoinSUMdUqdaWzVjQUNNUivjaDEYrdU3daq1OT/XmUm6oSYR3Cn/agGluUcp9QHAmE7VMbWitUk09R/AR4GZfjYz1AnTaa1W+jbDwqDetKaUapzkxwsQozVDtag3rZXyXLegzd0RIbVDmzodvGcXOzZpk6hMRvGiZ6bY2iosXqlTKiQe2EtTcxgJeak9psgG1fnt++l927l0XJX/bP+fnQ1Ay8o44U/+DIClaPN3gMGdQyw/a3YmIPOFcD4rf/MY287V6YVaOwJkEtq85LhTwgQ8k7Pdl72Elb95rKhjDuivgaPPbKVlZRzunK5+hVVjK2JTISInAm8KRwKsPbaLj15+DKvcXwIw9LqTGUitpDW0F4BLr7iHlg6dbuMdJ29l20t/AcD67y2CtZOng7Ku+h+WZB8Z95l791/ruo85Fln6XgCOAdLX/ykAwUtPQ23ZpstsLN+5VgLhfFq8201t+hFfv06f2y+f7uFL9pdIflObzCb33kL7N+4p6pjPfPdpAB75RYy3fnvNDPXXntZymgLeCPQCnyrcnnVhOJ2lZyTJjh5tXjc8NkQgoE3ODvUluOAly32zdEvCLG3WJsgBK0VkklR/AF+46iTfvPO4S/Kfv+Hzd7F6g+4MX3dUNxzVzfnv+AEAzStaWbq6rfSTrgLC+Xz+tfr1B7/1MIf69bXrbo9yz2/0eQfbo5x+3g08cu97izqm46XZfOq5g6y7YHpz0lrU2ky0NIe5+Jw1OFmX0YRueywe5sS3nQSAZQkvPqxTSZ58yXr2HBhhzwqdrmll3CU+SQpTgAtWtHH7Ts8cviv/+d17BuiM6p3OXBznzMVx//PhtMPiWLjcp1gRcub7f7oBfrr1EOu99F6DIyledZ52eQpa4pv2F5t6Mt4S4RUvXe2n8rxpyvrrT2sAtmUx7LlP3PbIHvbtHCDg5VQbHkz65ZyMy76eIQDSJywhEmhn0RQZbnOm619+YPu4z7/zTA/d7XqnP92wyP/8B5sPsHmH1uYxq9vLcFaVJae1j5wLn/z5MwA0RYPs3trHZVfqB4BoOOCnBSzWxSIxmuGKVx0LQCwSnFJrug31p7eO1ggXnKivRci2iMf0PCB96QYi4QDf/ZZ+tj3zwnX+Phk3SkBSUx5zSVR3ZgknOe7zgbQ2pQ/bFkubOljVHPXKPclgRrvXNgf7mMrtsVbIaW11M+wc0ddhQ0eMLX3aZfjd58QJWaMks9oFLmKfWtRxI+EAn3yt/q1rz3CYm/5iujbUn9Zg5ue6qVjYk3RDnaJqLgBEISKyAbgafcNlge/Pb4sMc6c2tDaFpi5VSr047Y6GOqI2tFYsIrJh3fEnz3czDHOi/rQGXL3q2BPnuymGOVE/estpbcOJpm+rT+pPa5TwXGcm6YaaxKamA0Pchg4C8Ual1NMAi9Ye90/z2yTDXKkRrR2hKcPCo0a0Viy3zXcDDHOnDrV283w3wjB36khvRmt1Th1qbc7PdWaSbqg5RGp7pUwptU5EAuiVMURkZfeaGrcrN0xKrWhtMk0BZwHblFL1ET7dMC21orViUUqtW3/CKcZ3sw6pR615/V9RJqCG2qKe9Ga0Vt/Uqdbm/Fy3oCfp1ooNtHztLgCGX30GG85qAyAYDWCH9aknehN0nKl9xSUeInnPTqJnnjXjsTu/ff+knwfXtvqvk9deSbgl5Ne58/c91KMxV+vqFoLN+jycRIaxg9q3PxANsv1CbTK09q4npz3G+XsnpGv7skxTWpUcpVFELgO+CNjAjUqpsuUkE5H3AP8KjIjI/wU+vqqzia+87XQAHj3mHwDYu1dxyftWIxGttT/e9nF+sV37a6o7v0HbXfqHqidHWjllmvrC9unj3rt7DgFgr8ynClRbvsDzX98EwPEnLocli6g3Et++jzXv075ab/7vH7P9hX5Wv0Uvfuz68TZa7/xLAKxLvjTtcR79wwf819/14lN/76+nKl0bWptMU8BjwKki8g2l1OdzZWNBS/vqLo7zztu0L/WLf9yD7fnyZhMZIuEAr3/paq+8Tb+Xlm5RZPr0Jp+65Gjv1dH+Z8lEhlg071z8iZ89DZb2Ex3ZM8jz2720WO89e7anPW+kU1kSKb0a/5NvPsbYLu3fGl0ex005XPJXtwBw53+8ZtrjvOc0L2bkacXEjqy81kREvO2XA2PAnyuligsccmRd7znttNN4/TG6L/nFizqOy5su3oCXcYeAZdHzJ3mtjKWy/OZJ7aP+npe1Mh2Xru7wXp3vf2YJxEP5oAlPHNZpsZpDNqMZHYcBgMX1lfBgcVz70m/oiuF6yx4DyQyxoD7XH285OM4veiquffXksUuOpP60Bvxrdyzk90HX37eN0zcuJuT5pMeCNls8P/TBkTRBW4vwyecO8cpjmoDpUyD+xTlrgbXjPlvanI9xcO/eAQAiIctPN7i/d3QupzNvJL0+bc2yFs5+00n+5z29Y/51vOHhXbz3jJmDm3//4xeMe/+maUuXprf50FpLKMB5y9sAGExv5czFOmVyxo1ii8NFn9OBWTYdHvPv0+892s+fnqL9zltDU9exNh6hsF8LeKnZcow4+lktao8SdQcAcNxpDliD5Hzzu6IuG9fvAMCWFEOZ5YQs3W/3pnbTGZ55bNT3pmbJFLEl8tRP3zab57qpWNCTdEP9UkqURhGxgf8EXgHsAR4WkVuUUs+WqXkfBdYDcWAzsBo4VKZjG6pMjWjtCE0ppQ6LSBPwMDBjZ26ofaqgtVcCG7y/s4D/9v6fCyYFWx1Th1pbD/TNudGGeWWuejNaM8yWOurbSn6uMynYDDVHLnrjVH9FcCawVSn1olIqjQ7WcGUZm5hWSvUrpXZ59Rwu47ENVaSGtDapppRSY0B6Dscz1Bgzaa0IvRWjtSuBm7y0Lw8CbSIy17QiRnd1Sj1qTSnVP8d9DfNMieOo0ZqhaKr0zFYuvZX8XGcm6YYaRPucTPVXBMuB3QXv93iflYuoiJwqIqcBIREpLs+EoQapGa0doSkReYn3PjKH4xlqjum1VoTeitFaOfu+GQ0PDbVK/WnNjKP1TEnjqNGaYRZU5ZmtZp7rGsbcfezgGOI50rUf1eZ/3rquFYl7+RGf68UK28iS98z6+Et+9CAA/e86H/W5VwMw8nwf4Rbt8xRqDtJ/2OHRY3Teye5VUUKtetvOxwc4a9tzkxx1fmlZof3+mhY1gef/FeqI0LRcfz66a4hop36O237hyTz/ZJLL+p4vS93iThu9sUtECpOH36CUuqFw90n2KWcApB7g373X+wteAzCi3XF49QsfZfgffwAjenUvOnSQH92qv+e7l7ybp/9Bx424/QtXzKrywFu/DYDznbcRWPozANShwxz/79qHKvPwLqxu/b30XHsGh7cN+36QJ1/7Uqyr/mdW9VWLpv/7EXZd/kkArKBN58YOnH3aJ3DjB09C4lp3P992iK/eqL/+X//LK0uut0a0Np2m9k+1UzKh237iJet59ve7ALCbw2xc20E8pLv3wZTj+9RFA7NPO3PLZy/l6n/TOeq/GA+za1sf685YBsCuzYcZ2aKtBs+8+EaCHfl5XWxN66y1XS1OP2UpP/zGowCIJcTWaP/pQDxE/NhOmtr0+PnpXz3L4s4mAD509pqS651BazC93orRWjn7vh7gmNybkaTj/7+2Q18TS6AzqsfPnuEU2/YM4nqdzaLo4llXeN7yNh7oGQTgoQPDjGWyAEQCFmFbGEvrY//ixcO0R3SchJBtsXtI+3wW49ddbZysosOL6WCJ4Cp9Dl1NIfoS+seUSMDmxkd388Pv69gu5bhv6lBr48bR/b1j9A+lOPWYbgAyrvJ9ruNNQbZs1/1OMBxgaVMHs+WtJyzlp1u1l9qvd/QykvK0FrQIef3l4Eiaf7r9eZZ1x7x6Q9z3iH52/9JbTpt1nZUm5MVzOHF1O5aIHzsivrTFj0sSj4X4t3u2AvC727fyq2svK0vdJYyj8661VDbO/jE9B1sT34TCQnm/YR4aSvHwPh0LoX8oybJzxsc1KIbmgI4lMeJsoje1m6Cl+4Mxpx3b0r7dTjbMUEbHmAlbQwSsNAcTer4wF31Xmp5R/ZW8pPtpf3KslEVz4CDJbJtf7qEDOg7O9d95jJs/dv4Rx5kLVXhmm9fnukIaZpJuqCOUAjc7XYnDSqnTp9m+ByiMVrEC2FeOpgEopS6c+Nnpp59uoiDXIzWitck0lUNEglNtM9QRM2sNptdbMVorW9+nlLrQ9Gt1Sh1qDcw4WreUNo4arRmKpzrPbDXzXGfM3Q21iXKn/puZh4ENIrJWRELowKS3VKqpXiRIQ71Sg1oTzUUiciN6wDAsBKbT2sx6K0ZrtwBv9/RzNjColOop/4kYah6jNUM1MVozVIvKP7NVRG9zea5rmF/S9+3JsmyFNgXa8+hhxryMCCs3NpO4fy8AydEsJz5Tmtn5oacPsaJdm7HHNrSz786dAPQdyHDGlvyxN59yrG/uvnRdlINveCkAi374h5LqLyfKM1tUrvJtP1TW8U3fI+0R+l7QJmf7XkzR3S3svuwlAKz8zZyyY+RqgeyMpnpT762UIyIfBm5Dp1j4hlJqUwkNmhQROQt4M/C6ws8zf3gAgK/sGOQdX7mI4fQSAKLR5+g/PADAph8+yyP3vrek+q0V3agxbYYlK1fxQvxdAIyemuUl3TqFzPL3QPANL6V/q1fvp/9A+416kXHFrY8cedB5RD3xewJNenExNZQiPRLA3a3Pz9naz+IPfwiAXQ+MYHvpZC5494+4++t/VkqtNaW1CZrqAD6ETtsxKRuO1aag61a0EvPSPEW99JLPeemDkk62ZDPgSFQf01WK17zyGAZHtIleW1eM67+cj7ly0ft/AoAVCZA6nOC8t34fgHu/M30Cn2pjiYCtNZQdy4CrB/dsIoMz5rBsdRsAoaBNV6s24b9zVx+XrCrF7LAyWhOR93vbvwrcik4bsxWdOuadJTR4HLffvQ2AZSvb/NRUowmHaFiPq7+/bwcr1raXbAZ8aEybgC+OhQl49roPv9iL6yo+cu46v9zPt2lT5e6mEN1N2uT+gZ5Bzlk6feq3apNIOTjeWGoJvrk7QJNnVr1/aIw9B0dwM1qHH/zWw/zXO84oodb61hrAvp0DdCxq5o7f7wCg//AY7V3azaLv4CjJhDbf/tmnXzHnOnLHPue0FYx5x7vn/h1+X3rDe3RA58/+ejMAR61s45TjtBvH/z5/0E9PWCuMDut+Oa+x/O8HudSGO3qGeOIJPd+ItYR5y/X38t2PnldizXPXWy1o7cbfD7KkU3//vUs20JvIYIn2W/zlr59n9YZOAK5/wykl1dOfWkPQSjCS0bp5pGeQVm+8LhxbBtIvEqWP9rCeP2TcrQStM0uqu9y4U9ghWJIhYg8AsHf0KLb1avelob4E773xj0D+vpob9de3zfa5rpCGmaQb6gilil0Rm+YQ6lb0jVZ2RORa4A3ALuBm4HOAifBej9SI1qbQ1CNKqW+V1DhD7VAhrXkPFbnXCv0AUDIicu1pp9We362hCOpQa8AbjN7qlBL1ZrRmKJo66tvK8VxnJumG2qSElbIq8F7geXTuxF8qpZKnnz6dC4yhpqkNrR2hKRExPnMLjdrQWrGUZupjmF/qT2vPA0fNd0MMc6R+9Ga0Vu/Un9bm/FxnfNINNYjyVsum+Jt/lgDXAq8BtorIt+e5PYY5UzNam0xTURExC6kLhhm0Vht9WyFL5rsBhrlSl1q7dr4bYZgrRmuGalGXWpvzc13DPACet/drPLHxfQAcOFDgE7ZjhO4NLQCMbRkquZ6jH37Wf73rFafijE2+4rPxief4ZYvObmNZsHKFdpKvJQ+nrg+/DICxHz7u+6FnhjNkvTQobsZl/44kAIEALDk6zsDO4dIrVsDM6WPmDaVUFvg18GsRiQBXAG/Nbb941dMA3PVkF66Ksjyi/XAeOHAmX/gr7Tv5r0viJbfDuiCfzUHt/CJH93wRgFsj/wc8n3TQcQ66D31Tl9v2PInvPVxy3ZXg8TWf4PiXPQNAZtcQkTOWYi3W96a0t/PDzTodyb5DhzjxNJ0u5bbb7i2t0hrR2hSaagL2iMjvlFJvnmy/f3yV9sv9/rMdxLyUVIGAhesqko6OgOqWZhkGwP988GX+68/95jkeeVCne8t9Dzl+99WrAHjNZ29naDjt9xu1xmtPCPP8hTqVziO/eA47lyIrEsCOOrR7KcaWdDbR7sVJGE7PGC17empEa8WilMoWWgh944O67X/+lX6Gh7Sf/mB/wvfffcmZK7nvt9vgLaXVe+X6bv/1zc/qLDXxWIgtuwYmLffVh3bqGAPA8q5YaZVXgJOWtZB09E1oCaSz+nU665LyXu85OMye3YOcdfF6AD/V2JypQ60Bvy7U200fcbn6C4P09uhninBziOFB/byxZEUrLe3RyQ41Kwr9/t//Pw8BOs7HTi+9W47PvnIjAK/93B10LtJj6+o17VBjPumvPFf3aTsOjXLU4jgJbwxIOq7vp/7U0/vZv3MAgNauGIP9idIrriO9Taa1T17SwzU/0z7hlhcHo3dAX5fLLt3APV7sglJZGYsBMR47pP3dT1ncwn3be/XGVflybaF1PHZoEe0RPUVrD++jLVSWJpSNXLyQ/vQa2kM7AEhlW3BUCFfpMfOpg8M88YJ+Rjnj3NWMenEfSqIOtcYsn+sKMb+kG2oQhVLulH/zjYicISJLAJRSSfRNZ6hLakNrU2gqCPwKqK0If4Y5Mr3WaqFvK0RESolcZphX6k9ruf7PUI/UxjhaDEZr9U59am2uz3Vmkm6oPZQXvXGqv/nna0AaQETOA66b3+YY5kztaG0yTX0LnZvznGo2xFAhZtJabfRthXxtvhtgmCP1qbX0fDfCMEdqZxwtBqO1eqZOtTbX57qGMXendxchL3V8KARJbTWFk4Vopzabau7V5i2Pb9RmtaduLi0d26o7Hh/3/sXzTvLTmmVTWQLe1R9LUHLqt0og570agOiegyQe0GnqBrcPYHspI9IjaVo8q207aDF2cIzjnyrTebglmpZWFlsplbOHeyNwA/CZ3EbxTHFsSxjNdBGwtK4OjKbp9cx99u8e9A/2ud88x6cvO7akBsnqj/ivX0XeTDSVyV1HnaZmxbLXcMmXSkkjVTlO7X4U9fG/BiD4+1uwzrkMRrwUf4FXcN+PtwJweP8Ix56g0+A89scPll5xbWjtCE0ppX4M/FhEnphqp6TTBkAoaPlmeqBN9nJpqXLmtQBfuGsLH79wQ0kN/fRlx0KBXn+6VZuzuUoxmtDaP+e8NQwOp/mXK08oqa5K0R19jrddoKP7xmMhtr2gkzMEghbrj+pileeOEosG2NM3BsC7Tl1ResW1obVisQvf5NIGhSNDtLXpMXN0OM3BvdocuWuCqfl1v3uBay46uqQGXH1cwQ9eJy/n07/S7mQZxyXmuSgc6h2juVlr/b1nrDriGPPNyV2Pct/ekwFwXMVggSn7i3v1ODA4rOcMSzq1UdZfnLO29IrrTGtKqb5CE+RDiWPp7XmI0Rf7AUg2BWk9So9d7V1NpApMZ9/5X78f55IzF776ziNTXJ3/jh8QaImQ3K/NkxO7Btnrub98/a7/U1J9leDytdpd7H8G1vPkjj7fxN0SYX+v7seGB1K0L9Ym+8GQzY8+dVF5Kq8fvR2htYTTQTqdcw9TDI+m2blH35vWKmF0KD+nzz1bjeubZslLCtwR15+sXcZyaf4AYpEAw2MZFnv9wYfOXketcWr3owA8fOAlLI7pe0fQzxpPHtQpOp/f2eenBXzJMYt448bF5am8zrTmvS76ua4Q80u6oQbxUixM9Tf/2AWBHy4GfjefjTGUQs1obTpNNc5i6oJmBq3VRt9WiD1zEUNtUn9aM0Ey65maGUeLwWitrqlbrc3puc4I1VB75MxZapebgXtE5DCQAO6b5/YY5krtaG1STYnIUcDgdDsa6oTa0Vqx3Az803w3wjAH6lNr98x3IwxzpL70ZrRWz9Sh1kp5rjO/pBtqkxpeKVNKXQt8DPgmcK5StZf3wTALakBr02jKAv6iag0xVJY6+nXT06ShXqk/rX1svtthKAGjNUO1qD+tfZM5Ptc1zC/pEgix9nLt5xW+Z7f/ecvKOPsfOwDotGjbzj2RQAWM/BKfvYJlf7IWq0lfcpVxWXFA+21s+fUu7lyk07FdcvD58lc+R4TzAbBf00vspTsB6HvvTfTv0v5ZTW1BVl+6BoD9D+4j0h4pT8VKQba2fU6UUg9Ota0vo9PofDb4/3jDF68iMar9mVo6DrNomU4p9qtrL+P8d/wAgHOuOr6sbet927m8dn2bbudwmqZ/fD+7eCUAW/uTfOJnOkXc5197YlnrLRXhfPrS+t7sPONC1PYnSPzXbQB894pT2LBW+yNGYyFct0zrIjWktck0pZR6Ybp9Apb291rZEiWyQXdclkA8FODAqN72pxsWcftO7RYVCpa3c3ugZ5Dl8YjXFiHQof3ij10c54/bDvNv9+g4Ah87/6iy1lsqwvmc0KEv99qLu/jPoPaVO9Q3xqolcY5drH3Sdw4kaG0uU+6bGtLaXBDRD0Cnn7yUR57sAWB4MElbl/ab3L61l9s+fznvuUFf19NPWVrW+n+9o5eXHq+/p7BtMZzWv6Yc6mxi137tF//xnzzFF646qaz1lopwPqcv1n3uUGYpd27T7U5nsgRs/TvJisXNRMMB38++ZOpQa0qpBwv9hEP2KOtPXMxOLwZONBZk0XI9fu7fPci3P/JyAK749G0sWdFa1ra890adNvXkS48iGM4/Jg/2Jdj0C/2Mds5rb+KBn729rPWWSu6Z7Q0nbmLvyDq++HPto54YTZP04oWccOpSnnpUxxhasqKlPBXXmd4mai2rAlx65jIAfnjrcwz2JYi36XFth2X5fvtv++J9vOHVG8vali2DOmbRG89eTSSg+4Nt/WPs6h3z08CVI25RuclpbWPHZpLZNgB6Rlvojqbo9fzQO1rChIN6WyhYpt+E61Brk3w27XNdIQ0zSTfUGTW2ImZYwBitGaqF0ZqhWhitGaqJ0ZuhWjSQ1swk3VB71JfPiaGeMVozVAujNUO1MFozVBOjN0O1aDCtNcwkXbUuIXK5NivuOpwg66VBEVuwJ5hhjCXKV697t04pFb7gaIiEIanNQEinCTbpNDbHLmum444d5au03DRfhagfA9B5Qhf9e7VJcvtRbQSW6rQ7betaSfanylenW78rZe1h7RqQ7RngM9/7IKN3PgRAbyLDT+/Y4pc79890eqpH7t8JZUhVlfrX1wHQfFwXVrfWVnbfCIl/uZGVb9XWNStjMS565Xpvj9oydwfoDK8EYMQZYuQTnyPWrU1pLUvo9NI+Letu5q4Hd5av0jrWWi6938p4hrGMNmUP2YIzwR0g4WjzsHSmPGZiu0a8elsCWHipa7BwlR5SuqOjRI5ZxGN7BspSXyUIWGcD0BR4iA0r1wAwmsiwpDVCyNZm+6GATLX73KhjrcUCOk3dy49aS8ZL67fnwAjhkNZdn5eqLhTW70cLUmSVyr6xAU7qDhKytYtYxo3iuDqNUXZRnGc7dD+x48Bw2eosJ02BXF/7NLGITt2UzmSJx7QrRXs8TGtzuGz3J1DXWgNoDe3mVecfz/f6dF9jWUImpa9Pv5dODCCbcYlEy/co+51nerjwnNWANtFNpLL+99L9kgidi/QzzyO/fbFsdZab5sDxLI294KdFvP8PuznjMp16s7M1wuqjuwAY6ivnw2796q05eJDTl7QBsPj1J/Ozh3b5rmH9Q0m/XGtHFEvKNyYMZzazRHdd2OLgemHCOiNBTujuYMegdkfYO5yc6hDzTjy4EZFNACxpssi4UWIR7bbT3hzyr9dYyvRtc6FhJumGOkIpncDeYKg0RmuGamG0ZqgWRmuGamL0ZqgWDaY1M0k31CYNtFJmmGeM1gzVwmjNUC2M1gzVxOjNUC0aSGtmkm6oPZQCpzI+JyLyeuCzwEbgTKXUIwXbPgm8G8gCf6mUuq0ijTDUDhXUmsEwjgprTUQ6gB8Aa4AdwBuUUv2TlNsBDKP7OUcpdfrEMoY6x2jNUE3MOGqoFg2mtYaZpAvnw1GbAWh5l43zR50ayDkwhmzu88sFowHO3PaV8lXs5XOTcAQsC2zvkre3geeTHlx7mGC50vxUCs+vRII2Ia+p2WSW5HP62iV6kyz/xcPlqauyN+EzwFXA1wo/FJHjgDcBxwPLgDtF5Gil1KztanKpKQJXHea4oIXs+BcAbrDez64th/1yIyM6NdtvPh+by3kcgb1M+2haLREd/wCwFzVDV4f/PvHFX4CX9qfpXy8vS72VIOuGcTMuzZ95MwCrBlt4/coHAEh98Zu8/pM/K09Fdd7h57TWHNzMMR06PdVAKkLGVfQn8z7BIe87/5sL9wEbSq/XS8cVkHwcCsEl6PnIh6wRgtaisvrvVQrBpTWi++WOljC9o2keev4QAHf+4Gnu/vqflaeiymvtGuC3SqnrROQa7/0npih7oVLq8BTbJiWntaWxF3nNiVpr97dE2L5vCIA2L2ZELK77mr8+fy9QntR7ljgE7QTixT+wbIeIPQCAq4Ic1a7TM/Z76S5rmeExfV8Oj6b9lGsh2yLeEuaSVR3lqaTOtQZabyctSsHrdCyhR717EnQKthyuq/jy20Zne/gpCdoWTeF8qspAVIi1aE13REN0terUXKqc8QMqgCUZUhndT1uRAPEm/eAWDtqcuEH7pL/r1BXlqWwBjKMRW88Pjmob5tJTl3P3M/sB/LgRAMFwgMvXPuO9O7/0esXFxvFf56JjKRyagwc4tiPqfdJVcl2VRCnd8sF0Cz0jKZq9++fYzhjd0W2AjpNQpsrqWmuzpUyJ6wyGMuOqqf9KQCm1WSk1WTL6K4HvK6VSSqntwFbgzJIqM9QHFdKawXAE02mtdL1dCXzLe/0t4LWlHtBQxxitGaqJGUcN1aKBtNYwv6Qb6oiZV8q6ROSRgvc3KKVuKLHW5cCDBe/3eJ8ZFjINtiprmEeK01opfdtipVSPrkr1iMiiqVoC3C4iCvhaGfpOQ61htGaoJmYcNVSLBtOamaQbahKlpg0McXg63zYRuRNYMsmmv1NK/Xyq3SZrxnSNMCwMZtCawVA2itDanPu2WTTjZUqpfd7E6g4ReU4pde8s9jfUAUZrhmpSqXG0mPgHIrISuAmtVxe94PTFijTIMO800jNbY03SE9pvSdrbCazW+Qfd4TROQf6+VXc8XtYqpb0dANXfD5aF5HzSQwU+6KEQcc+fuFZR/T0A2IubWPHSZQCMHhrDzep5bNn80aHklTKl1CVz2G0PsLLg/Qpg35wbAahMEuvkY1HDOnfvU5sP8qmPnOtv/+LVp5Zy+COwL3uFrvfeu8DxfOo62pDFiyDg+aOdNtkzV+3R0vMrWv7rnXzm0XMAyLqHeMnSywBY/8nXlq+iBbIqm1Vh3x88Emgi4Cr2HPL8NNd388o1nV7J0v3oAKKeP/CY0+H7p9uS8X3UFTYBS4g3BctSXyUZdbpY5PkdvuyYRQylHDJL4gDl80eHsmhtur5NRA6IyFLvl82lwMEpjrHP+/+giPwU7dZT9MTJVZb//a/tiLPv0AgA0bD22/3CVScVe6iiGUzFaAlZ2KL9uS1xsK1czIUMuTTZ0QJf4lokkW0jGNBehoGA5edgjkWDXH1cGfvmBaK1/mSGTs9vf1lXjMER3b+kCmIP3Pb58sZWWd/ZxLaCPOyRkEWTlzPbVYomrz2LN3ROun+t0DO6jnBwOwAnnrOKfT06dkQ4aPHxC0uPSzKOyo6jxcQ/cICPKaUeE5E48KiI3KGUena2lQUkxcqWCGkv5sCaZS3+tuvfcMocT2FyDiXW0xXR35GNg5CffNo4uKKvacCq/dguAFv7x9i6bwjXMzuPBW3Wxsvki55jgTyzFYvxSTfUJtX3ObkFeJOIhEVkLTq61kOVqsxQQzSQf5Nhnqmsn/AtwDu81+8AjrAaEpGY9xCLiMSAS9HBNA0LDaM1QzWZx/gHSqkepdRj3uthYDPGXXHhUiGtiUiHiNwhIlu8/9snKbNSRO4Skc0isklEPlJSpTNgJumG2iO3UjbVXwmIyOtEZA/wUuBXInKbrlJtAn4IPAv8BvjQXCK7G+qMCmrNYBjHTForXW/XAa8QkS3AK7z3iMgyEbnVK7MYuF9EnkQvQv5KKfWbUis21BhGa4ZqMvM42iUijxT8vXcWRx8X/wCYKv4BACKyBjgV+OMcz8ZQy1T2mS1ntbEB+K33fiI5q42NwNnAh7zsUBWhoczdZf3HAHDv/Ruyh7RpaGLHEBufeK5idSa+fR8AkYvWk91+GHuxl26rvx9atEml/38No3bvAiCwqgW7qwmAzF07abvx7gpUBriV8TlRSv0U+OkU264Fri1XXdLxFlTiv5El2op+1VgrF6xoK9fhj8C9/U4ArPNfivqjNgKQ9eugcxmkE/42srU/+VQ7d2OdchaXnKJdK75/5xbWt0QqUBEV05qIvB74LLAROFMp9cj0e8ydttA6do3o77g3kWEkneVDZ6+pVHXc+oI2v3v5WqFnWOupPRKiKeillbQSxIIpRpO1r7W+1ApataU28RA4ruLtJy0rf0UV1BqAUqoXuHiSz/cBl3uvXwROLqWejvAatnlm2iHbIRLWjxGV1NsLfaN0N4Voj2h9BSxh77BuQ3dTiMFUxv+8lnFVIJ/eqyWC7bW3rKbusGC0dkpXMz/YfACAnfuHfRPkO//jNaUcdlp++sddHLNa/4D2wKN7WLWyjRWLtDtiZzzMmsX6eW3H2iN+ZKsp+pOOb6odCto8/LROKVZ2U3coRm/ViH+AiDQDPwb+Sik1NJt948GNAOwdHcJxlf+dly1N3SQMphwGU/r5cHFT3oVj93CQJbEACX/4rO1xNKv0ABoN2HS1RRn23FHOW95W/soq27ddCVzgvf4WcDcTXCu8haLcotGwiOSsNmbtWlEMDTVJN9QLjeVzYphPKqq1Z4CrgK9VqgJDPWH6NUO1MFozVJPKxREqNv6BiATRE/TvKqV+MufGGGqcivZtxWatAKpjtWEm6YbaQ6mK/gpgMPhUUGtKqc0AIrX9656hSph+zVAtjNYM1aSyesvFP7iOqeMfCPB1YLNS6t8r1RBDDTCz1qZNLVkLVhuzwUzSDbWHAhzjDm6oAjNrrZRcwgZDHtOvGaqF0ZqhmlRWb9cBPxSRdwO7gNeDjn8A3KiUuhx4GfA24GkRecLb71NKqVsnOZ6hnplZa9O6VtSb1UZDTtKt8/4f1nn6dfv7KltX03W/ztc7YZt76/sByO7s5/CmwwDEJjnG0PsuBKDla3dVookzcvANL6Xr7TqtjsQiSFjfIJEllUobt3BM9WT5B/zX11xU2brsN9+Ur/eqD4zblnG1j3pwbA+pr30HgPDH/uLIg2S8uD7ByyrTyBnI3RO0xFG7t0CbTit3ynGLK1TjjFqbsy+dUuqIFf9Ksqo56v1f+boKfbbXxo+MFbBtSLFzMMFv730RgLeesHTS4/zdLzZx7avLnKKlSN57o7ZQ++ifnkjI1r1zyM4SCVQqnurC6dcK40O8pLvygnv1uq4p2/DzbYewPGsVaxqrlV/v6C1IRVhdfrxFP+sd19XKCd1aXzsHE2QrlkFi4WjtjRsXj/u/0hT2RxNjU9y+s49ez992dDg15TFufnZ/+eMMzIIv3LWFVUtacBz9i2M0HKC9rQIxXXwqp7ci4x/cD5TFZG15TPvxrz9jVTkONy2ndE3edy5t0lrryKUfbJ56Uro/oecOS6JH9pHVYO/oEGFb+6Qf35Ug4YQq2K9Bhfu2mrPaaMhJuqHGUaCyJv2VoQqUqLXpVmUNhnGYfs1QLYzWDNXE6M1QLSqrtZqz2jCTdEPtoRRkjD+doQoYrRmqhdGaoVoYrRmqidGboVpUUGvVttooBjNJn0esy78KQO+bzkGmSB0z+tFXkB5JT7qtWsQ3tCOLvSCHXR3I2o8C0FShLCgKUBU1l2k8gtaZAAz81d8S3dgxeaGxnzEWWg9AU7UaNgF3v46/YS9fhqxYz3mtbUCFUnlQWa2JyOuALwPdwK9E5Aml1J9UpLIaY31LhOt//gzRWGjS7Tc+uhuARe3RajZrHN2LtalhazhN2B4GoDO8kpWT+RyVAdOvVYYr13dz/75BAIbTR5pB5raNpObPR3u55xLSHFLEg/sAWN+yDlZWpj6jtcpw6eoOPvrDJwDoOzh6xPYbHtapagdHUjCP5u4rFsdZ29FExEsjdlJnrKLtMXorP5eu7mAwvRWAkczkQcb3jg7Rm9Rj6JJ5Gko7wtvJelPJgKR55ZpTK1pfo2nNTNINtYcLpE3QG0MVqKDWlFI/BX5akYMb6g/TrxmqhdGaoZoYvRmqRYNpzUzSDTWIaqiVMsN8YrRmqBZGa4ZqYbRmqCZGb4Zq0VhaM5N0Q+2hMP5NhupgtGaoFkZrhmphtGaoJkZvhmrRYFozk/QaoPv7Dxzx2djHLgXAbo/Qef3fV7tJ4wisiEOT5/AyNFz5Ck2k0IrRduPdk37uPvhJ9p7496wIPDLp9mohMZ1yRI47kxFZScWTOxmtVYyvvG3yzHXX37eNU9fqVFjnr3gSWFfFVuU5+3id0iliD2BJFQZ9o7WKce6y1kk/39Q3StLLqftnx2wGJvftrBaOa/NCfzcAZ1Yyo5jRWsW4/g2nTPr5DzYfwPJiC/3NhfuADdVr1ASyriIesqdNSVhWjN4qQmvoKO//8Z+nsvo57VDiWE7uyj2znV/FluVRWDiunh+MZBdX3je+wbRmJumG2kMpyDSOz4lhHjFaM1QLozVDtTBaM1QTozdDtWgwrZlJuqEmaSSfE8P8YrRmqBZGa4ZqYbRmqCZGb4Zq0UhaM5N0Q+2hFKQbx+fEMI8YrRmqhdGaoVoYrRmqidGboVo0mNbMJL1Gafq32+e7CT6Bc0+EUNB7UwXJKFANZM5SC1hn/4uXsnd+/Jr8drzxXQCMOR0Mp5fSXGm5Ga1VnY++fH3Bu/nT29nLMgAErDSWZCpfodFa1Tm+I8bxHbnE9/OntWXNevxMZZXvI19RKqw1EXk98FlgI3CmUmrSYCYichnwRcAGblRKXVexRs0zb9xYGGRg5by1A+DUZS00BW2CVsL7pMKOwqZvqyphW8d7OaUL5vuZLe3GGEovBSDjSsWl1mhas+a7AQbDRJTS5ixT/ZWCiHxBRJ4TkadE5Kci0law7ZMislVEnheRPyn1PAy1TyW1ZjAUMpPWytC3vV5ENomIKyKTR+3T5S7z+ritInJNSZUaapJKaw14BrgKuHeqAiJiA/8JvBI4DrhaRI4rtWJD7WHGUUO1aDStmV/SDbWHUpVMsXAH8EmllCMinwc+CXzCe3h4E3A8sAy4U0SOVko1zpJdI1JZrRkMeSqvtdzE6WtTFSiYOL0C2AM8LCK3KKWerWTDDFWmwlpTSm0GkOmjh58JbFVKveiV/T5wJWC0ttAw46ihWjSY1swk3TAjqrcPLG10kfrdc0Q/+7eVr7NCKRaUUoV+BA8Cf+a9vhL4vlIqBWwXka3oh4w/VKQhhkkZyegUSbY4tIb2Ah0Vr7OR0nkY8iScNgAcN8y2ARuAc5dVts5Kas1MnGqXjKu/k4ST5bl9QwCct7ytonXWQL+2HNhd8H4PcNY8taWh2DucoinosKNPm7u/9YS2itdZA3ozzAPJbAvipTB1VXWMsxtJa2aSbqg9Zk6x0CUihT5wNyilbphDTe8CfuC9Xo6etOfY431mWMg0WDoPwzxSnNbK1bdNhZk4NQJl0JqI3AksmWS/v1NK/byIVky2WtQ4T9eNhBlHDdWiwbRmJumG2kPNmGLhsFJqOp/LGR8uROTvAAf4bm63yVtiWNDMrDWDoTwUp7WS+7YZMP1cI1AGrSmlLimxFXsYH0FtBbCvxGMaahEzjhqqRYNpzUzSDbWHAlWCz8lMDxci8g7gCuBipVTubjcPFI1IiVozGIqmDFozEydDUdRGv/YwsEFE1gJ70TFf3jy/TTJUhNrQm6ERaDCtmUm6YUasC/7dfx09rzp1VsrnxEsJ8wngfKXUWMGmW4Dvici/owPHbQAeqkgjDFMSD26sep2N5N9kyLOqOZcrJsrSpurUWQNaMxOneWB9S8R/fVJnbJqS5aOSWhOR1wFfBrqBX4nIE0qpPxGRZehUa5d7wVk/DNyGTsH2DaXUpoo1yuBz6Wody+XcZa1Vq7MG+jbDPLAk2lX1OhtJa2aSbqg5lFJkK7dS9hUgDNzhBVh6UCn1fqXUJhH5ITqAkgN8yER2X/hUWGsGg0+ltWYmToYcldaaUuqnwE8n+XwfcHnB+1uBWyvWEENNYMZRQ7VoNK2ZSbqh5lAKXKcy82Ol1FHTbLsWuLYiFRtqkkpqzWAopNJaMxMnQw7TrxmqSSX1JiId6AC/a4AdwBuUUv1TlLWBR4C9SqkrKtIgw7zSaH2bmaQbZo+6K/9aLqzA8VVDmbMYpsFozVBFFPcAIJxfgYMbrRny5LQGFdCb0ZqhgIpqDSqtt2uA3yqlrhORa7z3n5ii7EeAzUBLpRpjmJ4611rNYSbphtpDgdtA5iyGecRozVAtjNYM1cJozVBNKqu3K4ELvNffAu5mkkm6iKwAXoW2hvzrSjXGMM80WN9mJumGmqSRUiwY5hejNUO1MFozVAujNUM1mUFvXSLySMH7G5RSNxR56MVKqR4ApVSPiCyaotx/AH8LxIs8rqFOaaS+zUzSDTVHowWGMMwfRmuGamG0ZqgWRmuGalKE3g4rpU6faqOI3AksmWTT3xVTv4hcARxUSj0qIhcUs4+hPmm0vs1M0ieh0Kcix2S+FZOVmysV8d2oAIp7QCwAxElVRkGqsVbKJupoKi2US2/1qDUAqUwlRmtFlJsLotzKxBGoBF7sAwFUgebKW4fRWjHlSqEe+rbC81XKG0vL3bkZrRVVbi6I8iYI9dC3FfRrWcIA2JUYSEvUm1Lqkqm2icgBEVnq/Yq+FDg4SbGXAa8RkcuBCNAiIt9RSr11zo2aqq2mX5uS3DlXrF/TlVSsb6vFIIUVehoxGOaO8nxOpvozGMqF0ZqhWsykNaM3Q7kwWjNUkwqPo7cA7/BevwP4+ZH1q08qpVYopdYAbwJ+V4kJumH+qbDWckEKNwC/9d5PRS5IYUUxk3RDDaJQrjvln8FQPozWDNVieq0ZvRnKh9GaoZpUdBy9DniFiGwBXuG9R0SWiYhJJdlwVFRrV6KDE+L9/9rJChUEKbyx1Apnwpi7G2qPBoveaJhHKqg1EfkC8GogDWwD3qmUGqhIZYbax/RrhmphtGaoJhXUm1KqF7h4ks/3AZdP8vnd6AjwhoXIzFpbUEEKF/gkfbhsfiHl9C+Z7fFrwR9l0vYFLi3PcSaWUeDWnT+d0Vo5KdbvazbHmLRMZbV2B/BJpZQjIp8HPsnU+V1nQX1oTft2e3nHlTvO17uW/DqPjH1Ql1qrEPWhtWLqqIW+bWL7LHl5yceYtExdag3KpbfK92sA9/j9WO6zWu7XbM6Z2zGKKVeXeqt9rRVTRyP1a1CU1hZUkMIFPkk31CVKmV8BDNWhglpTSt1e8PZB4M8qUpGhPjD9mqFaGK0ZqonRm6FalKi1egpSCGaSbqhFjKmeoVpU1nSqkHeho4YaGhXTrxmqhdGaoZoYvRmqRWW1lgtSeB3TBClEW0Xi/ZL+N5UMUmgm6QuQapjfVLINisZKH1PXqLsql7Kq2CZUVmtzNp1SSv3cK/N3gAN8d84NrXPKohEvndDE4000pZ/4+UST1Ny2/JsJn0+TNqZQa1PVO/W+pl+rGzytzWffZsbQ2qfS/dpkdRT2O1O6EUFJ/dpk9U57Chi91QtmfjAt1wE/FJF3A7uA14MOUgjcqJQ6IgZCpTGTdEPtoRRZsyprqAYlam060ykAEXkHcAVwsVLKPMU0MqZfM1QLozVDNTF6M1SLCmqtFoMUmkm6oeZQgMkQY6gGldSaiFyGDhR3vlJqrDK1GOoF068ZqoXRmqGaGL0ZqkWjac1M0g21hwLHme9GGBqCymrtK0AY+P/bO+84Sco6/7+/1WHyzszubM4sy0oSkSgGQJEDRDEhmBOneHreeUb09DgVRT1P8acHcugpqJhRVEQwgCCuJAXJbGDZvDu7Ozl1d31/fzzVYWYn9Ex3V3dPf9+v17ymuuqpep6q/vTz1FP1DbeKCMB6Vb24ZLUZlU2J+zUROR+4FDgcOFFV752g3FNAL5ACkpO5cxhVimnNCBO7ZzPCosa0ZpP0KqASfEjGo1TtUqBULici8ingPMDHRW58S2DKgohcArwdd0PxXlX9TWlaUblM+zsNyWezGrWmqoeW5sjVzWg/yml8rxNobSLfyfT68bZPvk9+fufT9UctpdYCHgJeCXw9j7Knq2pnSVtTYUyrD7F+bSpMa2MIu18br8x0+rWJys/Ezz4EvRkTUInzg5KmQKS2tGaTdKPi0NI+KfuCqn4cQETeC3wCuFhEjgAuBI4ElgC/FZHDVDVVspYYZafEWjOMDKXWmqo+ChBYbRg1jGnNCBMbR42wqDWtlTcss2GMhzqfk4n+Cjq0ak/OxyZXG+Dern9fVYdVdTOwATixsNqMiqeEWjOMUUyhtRD1psAtInKfiLwjtFqN8DCtGWFi46gRFjWmNXuTblQcypRPygrKXS0ilwFvArqB04PVS4H1OcW2BeuMWUweWjOKTLlT9k2HYrY1T61N2rflk/IvD56rqjtEZAEuXsJjqvrHPPc1qgDTWvjUar8GNo4a4VFrWrNJulF56JRPxArKXa2qHwM+Fvigvwf4D8bPIlpDni81ytRaM4zikJ/WJu3bpkr5l1czghgcqrpHRG7AWQzNyolTzWJaM8LExlEjLGpMazZJNyqOQn1OpnFz8T3gV7hJ+jZgec62ZcCOmbfCqAZqzb/JKB+VoDURaQI8Ve0Nls8EPlneVhnFxrRmhEkl6M2oDWpNa9Vjn2PUDAqkUjrhXyGIyNqcjy8DHguWbwQuFJE6EVkNrAXuLqgyo+IppdYMI5eptFaEvu0VIrINeA7wKxH5TbB+iYjcFBRbCNwpIg/g+rdfqerNBVVsVBymNSNMbBw1wqLWtGZv0o3Ko7TmLJeLyDpcCrYtwMUAqvqwiPwQeARIAu+2yO41QI2ZThllpMRaU9UbgBvGWb8DOCdY3gQcU7pWGBWBac0IExtHjbCoMa3ZJN2oOEoZGEJVXzXJtsuAy0pTs1GJ1FoQEqN8mNaMsDCtGWFiejPCota0ZpN0o/KosSdlRhkxrRlhYVozwsK0ZoSJ6c0IixrTmk3SjYqj1gJDGOXDtGaEhWnNCAvTmhEmpjcjLGpNazZJNyoSf/bFfzAqFNOaERamNSMsTGtGmJjejLCoJa3ZJN2oOGrtSZlRPkxrRliY1oywMK0ZYWJ6M8Ki1rRmk3Sj4lBqy+fEKB+mNSMsTGtGWJjWjDAxvRlhUWtaE9XZazcgIntxabaMymOlqs4fb4OI3Ax0TLJvp6qeVZpmzQzTWsUzrt5Ma0YJmKnWoML0ZlqreGaN1sD0VuHYPZsRFrNKa4UwqyfphmEYhmEYhmEYhlFNeOVugGEYhmEYhmEYhmEYDpukG4ZhGIZhGIZhGEaFYJN0wzAMwzAMwzAMw6gQbJJuGIZhGIZhGIZhGBWCTdINwzAMwzAMwzAMo0KwSbphGIZhGIZhGIZhVAg2STcMwzAMwzAMwzCMCsEm6YZhGIZhGIZhGIZRIdgk3TAMwzAMwzAMwzAqBJukG4ZhGIZhGIZhGEaFYJN0wzAMwzAMwzAMw6gQbJJuGIZhGIZhGIZhGBWCTdINwzAMwzAMwzAMo0KwSbphGIZhGIZhGIZhVAg2STcMwzAMwzAMwzCMCsEm6YZhGIZhGIZhGIZRIdgk3TAMwzAMwzAMwzAqBJukG4ZhGIZhGIZhGEaFYJN0wzAMwzAMwzAMw6gQbJJuGIZhGIZhGIZhGBWCTdINwzAMwzAMwzAMo0KwSbphGIZhGIZhGIZhVAg2STcMwzAMwzAMwzCMCsEm6YZhGIZhGIZhGIZRIdgk3TAMwzAMwzAMwzAqBJukG4ZhGIZhGIZhGEaFYJN0wzAMwzAMwzAMw6gQbJJuGIZhGIZhGIZhGBWCTdINwzAMwzAMwzAMo0KwSbphGIZhGIZhGIZhVAg2STcMwzAMwzAMwzCMCsEm6YZhGIZhGIZhGIZRIUxrki4i60TkryLSKyLvLVWjwkREnhKRM6Yoc6mIfKdI9b1LRHaLSJ+IzJvB/kVryzTrXRG0OVLCOj4qItfMcN/TRGRbsdtkGIZhGIZhGIYRJtN9k/4h4DZVbVHVr0xWUERWiYiKSHTmzZtdiEgM+G/gTFVtVtV95W5Tvqjq00GbUyWs4zOqelGpjl8K7MFVUeor6MFVcIwp21xJmG6KUt+MdFOqB3oi8nwRebzYx50JtaqvaqBUD9oLechdxDbUpO4qoV8rJUFbDqmAdtSkvmqZShpXy8F0J9Arge+XoiHFQEQipZxEFoGFQD3wcLkbYhSN9IOrY6cqKCKrgM1ATFWTpW5YNZDz4OpkVX2g3O0JEdNNAVSiblT1DmBdudsRYPrKoRbOUVU/U+42YLoriOn0ayKiwFpV3VDqdqlqc6nryBPTVw7lOkcROQ34jqouK3VdFTauhk7eb9JF5PfA6cBXg6dqh4nIS4KnWj0islVELs3Z5Y/B/66g/HOC47xNRB4VkQMi8hsRWRmsFxH5kojsEZFuEXlQRI6aok3fEpErReQmEekHTp+iTYjIG0Vki4jsE5GP5Xv+Y45xsojcJSJdIvJAINj0trcG59crIptE5J3B+sOA9NOgruB6TlbHkSJyq4jsD56qfnScMge9Ecp9Khc83f2RiHwnaM/fg+/tkuA6bxWRM3P2vU1EPisidwffwc9FZG6wbZRlRFD2UyLyp+DYt4hIR86x3pRznT8+3afROfW9WUSeFpHO3O9LRBqC7/+AiDwCnDDmWEtE5CcisldENkvw1FVE5orINhF5afC5WUQ2iMibJmvbJKykgh+6SAndE4pErT64Mt0Uxox0I7Vj2WX6qkBqQH+mu8Ko1fEwX0xfRm2hqnn/AbcBF+V8Pg04GjfZfyawG3h5sG0VoEA0p/zLgQ3A4bi3+P8O3BVs+wfgPqANkKDM4ina8y2gG3hu0Ib6Kdp0BNAHvACowz2xTAJnTFHPpbinRgBLgX3AOUEdLw4+zw+2vwRYE5zDqcAA8OyJrskE9bUAO4H3B+fUApw0TltOA7aN2fep9PkEZYeCaxsFrsU9dfsYEAP+Edg85vvdDhwFNAE/yalrVNuDshuBw4CG4PPlY67z84A48F9AYprXOV3f/wbHPwYYBg4Ptl8O3AHMBZYDD6WvRfC93Ad8Iqj/EGAT8A/B9jOBXcCC4Pg/ns7vIKe9vwdSwTXuC67FS4C/Aj3AVuDSnPJPB+fUF/w9J1j/NuBR4ADwG2BlsF6ALwF7cDp/EDgqj9/ElcBNQD9wxmRtCvZ5I7AFp+OP5Woon+8q+HwycBfQBTwAnJaz7a3B+fUG38M7g/WHBW1MX5PfT1LfKUAnsDz4fExQ1zPG6r7S/0w34ekmKK/Au4Encf3facA2XP+6B9fXvjWnfCuur9wbnN+/4/qUuqCdR+WUnQ8M4vqS08jpj4EP4/rTXtwD2heZvkqurxOBe4Nj7gb+eybnmKObfwp00wt8Cje2/zk4/g+B+BTtSWvtw7gx5zrcb+CHgcZ6cZOO43P2ORw3nnYF216W81vZBURyyr4CeHDsbwt33/Cd4Np1AfcAC013s6Nfw70E06B8H3AB0A78EtdvHQiWl+XsM+o8xujlZuA9Y+p4AHhlzm/h0GD5HOCRoP3bgQ+UUlemr8rq13Bzg0HAz6l3SdDGP+M0vxP4avo4jD8fvA24iCoZV8v1N90fyW3kTNLH2f5l4EuTfCm/Bt6e89nDTWJXAi8EnsB1bl6e7fkWcO0UZXLb9Ang+2PENpLHD+RSsp3Zh4Hrxmz/DfDmCfb9GfAvE12TCfZ5LfDXPNoySrzBuqcYPUm/NWfbS4MfVCT43BK0py3n+708p/wRwfWJjG17UPbfc8r+E3BzznW+Pmdb4wyuc7q+3EHmbuDCYHkTcFbOtneQnaSfBDw95tiXAP+X8/n/AX8HdgDzZvwDsgdXEMKDq6DsZbiBugE3gL4nZ9tTU7W5kv5MN6HqRoFbcQ/0GoLzSgKfxD2sPCc4dntQ/lrg57j+cRVuXHp7sO2bwGU5x3432X7vNLJ90DrcDdqSnPauMX2VXF9/Bt4YLDfjzIanfY45urkRmAMciXtI/DvcQ99W3ETlzVO0J621zwXn0UD24fk5uLH1s8D6oHwsaNNHcQ+YX4i7GV0XbN8IvDjn+D8CPjLOb+udwC9wY28EOA6YY7qbdf3aoTmf5wGvCr7zlkAbP8vZ/hQTT9LfBPwpZ9sRuIlT3di6cBOw5wfL7em2h/FXw/qqxH5t7NzjONz8LRq061HgXydpZ+a7pErG1XL8FZSCTUROEpE/BCbF3cDFQMcku6wErgjMxLuA/bgfw1JV/T3uycvXgN0icrWIzMmjGVun0aYlueVVtR/XeU6HlcD56XMIzuN5wOKg/rNFZH1gpt6F66gnuybjsRw3GBeD3TnLg0CnZv32B4P/uf5GuddzC+6mYaL278pZHsg5ztjrPMD0r/O06gjammYlsGTMd/RRnClZmqtxFgP/pxME8BMXsKIv+MvLxEpVb1PVv6uqr6oPAtfjBuKJeCfwWVV9VJ1P0WeAZ4lzA0ngBttnABKU2ZlHM36uqn8K2jA0RZteDfxSVf+oqsPAx3FPSKfDG4CbVPWmoI5bcU99zwmuya9UdaM6bgduAZ4/zTrA3VS04h7W7MD1FbMC001JdQPuWu1X1XSflwA+qaoJVb0Jd+O0LjBXvAC4RFV7VfUp4Iu4tx8A38M9RE3zumDdWFK4m7AjRCSmqk+parH69GlTQ/pKAIeKSIeq9qnq+hmeY5rPqWqPqj6Ms9a6RVU3qWo37qXDlL6xQbv/Q1WHc/R3Z6D7FO7t+jHB+pNxY9zlqjoS3Bf9kqzmrk8vi0gL7rdy/QTXYR5uYpVS1ftUtSePthaVGtJdLmH2axlUdZ+q/kRVB1S1F/dQe7JrncsNjNb+64GfBtdgLAlcvzZHVQ+o6v2Ftn2m1JC+KrFfG0XQx6xX1WQwbn6d/PVXleNqGBSaJ/17uCcyy1W1FbgKN+kG99RkLFtxpj1tOX8NqnoXgKp+RVWPwz3dOQz4YB5tGFvPZG3aiZsAAyAijbiBbDpsxb1Jzz2HJlW9XETqcCbi/4UzLWvDmcHIJMebqI41eZTrxz01BTL+MPOnWddYlucsr8B1Dp3TPMZOIBNQQkQamP51zqeOsW1NsxVnxp/7HbWo6jlBeyK4DuRa4F0icuh4FajqHeoi2jer6pH5NMoeXJXswRWqmsA9uT4K+KKqjtfHjEKyqQP7RKRvunWGhemmdLoJ2Drm8z4dHWgn/QCwA/cGM/eh3xbc2zEILDmCa7MSeBbuBncU6oI5/SvuwdIeEfm+iCwZWy4sfdaQvt6Ou3d4TETuEZFzZ3KOOWXGPuQe+zmfgFp7VXVozLqxD5/rA3/1JcBWVc29cc/V3/eAVwb3Gq8E7lfVXK2muQ5n4fd9EdkhIp8XF5RsFCLy+hz9/TqPc5kWNaS7secQVr+WQUQaReTr4mIB9eBM4tskDz/pYFL/K+DCYNWFwHcnKP6qoM1bROR2CeJNjdOeh3O0VfBDiAnqqBV9VWK/Ngpx8a5+KSK7Av19hvx1XZXjahgUOklvAfar6pCInIh7+pFmL+4JUW7ahquAS0TkSAARaRWR84PlE4IvKIabfA7hnpoUs00/Bs4VkeeJSBxn7jjda/Ad4KUi8g8iEhGRenEB3Jbhbu7qcOeeFJGzcf7P0+WXwCIR+VcRqRORFhE5aZxyT+AG95cE1+3fg/oL4Q0icoS4BxifxPlrT/d7+DHuGp0SXOf/ZPoPKqbihzgttQfX/p9ztt0N9IjIh8UFmIuIyFEikg4ulw7C9zbcA5Vr8xnI8sQeXJXmwRUishT4D+D/gC8Gx54UzaYObNbKiVA7HqabEukmYMoHOgGduAeTuW8dVuB84AgmTz/EPfV/He6tSO+4Fap+T1WfFxxLcSbPY8uEpc+a0JeqPqmqr8X5Mn4O+LGINM3kHItIvtoDZyG0XERy70ty9fcIbtJ+NhO/bUKdhch/quoRuHge5+JMmseW+26O/s6eRjvzpSZ0N845hNWv5fJ+nDnwSao6B2dSTc6xR73UARaN2f964LXBpLsB+MN4lajqPap6Hu439jNcfzheuSNztHXHDM4nH2pCXxXYr41X75XAY7iMA3Nw99m52oMJ9FfF42rJKXSS/k/AJ0WkF+eHnPmxqjNxvgz4U/BE52RVvQF3Qb8fPGl5CDfYgPOP+F9coIN0UIX/KnKbHsb5OnwP92M5gAvqkjequhU4DyfAvbgfxAdxfvS9wHuDOg/gxHbjdE8gOM6LcT7ku3ABHk4fp1w37nyvwQ3i/dM9n3G4Dve2chfOv2bauSiD6/zPuHR9O3E+dXtwvi/F4j9xOtmMMxe7Lqf+FO7aPSvY3om7Rq0ichzwb8CbgnKfw/3QP1KkdtmDqxI8uBIRwenyG7inyjtxAU9mC6ab0jzwnBZBn/BD4LLg4ehKXH+RmwP5eziT+NczwSRJXD7fFwY35UO4txPlTA9aE/oSkTeIyPzgpq8rWJ2a7jmWkb/grumHRCQmIqfhxrLc1Lffw43LL8D5HR+EiJwuIkcHD597cA+eyqG/mtDdGMLq13Yz+tq14PqZLnFZef5jTPm/ARcGujoeZ3qdy024ic8ngR/oaGsOAEQkLs76olWdZVsP1q9Np02zpV/bDcwTkdacdS04PfSJyDOAd6U3qOpe3BzlDcFv4m0cbC1cjeNq6dEKcIy3v8r4Y4rAgAUctxkXHGN1uc+x1NcMN/BtwT2Y+CXOfCo36usncR1rF9ngH2/EBbFLRwP9ZrD+RbgAaX24Bw3fBZqnaM+3gE+PWTdVm96MixJaSDTbk4DbcaZVe3GmcyuCbe/GdepduIcp30+3kfyDKf5LcC3S0UKXBPWkA9hM2eZK+jPdhKOboKwyOsDSaUwecLMdd6Odfgj7CcYEM8UF5tlPThRcRge4eSbOoqc3KPdLgmA3pq+S6us7uAfCfbjI6C+fyTlOoJs7gbfkfP40cM0U7RlPa5eOOc9RWsa9xbsdF5DqEeAVY/Zfgbsx/9VEx8W9kXocN9nYDXyFPH4rpruq6tcuxj2s7gJegxsTbwuuzxM43+RcXR2CewjUF7TnK7ltDsp8I9jnhDHrFTgU95DhZtxLqB5c1oDnlVpXpq/K6teCct8kmz1iCe6h4WNBG+8I2nVnTvmzcS/NunBxXm5nzHyDCh9Xy/EnwYkbBiJyG64zuaYIx3opLmKk4H6QJ+GigJrgDMMwDMMwDMMwJqBQc/eSI6ODT+T+vb7I9fx6gno+OvXeM6rv+RPUV9VBDnI4D+dftwNYi0udpmFfZ8MwDMMwDMMwjGrC3qQbRpUhLh3cynE2vVNVJ4rIOpN6fs34qWE+o6qfKVY9OfU9H5f+4yC0yoN/VAKmG6OUzFZ95dGej5INRprLHVqaYGxGDrNVd9avVQazVV95tMf6tQrAJumGYRiGYRiGYRiGUSFUvLm7YRiGYRiGYRiGYdQK0XI3oJR0dHToqlWryt0MYxzuu+++TlWdP962OW1HaDLRP94mAAYHnv6Nqp5VssbNANNaZTOR3kxrRrGZqdag8vRmWqtsZpPWwPRWydg9mxEWs01rhTCrJ+mrVq3i3nvvLXczjHEQkS0TbUsl+zni2Esm3Pe+P72roySNKgDTWmUzkd5Ma0axmanWoPL0ZlqrbGaT1sD0VsnYPZsRFrNNa4UwqyfpRpUigsQi5W6FUQuY1oywMK0ZYWFaM8LE9GaERY1pzSbpRuUhIJ7MfHeRdcAPclYdAnxCVb+cU+Y04OfA5mDVT1X1kzOu1KhOCtSaYeSNac0IC9OaESamNyMsakxrNkk3Kg+hoCdlqvo48CwAEYkA24Ebxil6h6qeO+OKjOqnQK0ZRt6Y1oywMK0ZYWJ6M8KixrRmk3Sj4hAEiRTtSdmLgI2qOqGPi1G7FFlrhjEhpjUjLExrRpiY3oywqDWt2STdqDwEvFjRsgNeCFw/wbbniMgDwA7gA6r6cLEqNaqE4mrNMCbGtGaEhWnNCBPTmxEWNaa1mpyk+3pHZtmT5xflmMrtAAinFuV45SD3ugCI+JllVfejUCJ4ksjreMOpOQDURXpGH3eqazS1z0mHiOSG5bxaVa8+6DAiceBlwHihIO8HVqpqn4icA/wMWDt5w6ZPWhdQPG3MBq3lXpdSUgStVQ/6h+yynF7c4xbzeGGTe11yV4vr00T9cbfnlhmLpEbAi44qZ1or0nGrWWswod6m3G2M1jK6TA5DtG5UOdNakY47G7SW1kmOflQ8p58Jtk2EDByAhtaDytak3oqojdlwz5ZXv6b+KK3B+HoT9WG4H+qaDipXU1rLg5qcpBsVztTRGztV9fg8jnQ2cL+q7h67QVV7cpZvEpH/EZEOVe2cfoONqqXGIoUaZaQIWhORbwLnAntU9ahxtp+GBcQ0TGtGmNg4aoRFjWnNJulGxSFCsXxOXssEpu4isgjYraoqIicCHrCvGJUa1UMRtWYYk1IkrX0L+Cpw7SRlLCBmjWNaM8LExlEjLGpNazZJNyoPkYJ9TkSkEXgx8M6cdRcDqOpVwKuBd4lIEhgELlRVLahSo/oogtYMIy+KoDVV/aOIrCpOg4xZi2nNCBMbR42wqDGt1cwkPemvH+VLnetvXSi+3oGvzmdMuZuUxtyyejREjylaPcVirO85uOuhuHYLKZQIwsHXKF9/dBjtiz5dXxyJFmbOoqoDwLwx667KWf4q7i1B0Smlv3XuscfWU6n+TmH5n6cJW2tlZYb+r9M+tv+70du8F5Wu3kKYxvUYzxd9Mn/NUeUicbd/4LeY73P9PLSWV7yNKShNQMzUre6/V4LbhvG0lvv9RF5c/DoLZYY+mplNU2gtsz3WkNWqnF4bWoOsDvL8TU6HlN5FRH3wA02rZvUWO6vo9RXMRFrL1VfOsozxRc+7X2tsn5HWoMrH0eQtEImV5tj6h+x1zNUbQPTM0tRZCNPU2ijEy0trKh7Ut9Sm1qZJzUzSjSqixsxZjDJiWjPCIj+t5RtvYyJCCYhpVDimNSNMbBw1wqLGtFY7NgNG1SBBYIiJ/gyjWBRDayJylog8LiIbROQj42wXEflKsP1BEXn2mO0REfmriPyySKdlVCBTaa0YfZuq9qhqX7B8ExATkY6CD2xUFaY1I0zsns0Ii1rTWs28SY96J097n8HkA9RHuzKfe0aWAqB4JPyGTFoyOGzcdGVJraM74YKFR2UYEZ+YN5gpkwxM5NPbAObEDpt2O/Nl//BT1Ed6iXuBWbv4CCkAfM2a+oj4oOScXzZVXcK/m2hwDlORNmVJUcd0H3xVc4qFmZidF8MkfLrHKKV5fKHnI5waXpq2ArQmIhHga7j4B9uAe0TkRlV9JKfY2bg3TGuBk4Arg/9p/gV4FJgz/QbMIE3MWDPS5HB2WyoZlEnm1DHmWa764P/ULXseROJuOZIznKSSblt631Ka9SVvAS8yflvzQU7PXJO0EvI1D512VSXu10oaEHMmJueJm93/nBRiDPW67yk54j77qey2sel7UiPB6h+5bZHge841uU+OZLXnRaHunOm3M18Gb4RYfVBXZGq9jd0up2fcBmRMCr9iU9Vag+m71IyntZ49WZPvkUFIDLlDi4dGoqNdKvxg2b8K4o3BsWJIvCFTREcGkYwbQh00vnx6bZwOfUEfG6t3dU3FeFpL3uIWc0y5p9RaxgQ534amq6/ee7YZjU/DN0GONhjqHa2nNLl9VdpMPN33RW4c34RcfUgmst+7eKXt1wZ+5v7H6rNm/7k6GXte42kNIHkLEomVbPzMVl/FWpsmNTNJN6qIGgsMYZSRwrV2IrBBVTe5w8n3gfOA3En6ecC1QWDC9SLSJiKLVXWniCwDXgJcBvxbIQ0xKpziBMS8HjgN50+8DfgPcMFELCCmkcG0ZoSJ3bMZYVFjWrNJulF51JjPiVFGptbaVMGVlgJbcz5vY/Rb8onKLAV2Al8GPgS0TK/hRtVRhH5NVV87xfaSBcQ0qgjTmhEmds9mhEWNac0m6UbFIQKRGoreaJSPPLQ2VXCl8UaLsW+Txi0jIucCe1T1PhE5bdKGGlWP9WtGWJjWjDAxvRlhUWtaq6lJ+l07uwFY2FTHSCrrY9E74nzi6qMez5zXxJPdzue6Mbqanl53iRpjEZK+u/f2BJK+EnykOZYgHukHYCTVxFDK+WgmfeXAkBfsU0dTzGNuvfP/3N4XIxr4VTREIzQE38T2vgE8EfzAaizhKw1Rd4ym2DBxz9XTUb901Hm118cy+0Q9j2TgXxX1PA4MJYLzXoRX5+NJ4G+q4KurOOYN4mu6rVEEf5TPPKTTttVlfJkHkn+nPtIFjJ/STjPpQFIHbZscwZsFPidT+VSnr2PYKcrS5Ftvru96WG1N11P6a1Sw1rYBy3M+L8OlI8qnzKuBlwWRkeuBOSLyHVV9w3QboVu/Bk1t7oOfcj7lgS+cxOqg9QK3rfsHGT+3jH/lRL5nad+0iJfjq54KiqU/+xDEqJB4g/P7hKzfZtofT3+U9Q1NjYzePoHfnXZdj6T93XP89dL7a9BWiTdkfUinsoIb1//vD9nlwGc47S88kW/deOnbpmaW9Gv3/QcsDeTs5Wijaz/U1yGr3+fKbb8y67M51A/RQE/ReBDXILiGI4PQ2AqM1lBuXATt73Z1BVqRpna0e4/bGIlmtRqNw56vubJp0v6f8QYkqAcvCi2vyh7/r5fC3PbsPul2JxPZY/V0Q3sH0rrAfY7Vg+akJPXGuXEUz/1mMtty0hvJ6Rk/aonWmdbGQR/4JMwJjIxGEpC+OR8ahmjQv637ELrxi9AYlOvrhnjQb/hjfM7jQTyBaMx9N2mtpTUCMDAIdLllz0Nb58IBF1uIeCz7BDZeD3uvCMpFYWQoe4z6RqhrytQlbVmjBH38826hoWH07yCZhLqgfcND0OTOR1rmj9az72d/S6oQxBXCi0AqkV2W37kZDTitDd/kFuMNRdYazAa96aOXu4WFy5FIFE1roqczU0ZWvw/d+63ggwciSDSe/Zy+fl40G08jWuf6JXB9pZ/KjmX9XZm+QaLx7Ng83O/GyJFsKj0dvD5zDAniYmhiKFt/eqzN7dd2BkZ/kWh2ezTmxs/B3qCQn+nvRt0PpHJi1WT0lpPaz8/RXbpfEwE5HcmJD2FaK4zaMew3qgYRiMS8Cf8Mo1gUQWv3AGtFZLWIxIELgRvHlLkReFMQ5f1koFtVd6rqJaq6TFVXBfv9fiYTdKM6mEpr1rcZxcK0ZoSJ3bMZYVEMrU2VkSen3AkikhKRVxftBKZJTb1JN6oEoaaelBllpECtqWpSRN4D/AaIAN9U1YdF5OJg+1XATcA5wAZgAHhrwe02qg/r14ywMK0ZYWJ6M8KiQK3lmZEnXe5zuHu7slEzk/Rfbd7HUfObAdjZN4wXmAFFPcmYhvcM+9y7p5d4xD2N6U94xDxn3NQ9nMyYyEc9wVcy5u+DSQ9PXPakkZTPQJDmIx7x6BnOmuwNJT2GA1P4nuEEHY1uuXckye7+rEm4J0JjTr6/rJl9khHfmVA92T3IgaFk0B6PnX1Z05ThlE9LPJppQ9qs/sBQkrrIXJ7qceZ6c+sjpNRta44dyJjSOxN2j4g406m+5AKaos7kJyLZevoSCzIp5aIyOi2bcCr37nHmNEuaU8S8nQDMr1/MVAhCtIp9TvI1zS6Xmft0qfR2jk3XNtZUfvJ9C9dakCP4pjHrrspZVuDdUxzjNuC2adf990+7hSUrYV9gZT+SgMaGjBmlRqPQFZhl+n7WdDLe4NIQpfFyUhKlkjlprca5PomgH1A/Wy4Sz5o+x+pBfXTY9SkZs0uASBRNl1MfieQcv/cn2X0SQzmmzzmmcfVNaKw+c0wd6EEy6ZNSo9sbqx99HrkmdunUc5HYaJP/kcGsqeoYU72M+8WB7yINLZBObV9/7kGXaCxV3689+QW3sHINDHQHK/2su0I0AgOD2XLJFBCUa2yAvgG37HnOVDhtTjqSgMEgNWnu9UmmIB6YWfb1u/2i7jtTVWcSDNDcmjVb3rfHmUGn9dDU5MyIAWI5aVJTI7D1a+5DTzfU17s60u1LLzc3QXq35hZIJbL6PLAj62YhgqSXY3XZa6K+02l6n7qm0SmZ0ianTZFsKkMCU9AgrZFu+AK0zXfr4z/Iuq5MQrVrDcD/4weQNWugc69bEY06X0Nw32nwverfP+3M27v2u23xGIwE2hrIuS/xPGcmD1BfB/TmuFzkuDUMDGbXe54rm9ZQU1O2j+vpDo6D0180EmgeYCDbDyVH0C1B/9vVnT32wEBO+aDd6c+eB7097vxi9bB/2xi3INc/SbwB6gLd+WT7q/4u5/6U039pr7uHk/bFE2vtoU/DomVuQ+S7yNzXkw/VrjfddQ2ybK1bHu5HU4ns91fflC2346ocFy5nJp4Zo7xIdqwZ7s+MNZpKZvunwD0oba6OSNaFLDGUDV7j+xCLZ1x+NDGU6V80ZyyUaDzbnkgEfD9r4q5+Nl1kKglpl9ShfjQaH50+LnfcHzkQHC8G9W7OxMigqyfX7D09po8MZo+VbsvwQPYY45i7C6c6rc1fFFzjXaNcQiajCFrLJyMPwD8DPwFOKKSyQqmZSbpRPYhA1EykjBAwrRlhYVozwsK0ZoSJ6c0Iizy0VnBGHhFZCrwCeCE2STeMMQiImU4ZYWBaM8LCtGaEhWnNCBPTmxEWU2utGBl5vgx8WFVTIuXVtU3SjYpDRIhG7amsUXpMa0ZYmNaMsDCtGWFSqN5E5CzgClxcl2tU9fIJyp0ArAcuUNUfz7hCo2opQt+WT0ae44HvBxP0DuAcEUmq6s8KqXgmzPpJ+u+3Ov+KeQ0xNnc5v5C9/SOsmev8OxqiXiZ12VDSZyCRyviRxyNexj99KMd3KO0jnt7mq2TWHRhKMDCc41+e88Sn14PdfdlUH7l+57nLIymfriBtWjySbZ+vWR+SI+c28LdEHwB7+keoj3rMa3D+IglfqQva9khnH/Ma4sH+ytaeJMvnuK99W+8I7fWxoM42kr7zq1/UVIevUeoivcF+Hgk/7XOSdQtb0LCQ4VTWakTVw5PnZz4fv8ClELl7dy/t9W0AzK9nSgTwItX5VLbS/bdnwlif70pqQ9pHeKap2qpaaxu/CK0upZQ++UjGj1YWB35eaf/LgS40ke13JOOj7Tmf29a2YMuISzkFzt831y83mvZ7C/6n/TI9L+OHpsM5/p+t9Vm/80yDg4fVaf82cL5tiRzf8JZXIf4PguP1Z1PXpP0xAaJ1zv++pT1zPO0O/FZb2jM+cFLXlPUFhsAfOJ1qbYK0cwI0vAz837mPo7adnl2c+3p033VZ38LZ3q89/BloSafCGshev8bWrO+meO67zP2u0kiOP7CfAn/A+QGD81eP5Ogh7UecTDq/XXD6y/FDZmQk69vb2JytZ06r8+PsCXy9d+/JpvDq7kIHs3qQNe93VT75BXRvJzJvntsQj2XbU9/k/NzTxwbYHYx5c9rgwG633DYf7duXOT9pD2KvJBPOXzN9vfxUNqeOAHPOd8upW92qdNo570XZdq79YCY9lLa2Ia1MSVVr7b7/AEDa29AtT2V0IsuXOj/dNGk9eR4MDWX7KN/P0Zo/2s877UPuee64uX1cJiaBZDXtec6PPNO4nGNDVqu+DwOpHB/1BHg5WkunJUx+MavNaBTmzcv2P9E4uvVpV761Netzv/FxZN5c9MmNbtvaNRkfZxUPaVuUbVvub2/Mb1E63uQWkrdk+zX1R2vt6H93v3Vwep9LXhSit3IG8tKn/59baGxFR1xfI01t2XEHIDGU/f160ewYEsTU0P3bs58z6cuS0BSklYw1ZX25E8PZOBbg4pqksj7pmfXRwB89dyxLj5+5sV4isWxsj1QC9u5Cjvxo9tzS/V1Le1ZnkaizGR90MQ+ob870dzrQlR2bt21EVqzL1un3u3YQpIirD/rV3HRs4rvHLM2vDNp0a/ac/OTBWkunvZuTgDbyogh9WyYjD7Adl1nndbkFVHV1pj6RbwG/LMcEHWpgkm5UIVLdQUiMKsK0ZoSFac0IC9OaESaF6a2qAnkZZabAvi3PjDwVg03SjYpDMP8mIxxMa0ZYmNaMsDCtGWGSh94mC+ZVVYG8jPJSjL5tqow8Y9a/paDKCsQm6UblUYRIoSLyFNALpIDk2EAS4pxNrsDlrx4A3qKq9xdUqVF9WFRaIyxMa0ZYmNaMMJlab5MF86qqQF5Gmamxvm3WT9K7A//ywaTPwqZ4sE4yft7DKT/jT95eHyXhK7HgKU3CVwYSzteiPhrJ5En3BAaTqcwxol7Wb7wu4kHgBpReB9A7mKShLkIyOEbKV/YOOF+Slx7SkSl3185uPBGGg3LxiMdxC9zccWze52d1OF+8X/R00hyPsL3X+UqduXIu2/udv8ni5jr6RlKZc41HPLb2ZH1H0+eX9q8H2DvQQmMswoo5sWC/Fnb2uzytc+rgwJDzc3nmvCbqItl+d6K+88SFLZnlax/cwfw54/gs5iAy2pe/AE5X1c4Jtp0NrA3+TgKuZMzT29lIroYm898eq7WJfL5L7a+em/M8v7zn+Z1fpnzxtBY+ff0w5HIDSyyORnN8NAcGs7mCO+Yiab/KxsbROYQ9D9K+5D29Wf/NaATtD/zZBgdH5ReWlhaYl+2zMuT0dzrQjSy6KPt5x1VZf71o3OX3BXTOAhj7vabzQA9ek/X/270DOfrf3T77roO6+qy/eVc3eqAr2Hk7Mr8jOHar8wVM1zvU6/zZAWlqz/p1Joay7Ule7/K15vjOTYTMe2P2/B7/fDan90Tlq1lrySSk4xo0tED3Lrecmyva98HPyV/ueVm/8Wh0jM+vNzoXtZf2T8+NkUBWmyMJ14Z0Xbl+wXt2I8demvnor78k4yucfGAr0WNcjCB54SvG7UNk7QdJ3fUGvByNe6d8Dgh02xY45qrv/DWbg/FsqH+0P3xOrmHd+kTmWDJ3WcbflcSw80MFtOdryPJ3u/WRF7uZygT3nnL4R7Lnd8t7sv7zE1DNWkv3O5KsQ+Z3oHuDIdz3s7EwfM3GGgD3G09f/5ERF+cAXH+WjmOQq5mRhDte+jc7lPUHzhwfghgCkvV37+nN9EMQ5GiHbFvSdRz+nPG1tub96F8vdR8aG6C7O9uvdV6LzJubbV+gYamrg64e56cOzkc+3S+OJLLXp74OFq90y4M9MNAHzcE+A1/MxGAgemZOgw5qYsanGSD5HdfHeSsWHlwwd5/C9Fa+QF45sUmk2f2mMvnk07m/1UcDv29paMmOi+ojja3ZG1/xsjEAojljQW5MirRvedr/PDGcKSvRlmx8FvHQkcFsHAHI5j8H9NHAE6CnF3m5KyOcCgtyTm3FP+Pf/E9ueemSjIbl8I+ge74JDXOyZYNxkfqWbG72pauzy6kkeB66Z7MrF6uDSOC3H4lk88DH6tC912TH/nS/BuP2baP6tfWXuHXp38AEVHPfNhNm/STdqD5Cikx7HnCtqiqwXkTaRGSxqu4sdcVG5WBRkI2wMK0ZYWFaM8KkQL1VVSAvo7zUWt9mk3SjIhGv4B+hAreIiAJfz/F/SjOeH9RSwCbpNUYRtGYYeWFaM8LCtGaEyUz1Vm2BvIzyU0t926yepPcn/IwZ99KWrIn1UfNbMibuvSNJWuIuUmB9NEKjQETctoSfTa3WFIsQDVITeOLM5bPHSGVM14FRZvBb9/Zl1g8MZp8AtTTGM2nScvEV6qMeZ6/KNWeb3Mw36gm7+0d4xaHzM+uWNs0J/sP1jzjTxN7+EZZ2NLGy1ZnxxDzhwJAzZxlKpjgw6JY9z7kE7Bt07WuvH85cx519yr5Bd64bDwyMqjMfWhpjmes2ESIylc/JZEFI0jxXVXeIyALgVhF5TFX/mFvNOMedvGGT0lv2NGWFkI8p+UT7TNfEfCYot8+ojVORh9Yqj+Q+tPNaaG93KaLAmdGuOtQtpxLObC6dRqihBdpdmh6JxLOmt6kE0tiWPe5CL5OCTfv2IWmT0Z4+lyoInMlya2smbQwjQ6NM4bNmod2wKKfNXjRjOifz35JZPanRmp8Ez5nU5ZqYyrw3wjzw//iBoA0jWRO5xsasOfJAnzN3TZtZ19dBh7MHHJXezYug6XQ0A93ogS9lUibljSdZ8+0JKIbWROSbwLnAHlU9apztxY210b8Dvefj6PBQzo3Rvuw1BvddgzPPnds22sQ97VrR0zvaHaC+Lvu99PVDW2B6OTI0OkVVUKdueXq0q4bnZVMNjqWrO2N+HH/fT/I6TR1I0P+jBwFoufL3mfWy5OJsmT3fdOeW/l1F41lT11Qy+5uIxiCdLbW3F+17HOYFdqiRaE76pEjGXDpX31PS2IB2d09apCq1BjC4M/sdL17ovudVwUvUVMrpA9zvLW2OLJ7TSW7Kx5zfdrbBOSbxQ/1Od+n+KpmEeNotJscs3vPcTVla+9Ext8xpE3SceXFepI/R1YMc95/Z/Tve5Ay5Cfq24DrI/A5YOC+bFnCgL9PGUak1k0nY+Jj70Njgfm99gU76+tG/fMyVO+my/NoJeHOD8SWdCnECCtVbWQJ5De6EziB155yh7LgoXmBuHnzu7824tehAT2YcQzy0c2c2RV9uir+RBHS4MUmjdZm0p27cqXOuVwDdXVkXBYDBYH1dUza1WprAzZSmVrwXfjmvU/Q73fES69fTcOkvM+tlwdty6rwxm3YtlZOG1fczKQ/Fizqz/6Yg7eneHWhgmp9JAQgwnEQaW52bEKP7z6mQpkBr6XFhonLVeM9WALN6km5UKcJU5iyTBSEBQFV3BP/3iMgNuDQfuZP0fPygjNnO1FozjOJQHK19C/gqcO0E22sy1oYxBtOaESY2jhphUWNaq50zNaoGwVkrTPQ35f4iTSLSkl4GzgQeGlPsRuBN4jgZ6DZ/9NqjUK0ZRr5MpbV89BZYA+2fpEgm1oaqrgfaRGRxcc7AqBZMa0aY2DhqhEWtac3epBsVh4gQK+xJ2ULghiASaBT4nqrePMbH6Sacmd4GnKneWwtqtFGVFEFrhpEXeWotH1eeybBYG4ZpzQgVG0eNsKg1rc36SfriZucjMpJS6oMvdiiZoiXwP4p6MRqizs9JGKYv0cDuQeeT4atSH3U+TYPJrL9h0leSvp9JXxb1PNrr3aXctC/ruzM0nKSx3vnhDQwlWDi3IbMt6nmZNGu5eALbe4d49vzmg7ZNxGj/9YPZttv5pSye38yG7d3ElrcBsKi5jsPa3bkn/AYe3efK946kGEkqB/rctr7hFH7gR97dN0w88OGfyVOrVxw6P+MjPxmFpFhQ1U3AMeOsvypnWYF3z7iSGqUUfuGlIt/0cFWZzkN9548+nE19QirwJYvWQbwBqWvKls/x15R4o1uIBP6aaR/iXJ9qVZi3xC3PI+vLWb8furth0bJgnyQ0p30lB50vHqB7O5HDc9rreRD0l/kylT9b6tFt7jSWt6G797h9Vq5A2oOXeQvqYXgAffwB16bde1zbAaJRl9oI0OHhrF9hWysSi8NqpoWs/SD65BemLJeH1qZ05ZmqKeOsm3msDcH5Beem/Ipm4wtQ1wRzA0fa+VHnzzmQ9YPNpL+qrx+trxw/X92+1aX5w/nfJu973C3HInirnb9j8vG9DD9xgEiL85GMrphDNNg/48uYJpkicbs7Rt0p+Z1m7F0/YPIEerjfkPpZn81IFHYG89EFC7K/kaSf9R9ubnLnndk2kk2zBAf7OOeB97wv4N/2b1OXqzatpQ+6NOh3kimoj2avV11Tts9K92HgUjH2D2T1Vd842p83rcF0ikBw/tpzWrL+r+kUf+B0mY6fMKclux5G+6tDtl+N5P895hN/QHd3IguDVJK797h4EHPdb1AWHYIGKbxk5xYXrwHQue0wGPgJ+z6qfvb8cnQ2ndHOO8fdMvk/nfodRlWOo+l+LTdVp3gu3kEy+K5bc/q+fXuy8SCSSaShMRuvALLj3/AQbAmeXyU3w0IXkyL5xwfw5tbjPWMNAEM33I14f3JNOKQNb1UQO2bpEmhuH93WTmfUohs3I2fkd3rRN1zn/k9WKFYPaf/7ZCKTbk4f+issDcbShiakbZFLOQcu1Vq6T8tNMQfoUG82JsQ0yKQivOfjU5atSq3NkFk/STeqDxGIjhNUzzCKjWnNCIuQtGaxNgzTmhEqNo4aYVFrWqudMzWqCs+TCf8Mo5iY1oywmExrRdKbxdowANOaES42jhphUUtam9Vv0lPqs3G/M+NojEcYGHHmlmvmNtLb58xS5jfGOTCUNXTb3T/E8YtcWob+RAciadP3KCl15SKSZEdfhPbAlL2tboh4xJkVLWzKpiRL+sqmLlf/lqEE8xriHBhyx+sbSjI4kmNGFXDK4taD1hXKB09fC8ANG/ayV5W7HtkNwLqV7WwMTNeXzxHagvPpaIyzoDHJtl5nnj+QSJHWfntjjKc73bl2940x/cqT1x6xiNdNsl1EiEVm34+t0ihJSrPgmJWSjm6qc6xKrfkpl46lpztrlrlnD6wIbLSH+5HmeVkzUc0xM25sPThVmBd8Fg9GArPj9sUQCUzWItGs+WhTu4v4EBxbwZnaA3j7XTsgm0YpYFTKlyIRe+f3AUh+83VEjnbmg7pvH7QFbahrQuINEKSmkwU9Lh0dwM6ns6arvp81B+3rRxv9aZmEppG1HwyWPjT+9iJoTUSuB07D+RNvA/4DnKV2KWNt6M5dLq0TwO49SGC+6dKnBWaZQ/0wksi4HnjHPw9NpxTKTX8VpChl6ya36fB10B6YzEdiRE8PNB2vz5jVR4eG6HtgD3WHu7RG/v5BdF9Xpg25V9U79+vUnVuMsx6NLH6Hc2lImxDH49kUWI8/7kzbAXwfaQl0tmQlDPTAju3uc47ptPZnUw2Ncg3JA++0/w6WvjR+W6tVa76fdV1paED37ctqbWQkkwqL3n1ZM+P9B5C1z0SDvgvIai2VgEigp/27oCVI9VffgkTjaGN/tny6XzzQmU0D6HnO5D39OTBnTjPtVI15Ejn/W/jrL3EfOvehGzdDb2/Q1E3I8sDdqKUFOSbw7Ktrgv4DQTtHkGQqY4avg4NZl54Z4L3y/3DB/senKsdREUj/BuMx19+kSeV8zwN9mfFBN27GO+0f3PJA1+h+LXdc3fA40hJodcHCjAajpxzp+olg7Ikd2s6eHznXnI65DXhpfUXjo9MHAnLCp9z/Qs55PKJnwsCP3Dlt3wg57kP6QBBvua0VlvYgi4N7jMZWJH2+iSFnMg8uhZvvZ93wZoA7z09PvL0atVYAs3qSblQnzg2ydn6ERvkwrRlhUQytqeprp9husTYM05oRKjaOGmFRa1qzSbpRcdSaz4lRPkxrRliY1oywMK0ZYWJ6M8Ki1rRmk3SjIqmlJ2VGeTGtGWFhWjPCwrRmhInpzQiLWtLarJ6kJ33lrgdcsNGFHY0smud8Le7evI/lQYqz+57aT1OD8xfpH0ywYkEzTdFOAIQUg0nnAzfst7Az8MFO+sLSllgmm0drfDt+EINvcWMXI76rp2dkMcmg0OJ5jWzq7CcZpF1727HLSnru4/HoUwdYMr+Jkw51/n8HhpL0DTkfua6hBEd0uHPoHalDGKG93vma9o0k2dvvfGXOX7cAVs6dcRsu+flDrFk2ud99reVBLDXVlDYtl0LbnY9ffFVqTX0YGkA3b4EgRaSsXgWdQWrD5hb0kfthbpv73NMHy1e6cnMWZP3tUknnQ5bKSY2W9i/3ky4tzdj1qpAcQVMj2fW9LjUMnXuR4/7T1VPE052Kkcf20/CikwDw2pdkfVP9FKQSSFPgMx1vzJyTLhHYE/gJb96bSTU0U5LffgORE4+atExVas29tnC+ufsDf9fGRvwHH3WbVy6BJze69XNaSD6yg2gwvlDfgnjBLcZwfya1D1s3ocPDyPIV7vNAH9IS7JNKwtJ1bjkxjPbuDcoM0vK8ZSS39ACgwyki53+rRCc9Cb46H2VwvudB6iH1PJeCEJDlS7N+68P9MDKEbnXpAlO7+zOxFGb6G/Fv+zekoWHSMlWpNYBUiuHbngAguriZyNJWNPAHl3nz8O93PrLS0pBJpybLlzof2XRKv6F+d90BenuycTva5mdSpklTO6ifTVOZGHI+xuDiBuTEF6CvP6+0aUVnR9Cfz21Hli7OaGqUf/nyNTCUjvsg2dRXIyPOL71AP+aRL70KgOjKOZOWq0q9CdnfaTplHcDQMDK/Y1RcFe3tcwttc1xcF3AxDYZ6M32A//D9GV9zWbM6c2xpXZiNw7G2w/VrXcF3O5Ji3gvcXCB62AK3HyDLy+RFEo/BgaCf9yQbq6WnFxb76GbX77NgUdYPHWDIXR/peBPSCMxgiqCPf94tjIlnM5aq1FoBzOpJulGd1Jo5i1E+TGtGWJjWjLAwrRlhYnozwqLWtGaTdKMiqSVzFqO8mNaMsDCtGWFhWjPCxPRmhEUtac0m6UbFISI19aTMKB/F0JqInAVcAUSAa1T18jHbJdh+Di5V0VtU9X4RWQ5cCywCfOBqVb2ioMYYFYv1a0ZYmNaMMDG9GWFRa1qb1ZP0ufUxvvSaZx20/q3/8ycebHK+O6eeuIJ1853/UcwTEr4ynHI+ZyN+Mwnf+X51DyeJBk9vnjG3kzqvFxHnw+JrFD/Iof7YgcUsaHSXdVPXMIe0uf37Ez5JX3nVWpfz85r7trIqqPeMFTP38Z4OGzfso7U5TjwQeMwTDvQOAbC8rZ57djpfkJa48kTCZ2DY+f919w3zjhNWFKUNS+Y3cejClknLVGeKhZZxfajLnS9cOHVUG6rFPz2sdhaqNRGJAF8DXgxsA+4RkRtV9ZGcYmcDa4O/k4Arg/9J4P3BhL0FuE9Ebh2z78HULULWfhBZO3q1f+M/uoWOucjKVVk/36U5vuWpRMYvEz8JyUTW97yuyeV9HYv6WR9PL+rysEfTvuspNMhlLcdeiv9TlypZVq7I+KeXGq85lvEH1tZkNm/tUD/EG9CeIG96KpnNHb9zVybPcqH+6IDzR+9YNGmZquzXGhYjx3ziIJ/W1I/e4hb2H0DWBUJsaiKWzmkN7loHfuiaSrp84QDRKN6aIyEe+FV3eJl86Pgp/HtdfyVr1qKbnL+7LF1CpGMIr8V9l5ELvp3JIy2xeGha0+07kPY292Hpimyu7uHAjxXQxzdkYkWweQup3QN4re73kvZHL4j6Ope3eBKqUmsAc1bQcOkvR63qf+8ZAEhsE/VnP8Mtr14J9Y2ugO/DyGD2tz0ymM3T3NCAzHfxOPCimbzhqA8pH933tPscq3f50QE6FrhjgNP3sZfi3/Zvrt6FC5DDP1Lcc56A4b86rdcdCyxelM3R3tMLLe4eSh97EAmWGdrufmcAXd14Z/1PwW2QFnefLEuXTF6OKtRb3aKMzz5k/fb9m/8J3fI0sjK4543HXM75NGmdqYtJocFniUTh2c9yy/EGWBD0DalkJoaL3nE7ctSR6ONPAhA5cjVebxBzoaUFWfkvrtz+7yKxemh5VZFPenx0exBXJJmEZYFffN9+NNCctLSgm59C5s935fbsysbm2NOJnHRZ4W0IfOGldZb2bTNkVk/SjepEBGI19KTMKB9F0NqJwAZV3eSOJ98HzgNyJ9rnAdcGeYXXi0ibiCxW1Z3ATgBV7RWRR4GlY/Y1ZgnWrxlhYVozwsT0ZoRFrWmtds7UqCIEz5v4zzCKx5Ra6xCRe3P+3jHmAEuBrTmftwXrplVGRFYBxwJ/KcJJGRXJ5Fqzvs0oHqY1I0xMa0ZYFK41ETlLRB4XkQ0icpBpjIi8XkQeDP7uEpFjin4aeTKr36Qn/CQ9iSCdhwzTOXQoAP/3T88dVW79LmeG94z5G9k3tIaukeUAzK3bjODMXNrr59M34kzYnu5dyCGtg6jvnnGktI4H9zqT9Tsf3cmSwIy9tSnO8jkuTUE84vHbv3dBYO4ej0XYF6Q1C4tvXPwcLvn5QzxnjTPL27Z/gHmtzuRw074Bdu51aRQOWdbKrn0Dmf0GBovXzn8+ZTWPHhiYtIyL3lhtHXvvuKbtY822y23+HhZjzewrtQ15aK1TVY+ftJqD0emUEZFm4CfAv6pqz2SNAcDvgsEbXbqdtHl6YgjvZf87uoL933XHb56bNVdPjmTNjBNAjKz5e99+SJvIp03GAZIJdDBI89O1x6WeWnSI++xF0I2bXT0rQYcCs8DtO5DjpjyTolD/iV+gD3zSfUglYSBIT1TXhA73o08E6cIaGtF9+7I7plNmnVB4G+Twj0DvTyYvU439WuoA9PzIaSYwFdaeveOmP9MtVyDrjke7d7vP/QeQlnmAMwXNpDiKRNDuPTlmyJ6LyAD49/+ZA9+4G4D2t6eyqcbmtiEjCfwntmfqy5j5RsO7jfFe+GX8W97j6l9+SLYt8+aie525tL+vH2+pux/QhE9k3WJnRlqsNpz8WXTn1ZOWqUqtAST3Ob0BRGNo9x6avvLbg4rpw59Blh3ulrt3oX37M+49QpASD2B4EO10z0dlweqM+wXqowPdGXcKolFnrgwwpy2TctJ/dBORY3Pq3duJHF60s52Uhk/9CoChT76UutUD6PYdQfta0C3unHRwOPu4t6s7k5ZuqjRW+RK76HpXz+YvTVquKvXmd0HiZrcsXiYt2lg3Ad1yBfIsN2fQ/gNonxtDZM5850KRHj+XLcumI5231G0DZ+5+m9Pwzm88yJJLFyKHByJKjiCNro/T3t7MjYJE42hqJLRUpmkXDr3n45m0hOqnkJVuLqSPPhG42QSp+AYGs+4XQarmQvFO/qyrq8R9W54uipuBU1X1gIicDVyNc1EMHXuTblQknkz8ZxjFpECtbQOW53xeBuzIt4yIxHAT9O+q6k9neg5GdTCZ1qxvM4qJac0Ik0K0Vk1vNo3yU2C/lnFRVNURIO2imEFV71LVIGE863H3bGVhVr9JN6oTAaKePT8ySk8RtHYPsFZEVgPbgQuB140pcyPwnsBf/SSgW1V3BlHfvwE8qqr/XUgjjMrH+jUjLExrRpgUordqe7NplJc8tNYhIvfmfL5aVXNfz4/nfjiZlt4O/Hq67SwWNkk3Kg4RF3neMEpNoVpT1aSIvAf4DS4F2zdV9WERuTjYfhVwEy792gZcCra3Brs/F3gj8HcR+Vuw7qOqetOMG2RULNavGWFhWjPCpEC9TRl8VVXvyilf1jebRnnJQ2vFcFEM6pLTcZP05+XfwuIyqyfpMW+QpmjgJ6ZRFjf+HQBlMFPG1xjPmu98QqIyzOLGB9g1eDQAA8l2WmIuDUZTtJM5sbZgf4/1Oxazpt2lANk3mGB7t/P53Nc1yDFr5gXHVjZ3Of/r7uEkHz3jsEy9b3rm5CktSsVnzzuKv3U63/Mnn+7i5KMWAnD/Y/uoizuf+0c3H6B3YITBfufX9JXXF+5c+vutznLkqI4RDpmzdYrShZnj5ZN/WkROA36Oe0IL8FNV/eTMax2fcvll5/rClyvtWrre6VyDYrR1ute80HvZYFJ905h1V+UsK/Ducfa7k/EHjMnxImhDK6J+1ne8rml0qj31kdacdFj16TQ9vdkUMrE6oM6lZQNIjqBbH3L7L1idbefeLdAf+LTX18HAILp/m/u8/wDeC7+cKRt53bXTPp1iIMd8Agj88ANfc+INsH9Pxk9Tt24jsdH1QzqUov5jPy+4Xt11jau/dQE0tU1ZvurmTZEoOmcB4mdT20nbotFaS6fgW3o4iCBzg/vnnj2QcCk+qWtyKYXArUsl0c1Oa8xfAhsfd8doaqL1H4IUQEsXQzr10dAweB7Rt30vW++RHy3FGU+Jd+ZXAdB915G6868ARJ53LPS5cdWb35yNd9DeAslkZp9C0e1XIq0LR/0+J2xntWkNXJyN9O/ITyHzV42vtUOflYmRIB0r0c4t6KCLRSHN85DGII3TUH8mvZ/+7U+w9ohgfS/61GbY4+4PZfkyl8oNoHMPGqTFSvdn3mnlM3RKx9xIbnNtij6jieE/u3uo6LIWZNh5V/l7B0jtd7+3tD97Ifh//ABy+FEAGf//yShAb+V5s+lFIBKkH/VTSJtLoZnW29h+DUDmLHBjKDhf9Gjc+aYDNLZmYsTo/m2Z2C96319cykBg0ZtSsHQ51Du/b7r3wEI3F/COflu2bXPOD80fPRc54VPQF3jd7Xgalq9xy/5jEI9Dj+vjaG7KxNlIj72FoHu/lY0pUfq+LR8XRUTkmcA1wNmqum/s9rCY1ZN0ozoRpFBTvXzzT9+hqucWUpFR3RRBa4aRF8XQmoicBVyBs9q4RlUvH7P9NEJ4+GhUNqY1I0zy0NtkJshV9WbTKC9F6NumdFEUkRXAT4E3quoThVRWKDZJNyoOKTCwjeWfNvKlUK0ZRr4UqrU8fTfBHj7WPKY1I0zy0NtkJshV9WbTKC9FmB/k46L4CWAe8D8udBDJKUzoS8asn6R7khj1f7ztseChTDrd2sIGNw4NJNvxxJl0JPwWRnxnopLSGMcsGGZ7XxyAnuEkbY3ObGZ4MMET27oAWDSvie7A1LKYacwKpb3etXXv7j5u7XHmUQvmN9Pa7M7nX553CK/53B9oaokXrc7TlgVmtOJPUdIRnfxXOFVgiAxT5J9+jog8gBsQPqCqD+fVOKNoVEKqtim0VrGoeNkUbONsE2+c7r2+JWveLp5bTpt5etFMWiw9sAN2u5Q0B674HU1HO5O++BnPgqFhdKszd9f+oVEpisqNxOrRHmeOqAcOIE1NyOrAfPoF/0Xs5n9yBYtkPSELnTmgTvA9jKVArU3pu1kqdDwtjdkmMFqPLR1Z1wrxwA90lxhGB7phQZA7aqAHFjnXDN25Cy9IW6obNyMLA5eNaLRoaaWKhUTjjDzq5gp19Q8603aAOS2ZdEL+T98Kc1qKV+eSZ8x+rUWC+47IONvSWouNXi8dK7OpF0Ug4bSiqZFs/3boM2CrS7mm3T2w/wBDd7s+Lt6bwFvc5sp1d2ddZiqFtlaSW1x2zuSWHogEGvCE6BuuA2DPa55D44LGolXpPe/szPUe97X2GArQW9nebGb6tXH6t3H7NfWzrmOJYWcy76cyn7V3r1uuawJ1V8076fmZlH5ecxPs3AaLA5eghpZsCrdKIXAj8R/bmE3/1TEXRhLIcf/ptt34j5l+rRh3TzJv+aRjzFgKvWfLw0XxIuCigiopErN+km5UHwJ4UlBgCHecyfNP3w+sVNU+ETkH+BmwdmYtNqqVPLRmGEWhCFrL13fTHj7WOKY1I0wK0Vu1vdk0ykut3bPZJN2oOESk4CdlU+Wfzp20q+pNIvI/ItKhqp0FVWxUFcXQmmHkQ55aK9R30x4+GqY1I1QKHUer6c2mUV5q7Z7NJulGRVLIk7J88k+LyCJgt6qqiJwIeID5OdUgtfRU1igveWitIN9Ne/hopDGtGWFi46gRFrWkNZukk/VXH0k1EY/0IzgfpubYHnx1zk+N0aPZPej8t6Neig3dMQh82KOe8NdNLrXP2tVzaahzl7W3f4ThhCvzz6dMnVYgLFY2O/+Ya95xMv/wYffw0num4Ac+NFfcuYkffvh0Lv6/uwE49xO/QVNu268uO2tGdebriw7uEX6BT8rGzT8NrIDME9pXA+8SkSQwCFwYpMoqO4X6aZcr5dpETJaKTbl91PZR6XZCOI8iaK3y8ZNZP0+AqPv9i/oQPRMGf5LZpH3BcyrVjN9207p57Puj80Ff0NGIt3Zppnzk/G+Vtu3TpeVVyEmvAiD17TfgrVwA+/YDsOm1R7PmTpeGM/WjtzB02XkAxI9ZhHfu12dUXb7+wVAUreXju1m+h4/ijdaaeBCMheInIebGDt13jYuFsCUICt7Y4FL7Af6GbRmfdJqbnO8wIA0NyEmXhXIaedN6AY2XXwDA9peewMJXuJfI3iFxkt95IwDRN1yH/7O3k7jSlSPmEbvo+hlXma/eakJrI85vXOuCdFbNLvWt+EloeJlbt//KbJqt7VvRwFcd3yex8QCRVqc7HUjg73E+7dqfIPbO74dyGvkiK/+Fxi/+C+C0NmdZ4A+8sw//i68EYMEP/0zXRacBsOVFz0I8YcWtf51xndPxEZ7V46h4mfSTo65JXdRpLXqm29Z/TXbbnu2ZPk1b5sGOoK+btwAammB74EkypxlZ+8GSn8K0CH47kQtexuClLiZk3SmrkPZ2dPuVAHgv+1/82/4NcP7pqZ0uDsxMfzemtYmxSbpRkUQKi944Zf5pVf0qUJzktUZVU4jWDGM6FNiv5eO7WbEPH41wMa0ZYWLjqBEWtaQ1m6QbFYcIlrvaCAXTmhEWxdBaHr6b9vDRMK0ZoWLjqBEWtaY1m6QbFYdQW4EhjPJhWjPCwrRmhIVpzQgT05sRFrWmtVk9Sfc1Sm9iMQBN0c4Jc6Wn/c57E4tpk60Z/+mkHyelzq+kMQqrW5yv3JPdgwwkUjy+3fkwveeUp3lgywp3LF+pD/zw7v37Tr7y+uMA+NIdG9mzf5DPnndUKU51xrR3uLyaO7Z0s2Sx83NatrCZ09/xE/5wtfPtfM3n/sCc9oaC6tk9eCQAEUnQEN0/eWGBGvoNjstkftzT2afS/NPHI93esuRMr0qtKZIacX7jgb/lpL6qiWEkvT3Hvw71nSFri/uda+e1mbzWumMHcrLzIfbWP0LrIa0ApHb3A9uJvvk7gPOP/Ovtzm/43J7Hi3iOhTPy6D7qYh7S6K5RtC7Czle4LFKLb/gLwx9y55d8spP4hEeZHBnudwue53LmTlq4CrWmiiQGXS7fuBsDJvQfVB+G+5F6b/Q6gGQC3FCKLLoI3Xl1JuaB7tyFnHm+2/a3hyEZ5A2ORtGdLu+wd/638G95D9rptBZ53bVFPMnC0ZTSedMmABZc1Ia3bD4AQ598KfWf+AXJr74GgMjcmSotoGsH4kUz38WEVKPWANRH0nExGlsn1Vo6foZEA5/zdL7q5AgEl0eWvgt98gtul95ekg8+DUDsvf+MPPQ18IJ9Yh6Df9oOQMuVv2foky8FYGR7H3O+/ocinmDhNM5vZKTP+dbHD20jurgZgA3POYpD//wQAAPnnUh9e11hFe17GokGek37/U9ENepNfWTQ3cNT1zRlvwYg9S3ZPs1POa0FITRk0UXo3m9l9+sKjr362bDT6Y7BXldXvzued9x/onu+GRzAQ+a/pTjnViRiq9sAGPrtBhpefwo0zAHAv/mf8M76H7f82/cSOby1sIr2b8ssSkPL5GWrUWsFMKsn6UZ1IigRMdc2o/SY1oywMK0ZYWFaM8LE9GaERa1pzSbpRkUynWjwhlEIpjUjLExrRliY1owwMb0ZYVFLWpvVk/TekRg7+12qz4bocnb1OzO6vz19gEMXOZOKOXVRHtvTB8Ah8xpZ274ys//8+sXjHvehvX2sbG3gzExatdU88NB6AE4+bik7Ot3x1qxsz+zj+8qieY3FO7ki8f0PnnbQukt+/hDnvPaZmc8//PDpBdfzxV+7FKudu3p55tGLJi3rnpSN75owW8nHLH0mJvCVxHjnOPZcwjbPr0qtpVLQ3wWxOmduB0hyBA1SEkk0Dl4EHQzSGMfqsqkOxIO6c8Y/7vanYPkaALyT/zmz+sDvPkL7i1y/qAMJem/fSvub3bamhU0cc0qqiCdXPBov//Woz/PvOgupy5qkN37+5oLr0F1PugXfh+b2SctWpdb6uvHvuBk5dA2kzYq3biXxF+faEHvRs6HZmcImbl1P9PnHIksPze7f7NJDMdYTYH8nLFwAgHfCpzKrk09fQew5LpUZezqRhtEmu9IxpzjnVWSW3XTvqM+pH7gfSPxEd/8Rf88Pi1LPgX/9Hx6/fS/PfsczJi1XlVoDGBpAe/a45cEeGOhGt7h0VdLe5tL1Af7OXUirM7FVVRBB5rm0d8RGH1L//ojbf+0a4u/978z63r98jDmnuHSS/t5B4oe2ZXeKOFeMulUFmvGWgPZvjh4zBz5yNgDLX31YZt2Sn99dcD3JH/8KHXb3zNFDOyYtW5V66zqAPv2YW66vQze6NGlDNz9Gw/knwBw3Rxi56S/Ezj0ZAFm2zrnugHMTGzuDGgrcn5qakMM/klmtQ791C23tcKATWZ2TkjlwMSNWoHtCCUi7taVPUx/+DACybm2mjHfGVwquZ8ebv8w9v3P3K2e8bdmkZatSawUwqyfpRrWimVz1hlFaTGtGWJjWjLAwrRlhYnozwqK2tGaTdKPiqLUnZUb5MK0ZYWFaM8LCtGaEienNCIta01rtJJszqgdxPicT/VUSIvIBEVle7nYYM6SKtGZUOVNordL0JiIfKHcbjBlShVqzcbSKqaJx1LRW5dSY1mb1m/Su3mGuvcOlRVm3sp2/b+gE4L5bNtCx2vkPRqIe6rtIgSedvJzoYQtYMWd40uM+tbOH3oEEx86/D3B+tNe8w/msXHHnJjpand/U41sOZPZ5/6mH8pnfPlHEsysdnzlvH5/97WI+9ouHAXjykT14Qc6DrXdv59Xvdef6vuevyfuYD93j0psM7Ohh++YDU5RWPElOv+HlYSlwVxgVKbcjnDqlb3pZUpkVgcnaXDpf9arSmiMxjG7fCNEItLlUTwz2ok8HaV5aWyEeRw+435ksX4EGfnTSPHfCww584480vtMNCTr39sw1X/DDP7Pvjc8DoP38w2n0s5FV2665De+dhcesCIOGz1/CwPs+DUDn65/LnJNczBGJRUjudr6Ed//vBk7d/ljex0zddk9m2Vs9eayNKtTa0mRnPwf+716a1m4kekgbAJ0/e5Lf/8Rpa+2hDzHiwiIQjcJxnhA51/mvSsPE/ry6bz8SpFrTFVmt1b3/p/g3/5Pbf/Ei/Ke2Zvbxzvwq/m3/VtQTLBXeBW8DQH92LakfvYWRh929R6S1jr4HnM9169mHELng29M7bjTCsnWN7L975xQlq09rwF3a1U/ix85/N3rUMvyn9tB3l4tnU7e4CS9Ip6iJFLFD3T2cNzQMqya+Fxl51KV8jQ4kiRydTfc577o7GfnKq90x5taT2Nyd2af+Yz8HYPDSc4t4iqWh4XLn+zzyxSsY/JiLN5LoHGSkb4SdD7g0dYe9/hnUXfKzaR238+bNDHUNAVDftnWK0lWlt6XAXYn9Qwx9x+khMree7TduAODPtw2x+Lqn6O5249zaQ4W1MRdUI/6mVS6uy0Sk/cr37RmVWlaCuBu682poaoIdTtMsd2kCAXTHVUU8xRJx5HPd/y1/Qzd/CQB94CHX+QMjD+yi7h/PQxa8bVqH7ThlKS9c4lIJ9m7vm6J09WlNRDYD1wM/UtXO6RzA3qQbFYmQmvCvklDV9wEryt0OY+ZUi9aM6mcyrVWa3oK+zahSqlBrNo5WMaY1IyyqUGsfB54JPCgivxaRN4nIFAnhHTZJNyoO53OSnPCv0lDV2knaOMuoNq0Z1ctUWjO9GcWiGrVm42j1Um3jqGmteqlGranq7ar6LmA58GXgfcDufPaf1ebu8Xg278vdD+zgiQd3ARBpjNG936UrGtzeQ8NSl9bl/vt3EI9FiK5x5nqLGsY/7vuev4Yv3r5h1LrvPOTMz5bMb+b8dS61DMct5+cb9wLw1yc6OfKQecU5sRIjnMpHz4AP/vRBABYtm8Omx52FxoXvO4WmBmdy9qvN+3jJ6vzOafiAu96veddJDA0nufW/Jqtf8WooMMRkjGe6nvs51wy8Gk3c821/2tS/+PVXodZSPvT1ozt3kdzoUj+muoeRwCQvubOPxnPWQtosXTxY5PokjcaQ+vEP2/SV3zL0yZcCUJc2awOefvGxzDvc/c69l/0vdcCfVroUUAsWRWhbXXlpisZDOJWmLzkNDb/l+SR3OBP36JImNv3U9edz5sCP69bx6uHH8zqmJtyT+/71O5mzZvyUndn6q09r0bZ62l52KPiK3+vs2uPNMU57mfvOxROe+pszEz78jMUkNncT2e7cLnTZKiZ6V+C94L/wf/ted4yc9f4fP4C0OzNmOeFTRE7IrqevD5k/v8hnWBrSfZW8/FT8G/+RePD78fcP0Xbh0a5QNJox7ffO+p+8jhufW8/SVz4DRgId/Wz8VFvVqDUAIh5+l3M3HPjp3+na1I0Xc++SBvcNZoqprzQ+3QtAc8InUl8HE0gjbbo+8qVXjcoEmPz2G4gsdia2kfO/lcnclvremxj+m3NJqHvWgiKdWOnIuoqcSv97zwAg2hxj3xP7Oez1rp+WpijJ77gUddE3XJfXcRN9Iyx7/REAeK11E2rNtaH69BZb0ETdP7jzk1ic5a3OVH3pq5J4LXEe/YJLq7j6rFWZfTQx5FKcToAsusiVG/zSqPXadb1biDcgi9+RfY8/eCPa7bQmzZU/P8jcg608Fd1yhVu3eiW6eQsAde94BRJvgMEbXbmGl+V33KYoLZe+FoCWHdtnndYARORo4ELgAmAf8NF89rM36UYFotUUGGKtiHyi3O0wZkr1aM2odibXWqXpTUTWTl3KqEyqT2s2jlYz1TOOmtaqnerTmog8AnwPGADOVNWTVPXL+RxjVr9JN6qXCJVntjIBv8EFhDCqlCrSmlHlVJnWflPuBhgzpwq1ZuNoFVNFejOtVTlVqLULVPXvMzmATdKNikNEK+6J2ESo6iEiEiVP0xWjsqgmrRnVTbVpTVUPOX5Nh/luViHVqDUbR6uXatKbaa26qVKtpQCCdGwnARtV9a/5HGNWT9IXz6nnspceCcDX1j/FS56/GoCICHPq3Knf8ehuuvqcr10y5XP3vds496jJfQvBpVSDQzOfYxHnObB0Tl1m3R+3d9Fa5zydVixq4eldPbCu8n2c0viBT+uale28+jSX4iTqCU/scSkSWuIRrrnPpea46LjJUwH+/qpXjvo8eQJeJVKgz4mInAVcAUSAa1T18jHbJdh+Ds4E5S2qev8M6rkI+Dy0TJkababk44tdjf7o0yU3pclkTM93vbxam2rfcWlagpzwKQTY94qTANhwbzeNjW7z0BAc2xij4fWnuBWNDdDl/IZlwepJD13/iV8ctC4x6Hz00vS/78V4gaPUnl0pdmxzKY5KlSSvFKSGUuiA+94f+H8PsXu36+vmzxdGRuDvRzlfzqMfmjwdW+wi90Km7aLctRMF3Kiefi041kXHHXcckfO/5T7fdDEAbe9YQVoAEomycPeezD7aP8TwL1xq0rp3rZr0+N4ZXxlnpUBzU/Z4D3zS1dPUhA4MoEFdcvCelYvvIwudv2n00Bbw3Q2mdneT/tH6P3s73su/MeWhGj9/85g135ygZPVpDfi8LDgk0wcNf/4VLD5lKVIfeJI3NpB8wn3/ftcwUu/u4Qbu2k7LmS+Yso74+34yekVEkMVZR/Z0ej9pjBEL4mwkt/SM8mOvdBID7g1jw+FzWXn66ozWkk93I3XuTEa++hri7/nhlMdacevYOcRk6QIL01s5tEbLcrznfcGt7P4B0RNe6JZHBiES5ajT3diqjz3uxlAg8d2fE3u18/uXSUKxyOrRiTEkEoyf0WB+0PdT97+hBWlwgTs0OVJd/VraN3/+ArwjTnTLkRjaswepc324dl6LdLxpykPF3/vj7IfFAJ+cpHT19G3Z+QF9IvIp4IPA/cCxIvJNVf3cVMcwn3SjIhH8Cf+m3FckAnwNOBs4AnitiBwxptjZwNrg7x3AlTNs6vuA/BPGGxVHubSW577GLGIyrU2lt5D7NXB9m1GlVKHWbBytYkxrRlhU4fzgebio7qeo6oXAscDUTy+wSbpRgaSjN070lwcnAhtUdZOqjgDfB84bU+Y84NogPcJ6oE1EpjahOJgRVT0wg/2MCqDMWstnX2OWMJXW8tBbmP0awMgM9zPKTDVqzcbR6qXAcdS0ZuRNNc4PVPXpoM5OAFUdIM/x1SbpRgVScPTGpcDWnM/bgnXTLZMPDSJy7Az2MyqCsmqtWBo0qoKCI26H2a8BTJCE1Kh8qk9rNo5WMwWNo6Y1YxpU3/xARI4D4sHys4PPEyTDHc2s9knPZdvuPp7a0QPAi49bxkjKfZmeJzQE/umPP7oH31dWNtdNeJyJuODwhQD8YlMnv9jkcooPJXwag1zt8ViE4YSfya++YtEcWgOfql/dtYUrXlu5fcZzD5uPJ85bxhN45hLnjNM5MEJLo/NLueTnD3H7/93PXT/Ly4JjSsSfNHpjh4jcm/P5alW9Onf3cfYZGwApnzL5sBP47xnsl9OQ6Xnz5vq+T+WLPt72UuQbD5OJ8sTPlDJqrWANpoZdnu4jXzSfzX/eCzg31/gz52d9e3t6M76v+eYtzWXNnX9n2znHA7DgS6/iwOMHWH1cGwC7H+li6zbX5J81rmPOnOx+ixcJh/9tcp/uctF26nIe/PIDgHOvXrzYfRWNDbByhdDY5mKJDHzkbKLLnM9gPn6cUzGF1mByvYXZr4Hr29ZlDtIb5KnuHcRbtcwtex7MbXPLu/Yw8ug+SLnqZP5bpl2h97wv4K+/xH245+PooKtT6uogHocBF1vBv+liaAtytcfi6PYdbv88/LpDx/eR9ja37HkZP2GZNxc90OXW19eR+PqFbLjybwBF+d1UodZGjaOJp3tI7e6n/rnBvXEyhfa7c/LmNjAQ5DKPNUZd7ulpEn3Ddfg/fSsA/s3/hHb3AyBN9Rn/7dSBIQY+cnbGR91rq6P715sAmPutO6ZdZ6mJNbp7ytgxy5zWgtgR0SOaMnFJvLY6hj/7cgCe/tmTrP3Lw0Wpu4BxtOxa0+F+2OVyfcuqo4KV7nfq7+km8fhmAJKdg8SXXDz9Glte5f73/RTdd1021/pAD3jBNCwxDD0/cst1TRCNoXtcvTPRd8nZtQsAOfYFIMH7XvVdvvehXvdZBL3n4wBs/49fs+yme8c70rSp0vnBLkbrblc+B6iZSbpRTWimg5yATlU9fpLt24DcSHbLgB0zKDMlqno6wPHHH29RkKuSsmotnse+xqxhSq3B5HoLrV8D17dZv1atVJ/WwMbR6qWgcdS0ZkyD6psfjIeIxPI5hpm7G5WHAn5q4r+puQdYKyKrRSQOXAjcOKbMjcCbxHEy0K2qO4t6HkblU16t5bOvMVuYSmtT6836NSM/TGtGmBQ2jprWjPyp4vlBcLwXisg1uAcBU1Izb9Lvv+tp5i5w5p/Xbe1m/x5n2tSxuJmtDwVpPRI+t33j1QXV89u/bOXYI1yataHhJD/47UYAYnURrn9/1jT38t8/wboV7QCc8qwl3LLFpTE6c+XcguovJoP9Lq6BrxDNeZzjBYYgcxti3PukM+3/2/qtxFrr+IcP3wTAbz53TgE1K6SmNNWbeG/VpIi8B/gNLsXCN1X1YRG5ONh+FXATLr3CBlyKhbcW0OAZUUqz89xjjzV5zzeVWTWg3F7geZRPaxPtO5365z7TpRCKHz6PZ7Q7FyevMYZ4gj7p+h6Ghgs2A44GZpTqK4vffCT+/iEAmuY3csyVv8+Uu2+dS10WjznryjuWu8/P31phZu+eZNLIDQ1lLJAZGoLhYaUtMG+V+giRhUGarN//K94Lv1xApdXdr+390eMAzDmkjcg2Z87o947gNboXAjt+vYn2Ne20XXNbYRV1urGQ+R0QdWbHib88DikdlUbL/+U7AdCOudDhxk1//SV4J3+2sPqLjD+QJJIMbh493w2oaYLUTrprP8mne0gG8tj/lucXaE5d3VoD6N7SQ9PCJgZveBKAgb0DNC1y93D9u/oZ6XNBotbc+fcZ13EgOHbrP6xGe939zu5vP0y82Wl6wQ//7Or+0FkAxI/soOU5zvw+9YM3E7lgsrRk4ZO+Jg2+P8q1Asi4P6Ue30bnXdsBiDfH2P7SE1j6i3sKrHnmeqsErQ1fdQORJc0ARPbtc4NXMEDs+PZDzDvcpVBsyRnrZoIe2AmxOrTP9XH61wdhjnOnyh1btOt6pKEVaV/iViRuhthZBdVddPwJ3mZ7Eah358T2J/E3PQ3A4L5BOl//XAA6vvunAiquvr5NRE4CXge8ApgLvBuXjm1KamaSblQRmpep3hSH0JtwP7TcdVflLCvuh1IQInIZ8Jrjjjuu0EMZ5aDMWhtvX2OWUkX9Gri+zfq1KqUKtYaNo9VLgXozrRl5U0V9W1prwNPA9bgE8Peqat5P92ySblQmBTwpC5l3AI8Dh5a7IcYMqR6tGdVOdWmtAqMVGXlTfVqzcbSaqR69mdaqnerT2pXAL1V1SESmFQvBfNKNCkSDp2UT/FUWi4DLyt0IY6ZUldaMqmYKrVWe3haVuwHGTKlKrdk4WrWY1oywqEqtvQzYICLX4dKy5f2CvGbepN/8uSZedPE+AJJ9I0jEOVYP7htg4Vrnb9K5vafgenJTqV38f3dzxDHuPufB+7aPKveRFx7GuZ/4DQDzFzWz7hnOt7SSfNJfdMpKAB7b3cszl7jcSj3DSfoTzr/OV7h3vfM36d/aTdPyVgYDX/+CUGDq9DEVgaqmgF8ff/xkwSRLw2R+52PLTZWqrWapIq2NR8PlHwHA/8E38ZpdWheJeaivyNCwKzSR79g0WPTj9ZnlwY+/hB1/cL/7xaeMTh163OPO93zj845mYDCR8fuuNKKvOJO1f3cp6x74xXbqg4yl8RiM1Av1Hc5XOLqsBWkP8sr1Fdi3VZnWVDWV268t/PHnANj1ig/REMQkGNw3SF2r092iU5fz9I0baSuwXu/cr2eW/R+82a1rrWfk4U7i45RLXHlBJlBKpILGzzSRo9dC+rfoeWjC+T4zkoARt5zY3E3fxi7WnLMKAH8gUVilVag1xoyjS37xX2x98b/SvdOl4atvijDc7a5X68o5NMxrKLjeedfdmVlO+8vOPaqD7icPjCrX+PmbAdjwnKMyfvGt6+bSeEHBTSgqrRceDUBqcyeRtYtckA2AoWE0SI24/+6ddG1xMSWa59cz2DlYeMVVpLfxtFb3iQ8w8L5Pu+VYkH5vt+vvl7z2cPb+wsV3aSqwblnuLKj1r5e6z0cfQerOvwKj35hK22tdmSDNJO2LkLYCKy82QbwQPbAj6zs/3A/JBJpyv1N9+DGG/uTmPsvOXIXfPVx4vVWoNeDXIlIPnAs0AttE5Peq+rqpjlGht1BGbaOo+hP+VRIicoKI2BunqqV6tGZUO5NrrdL0JiInlLsNxkypPq3ZOFrNVM84alqrdqpTa6o6hJugx4BfAXkljbdJulF5aBC9caK/yuLrwEi5G2HMkOrSmlHNTKW1ytPb16cuYlQk1ak1G0erleoaR01r1UyVak1EXgBcDnwbl3P9lHwOUDPm7rsHjyTRcysAyd4RNEiDUtcBTS11APQ0uLQbL/+kK/ezT7y4oDqveuuJ2Q8vOYLnv+56IkEdyb4RBp7qAmBXzOP/7ry4oLpKwSvXPgrA1+9exR1PONPQoeEk0SAf28anDtC735lKxTsaqWuI8usCU9hlqDzfkomIqOr+QszdC08jdnA6tanM32cLRTmX6tHaQchgt/tfF4XAhQdAPMmkpWIkazo7/NmXU3fJzwqqs+FTv2JNzmf/xn8MFnz8Pnfvs/TsQ1jUOUDTl24tqK6SsWANTf/otPPs1vUceMilkvRiHq1HdRA71KXH9Jrj+E+7bdG3fa/weqtLa5HcD9LrrkOsMUpdkJZupGeY3q3OdLZ+UfOonYcuO4/6j/28sAbkpLiKAgMfOdt9SKSQFmf8ntjZT7TVjeGxd36/oPpKwjGnonf+0i0nU9DTm9mUeMxdUz8YR6PL3DWMv/fHhddbZVo7aBzds5He3YNs3xHcq9WlWL7K3bI2dDSQHMrmRN75ipNYfMNfCmpAblqoxuD/n1c/g8YG2B9Yv+/cpdTXdwHwygLrKwVy5vnu/ze/TuKvT8NI8GYxIiR39gEw1DVEy0LnKhCpj7Lyd38rTuXVo7eDtCYDB/DTekr5+N3DDD7hvvSGiDDSkzXTTgUuOIWk35NjL80sR4PBdPBj2bTFXnMcv2+EyOKgP3jPD2dcV8k49nT3/57foguCtJnigfrow27uMPLgnkxawDnPX0bk/G8Vp+4q01qwfAFwtar+BPiJiPwtnwPYm3SjAlHnczLRX2URmU4QCKPSqCqtGVXNFFqrPL1Fpi5iVCbVpzUbR6uZqhpHTWtVTdVq7UXA73O25aVBE6pReShFCXYVEteDRWWrWqpLa0Y1U31aux74dLkbYcyA6tSajaPVSnXpzbRWzVSh1kSkExgE7gAQkUOB7nwOYJN0owLRSnwiNi6qepmI/A74c7nbYsyE6tGaUe1Ul9ZU9bLjjz/eJulVSfVpzcbRaqZ69GZaq3aqUmuLgVtUM3b6HvDP+RyjZibpMW+Qw16wCoANf9mGF3OW/u0rWtnymPO3vvW/X8rp7/gJ81a1F73+i65ezzFnryUSpC1IJVMc6BwAYMv6bZz4omsAuPt3FxW97pmS9vd9/bGPsrF7OQBX/eIREsPOd2ffnj6OOtmtf+yvO5m3oHn8A00XVUilpi5XIajq+un6pJcyLdpUx01vrzTf9LKkiqsyrR1ENEi7tnQJdfXOLxfPg+Ym2BP4Wb/8G/i/fa8rV19cC2Z//SXI4iBQbjRCJOqGlMi6YRJ/fpThz78CgLoP3VDUegtFOBWOdH6GDR9ah1zxHcD5N8cObSeybhUAunUb3tzCUz25g1W51sTFPGh9wXK6/7gVgKEDQzTOdx68XY/uY939j2ZSWc15ztLxjzND/FveQ/0LAwfOeDyTEi+6q4fkZvdSov+9Z9D0ld8Wtd5CEU5Fnu38W7WnE//3f3TLQ0kkuA+Jrm6juSWeSaNYMFWotYPG0XgDi589n3iDc+mMNkaZs6wFgJ6tvSz5+d2AS4s2Z3lLUduS1vDhL1pErDF7mzy4b5B7f+361Vs61nFm5+NFrbdQ0mN69DX7iGzfwP5P3wjASF+CVHDftuiUpey6y6XFapnfOP6BpkuV6e0graVSNL3iCAD2XH0vg/sGqW9zeTm9Jw5k/PZ3nHcii9757OK25ckvAFD/hhdAMIbr5i34WztJ7XBxBAY//hIaPvWrotZbKJn7x2d0okNBnI1d26BjAf5e1+7I/EYa693vR+pixam4CrU2zron8t2/ZibpRpVRYakUjFmMac0IC9OaERamNSNMTG9GWNSQ1mySblQe6RQLhlFqTGtGWJjWjLAwrRlhYnozwqLGtGaTdKMyqZ7AEEa1Y1ozwsK0ZoSFac0IE9ObERY1pLWamaTPrdvEWacfDsB1u3pJJdyX7HkefmL0Fx6NFS8z3Xce2gnAC05eQVNDlMHAL2hoOElLo/M/+9OCJh5/cHfR6iw2LbHDWTVnEwDzOpr423rnj7j6GR0smd8EQOKI+Rkf+4JRdflkjWkRuj93CUj7OYV2LlWuNY0F/tLLlsOgy7VMPAbJMU+aR1z+ch0qzrnq0/8PAFm6zPnAgxs40wFdOhYQO72O1AOV5bM5iuiZ7n/jzcSP6gDA70vgLWrP+AYSL5KPMFS/1prnARB9wbOYE4yZjU/3IHUuzsHwTucjCaq+6wAAGvdJREFUno73ogOJ4tW94yrkyCMhHug9MQRJd/zokUkijz8JQHJDZ9HqLCqNLwdA+BnSHPidDiXxgvzuXkcTkbn16FCR3hBVudYAaFtC22uOpP8rzvc82hDL3Kv17+rPFPOTPtHG4t3Kpr73JtpfdigAUhdFh5Nov9Naw6I5PH/BRgA2/GZr0eosOs2vRBb/iIYgz/amG57iiHNd/KDIwkY6nuF+y4P7BotTX5XrTVs6kGOdj/rCj3Uw9OO7IejHUp3Za9Qwr0jxSdL0/gRZdIhbjkQyk0+Ztww5opvIls2ufTt3FbfeYtLyKkR+CoAuXAKJYbyWwP98XhMRz8Uy0f6h4tRX5VqbLjUzSTeqjBp6UmaUGdOaERamNSMsTGtGmJjejLCoIa3ZJN2oPFQPfhNoGKXAtGaERYm1JiJzgR8Aq4CngNeo6oFxyj0F9AIpIKmq00tNYVQ+pjUjTGwcNcKixrRWM5N04VSevdiZW0TfcCx3/m0HAMODCfZv78mW84TrPyhFqzcWcSYzjY3OJDDa4I69oKWOtnpnErJjRRtPPbmvaHWWAsE9uUqmfHzfpfpraqmjNTDdO/XEFZy/bkHxKizRkzIR+QLwUmAE2Ai8VVW7xin3FDO8uQjdZLsGKWr6uCp+Kpu5Ds2dsPYwt9y1H5JJtCvbrxGkRotf8r7iVBwJhg4vJ6WbCMTSZuINmTorHvFgjkvhFOnoQvd1M3ync+958LoNnLTxseLVVVqtfQT4napeLiIfCT5/eIKyp6vqtGzDM/3a4h3Ezguu1x1/IbHBzc3iHc4UtG6O00D8Q/863fZPjBd12srVXX3azSKFrHE3bZH9fcWrs0T4Pe4+xO8eRloCd4poBFk0l8gLv1zEiqpXa5BOk/g3lv6r+56H73gqs60rSLkHoCml/Vufnu7hJ663PgKNWbNmiUaR+S4tr8ybS3Sxc02seItbL4ImXCPjMTKuFRKLUP8sd6/W8s7vF6++ah9H6wOJrjmSupcMMnzLwwBEgusGEK2LIOe8togVS7ZPEw8kuIaRKNI8F13XFLSvwkmn/+7eh+7e41LAArJ2DTJ/pdvW/Mri1VfFWpsuxXO+NoxikfY5meivMG4FjlLVZwJPAJdMUvZ0VX2WPf2fxZRWa4aRZSqtFa6384BvB8vfBl5e6AGNKsW0ZoSJjaNGWNSY1qrkVYdRU5TQnEVVb8n5uB54dUkqMqqDGjOdMspIflrrEJF7cz5frapX51nDQlXd6arSnSIykWmTAreIiAJfn8bxjWrBtGaEiY2jRljUmNZskm5UJKqhmLO8DedXN24TsJuLmiAkrRlGPlrrnMxyR0R+CywaZ9PHptGM56rqjmBidauIPKaqf5zG/kYVYFozwqRU42g+8Q9EZDlwLU6vPu6B0xUlaZBRdmrpnq2mJundw+7py7yGGMsWutQU23b3ZVLGAPz+qiL6TQBLW+sB2Nk7DEA86rxL6qMefuDH0VAXZcnKtqLWW2x29C8JljayfM1ct25LVyaN3DtOWFG8yqZ+UjbpG4DJbi5U9edBmY8BSeC7E9RR8puLovpV1xBFvW6z5KmspkYg5voa6usgGSH5VOArDHhnfrW4FdY5nzMGup0vHbgUMtHAx1Z9iEbw5tQXt95S0H8AWeheBMZPbUF7e4kd6m4CiuqPXgStqeoZE20Tkd0isjh4s7kY2DPBMXYE//eIyA3AiUD+fZvvQ4PzSffWLEe29QIQaXIxVpq+8tu8D5U33fthTluOT3oUIjneenVOZ9IYK37dRUSH+pH0/UYsgr/XpXfyWuJEzrmqiBXNEq319EJbKwDR1a2Z6zXUnzVrXXf/o3kfLh9k5Qr8TVuynxvqsj7qyVRGYwvXNBe13mKjuzcjde73csipSxh8yvnxN8Yi1H/s50WurKTjaD7xD5LA+1X1fhFpAe4TkVtV9ZFp1xaNIUuXoEMPAhA/rD2zqeXK38/wFMZH925BOoJ750gkO5aC80v3nc610uO7RFxsGt2yleQjOyDl5jbRxgZkdZHi4KSZJfds+WI+6UZl4uvEf8EbgJy/UW+5VfUMVT1qnL/0BP3NwLnA61XTES9Gk3tzAaRvLozZyORaM4ziMZnWCtfbjcCbg+U3AwfdiYtIU3ATi4g0AWcCDxVasVGBmNaMMCmd1qaMf6CqO1X1/mC5F3gUWFpoxUaFUiKtichcEblVRJ4M/rePU2a5iPxBRB4VkYdF5F8KqnQKbJJuVB7pJ2UT/RWAiJyFewr7MlUdmKCM3VzUCiXUmmGMYiqtFa63y4EXi8iTwIuDz4jIEhG5KSizELhTRB4A7gZ+pao3F1qxUWGY1owwmXoc7RCRe3P+3jGNo4+KfwBMmkZIRFYBxwJ/meHZGJVMae/Z0lYba4HfBZ/HkrbaOBw4GXi3iBxRaMUTUeE2FMXl2fOdedKPHt9D/6D7MocHE/z2yy8rWZ13PubSdaxcNIdHN+9nXmD+fqCljvZmZxo6v72BBQsq23RqU5czM1u2oJnVS+YAcO/fdvLvZ64rfmVKKVMsfBWow5mwA6xX1YtFZAlwjaqeg7u5uCHYHgW+N5ObC+HUg9KwmYn7zCnJtSut1kJD2l6Lbv2a+7C/C+3vJ/6eH5asvtTNtwIQee6zXcoVQFpbodG59RCrg6YWtG+4ZG0oFtrTmUkZQ2MDpJJE3/CVElRESbWmqvuAF42zfgdwTrC8CTimkHpk7uvRjV90H+KxjPlvKfWmGzch8+ZlTJ+Jx9DtLo2qzJvnzKKh8tP+DfcjTe4eIOIJfsS5v0Uu+PZke02f2aK1o/8d/0dvASDxxAH8gQQARz9URDeUMQz+4C/UBSnKum/ZTOPauURXuuf53oJWood2ANC6ctpZ5UJFt+8kfvg8ACTm0X/7VoDim7pDPnoLI/4BItIM/AT4V1Xtmar8KFpeBYDuuAqSSWKrAzeLt31vWoeZFj29aI9L9caCnNPfthUWLoBBd99d8fcoaTP9eJzIwib8Ljfue8/7QvHrKm3fdh5wWrD8beA2xrhWBA+K0g+NekUkbbUxfdeKPKjwEc2oTUoa3f3QCdYX9ebCqBZKp7V8At4E5c4CrgAiuAdF6bdSXwBeCowAG4G3qmpXSRprhEBt+dIZ5cS0ZoRJYXorRvwDEYnhJujfVdWfzrgxRoVT0r4t36wVQDhWG2bublQequ5J2UR/hlEsSqu1KU2nRCQCfA04GzgCeG2O6dStwFGq+kzgCeCSQhtklJGptGZ9m1EsTGtGmJR2HM0n/oEA3wAeVdX/LrRCo4KZWmuTulaIyG9F5KFx/s6bTjMKstqYBvYm3ag8FEimpixmGAVTWq1NaTqFC0i4IbDeQES+H+z3iKreklNuPfDqUjXUCAHr14ywMK0ZYVJavV0O/FBE3g48DZwPLv4BWRfF5wJvBP4uIn8L9vuoqt40zvGMamZqrU3qWlFtVhs1OUk/f90CWDepFUPR+MgLD8t+OGK0y82vNu8DYGgkSWqSqITXP7ILgNceMZ7LTun52vqn6Gh1KUga6qJEo84AY/7CUvnR66x50h+mD/pkdY31jZ+qXLl85/NtZzFrLKHW8jGdWgpszfm8DThpnHJvw5nOT4gsf7dbWA4yk9ZOg+gbrsvWu/rg7brxi+jW7ez96RMALHrd+McZ+NBZNH6+PLGkOl//XADmffQlLm0dQH0jUleqtHGzqF9b8/7McvzY0tfnjZOeLK07/5fvBC9QvDex8v1b3lP8VIR54v/s7QDIurXI4cE9wdbteIlS+TXPHq1Fzv8WAI3nh1Nfbn80d0y/5f/2vegBF/9guGeYlgmOkfzOG0f1kWEz9MmXEls3Fx1yZsHSWE+0vZTpMEuntzzjH9xJkYY9WXIxALE1xTjaFHUd84nxNyx2WpP2ILj40okD1etOl9xIFk8nFl/x0O1XQtzND+Two2DoXrxUKTPjlLRvS1ttXE6FWG3U5CTdqHAUNGFvAYwQmFprHSJyb87nq3NT/hUh4M14NxajRjgR+Rguouh38zymUYlYv2aEhWnNCBPTmxEWpdVaxVlt2CTdqDxUITE73gIYFc7UWiu16dQ2YHnO52XAjpxjvBk4F3iRqlri9mrG+jUjLExrRpiY3oywKKHWwrbayAebpBsVhwI6ifm/YRSLEmttStMp4B5grYisBrYDFwKvg0zU9w8Dp6rqQKkaaYSD9WtGWJjWjDAxvRlhUWtas0l6GXnJapfD8ou3b2BgMDFuma+tf4regRH3oUw+6cvmNzGvweV0b+xoyuSb55iJ/WQKwgdGzHSqmKR9zCfz+Q7fH3xqSu4bX1qtTWk6papJEXkP8BtcCrZvqmqQOJWvAnXArc4NivWqenGpGltMZM376brsVOLNsXG3J655LQDRxU1hNmsUjUsDj9K2dqh3fZrMe6OLElAKrF8rCd65X8e/K4jH2Nd/0PbJtoWFLA7G7uYWaJkLgJfj1190TGslwTvjK/S883QA+nf10zFme+LKCwBI7R8q68117NB2vENW4AWxNuTofy+tT7/preh4Z3wFul0YGu3bP24Z3X4ldO51HxaH1bLRyNylkApSokXjSKnjftSY1mySblQgWlNPyoxyUjqt5WM6FXy+CTjIn0lVDy1Jw4wyYf2aERamNSNMTG9GWNSW1mySblQeivk3GeFgWjPCwrRmhIVpzQgT05sRFjWmNZukVwDvP/XgF2bXPuhiR/m+8uEX7gzWHnZQuTAYGvHBZVigM216X0oUtKQpHGqXiczHK9HUPRRMayWj/Zvja2r4i68kdsIhAMgLXhpmk0ZRf9oqt9AwBzyv9BWa1kqGd8rnxl2vD38GRpwrmbzyLSG2aAKSI/DkI275hBLWY1orGXO+/gf3f8z61A/enEkBWPexfwu5VePQ3BROvwamt1LR6twnpHXM+uHA8K5zLxxTnnS5GdRHk8NuuW8/Umqv3BrTmk3SjcpDFSydhxEGpjUjLExrRliY1owwMb0ZYVFjWrNJulGR1JLPiVFeTGtGWJjWjLAwrRlhYnozwqKWtGaTdKPyUIWR2vE5McqIac0IC9OaERamNSNMTG9GWNSY1mySXqG86ZlLcj6tLls7ANbMayTUB1daW0/KKoGSpzqrVExroVP3/p+WuwkAyAknu//ROHiR0ldYYq2JyPnApcDhwImqeu8E5c4CrsCl/LtGVS8vWaPKjBz5UaTcjQBIp2AbHkKHhwBK2y7TWuhELvg2IfQieeEd8wxobIBYXTgV2jgaLnUuOYwcc84UBUuPjgxCT6f7kAgpZlUNac0m6UbFoQpaQz4nRvkwrRlhEYLWHgJeCXx9ogIiEgG+BrwY2AbcIyI3quojpWyYES6mNSNMbBw1wqLWtGaTdKPyUK2pFAtGGTGtGWFRYq2p6qMAIpO+oz0R2KCqm4Ky3wfOA2ziNJswrRlhYuOoERY1pjWbpBtTsrNvmIaoS+Xx9y0HeN6Ssfkgik8tpVgwyotprUYZ7AVAkyPols0AeCe/sqRVVoDWlgJbcz5vA04qU1tqh7QZ6EiC1GPbAPCeV9oqTWu1i+7cBc1N6BaXyjdywcWlr7P8ejPKwVA/SJDqLxrOlLKWtGaTdKPyKGGKBRG5FPhHYG+w6qOqetM45WrGl66mqbF0HkYZyU9rHSKS6997tapenf4gIr8FxstE+zFV/XkerRjv1Wft3PHUCqY1I0xsHDXCosa0ZpN0o/IofWCIL6nqf0200XzpaogaC0JilJH8tNapqsdPeAjVMwpsxTZgec7nZcCOAo9pVBqmNSNMbBw1wqLGtGaTdKPyUNDy+pyYL12tUH6tGbVCZWjtHmCtiKwGtgMXAq8rb5OMomNaM8KkMvRm1AI1pjWbpBtT8tJDOjLLZ6yYG0qdU/icTGqmlwfvEZE3AfcC71fVA2O2my9dmShHKrha8m8yssiKf84uLw6nzlJqTUReAfw/YD7wKxH5m6r+g4gswbnsnKOqSRF5D/AbnCvPN1X14ZI1ygBA1rw/sxw7Mpw6TWu1i3fGV9zCyeHVaeNobSKLLgq9zlrSmk3SjYpDVUlN/qRsUjO9yXzpgCuBT+F84z4FfBF429hDjNesyRpkVCd5aM0wikKptaaqNwA3jLN+B3BOzuebgIPicBizB9OaESal1JuIzAV+AKwCngJeM86LlXTZCO7ly3ZVPbckDTLKSq3ds9kk3ag8CvQ5ydeXTkT+F/jlOJvMl65WqDH/JqOMmNaMsDCtGWFSWr19BPidql4uIh8JPn94grL/AjwKzClVY4wyU2N9m03SjYpDVfFLF919saruDD6+AnhonGLmS1cjlFJrhpGLac0IC9OaESYl1tt5wGnB8reB2xhnki4iy4CXAJcB/1aqxhjlpdb6NpukG9NGuT2zXCof4hI+Kfu8iDwLZ77+FPBOAPOlq0yqXGtGtaF/cP/l9NIc3rRmpElrDUqiN9OakaHEWoOS6m1h+sWKqu4UkQUTlPsy8CGgpVQNMfKgurVWcdgk3ag8FPwS+Zyo6hsnWG++dLVICbVmGKMwrRlhYVozwmRqvU0a7HeKOEJTIiLnAntU9T4ROS2ffYwqpcb6NpukGxVHrQWGMMqHac0IC9OaERamNSNMCg32O1kcIRHZnXZTFJHFwJ5xij0XeJmInAPUA3NE5Duq+oY8T8GoEmotSKFN0sch18Q2zXimtuOVmynlSD01E3LPOeXXEfVKUklNmbOM1dFEWiiW3qpRayWsxLSWR7mZUnVaEw/xk+Pndyi8EtNaHuUKoRr0dpDWoPh6M63lVa4Qqk5rqRG3HClJRaXU243Am4HLg/8/P6h61UuASwCCN+kfKNUE3bQ2Mcrtpe3XXCU1FaTQJulGxaE1Zs5ilA/TmhEWpjUjLExrRpiUWG+XAz8UkbcDTwPnw+g4QqWq2Kg8Sqy1igtSaJN0owJR1LcbDCMMTGtGWJjWjLAwrRlhUjq9qeo+4EXjrB8VRyhn/W24yZUxKylp31ZxQQptkm5UHvYWwAgL05oRFqY1IyxMa0aYmN6MsKixIIWzfJLeWzS/kFL7x052/ErwRxmvfVHv5KIc56AyCn7V+dOZ1opJvn5f0znGuGVMa0U5zkyPXwl6O6iN3kEvbaZ/jPHKmNaKcpyZ1mFaqwaKozfT2jjti7y48GNMVK4q9WZaKxZh9WuQl9ZmVZDCUoT9MozCUMVP+BP+GUbRKKHWRGSuiNwqIk8G/9snKHeWiDwuIhuCYCVjt39ARFREOgpqkFFeptCa9W1G0TCtGWFi92xGWJRWa+kghTBJkEJVXaaqq4ALgd+XMouATdKNikRTOuGfYRSTEmotHSl0LfC74PMogjQeXwPOBo4AXisiR+RsXw68GBcwx6hyJtOa9W1GMTGtGWFiWjPCooRauxx4sYg8ibvvuhxckEIRuanQg8+EWW7uXpuEkrqqhG1QBT9pT1+rAdPapOQTKfREYIOqbgIQke8H+z0SbP8SLkDJQU90aw3TmhEa+gf3T8r3HsO0VhtUe78GpreqQv9Q1n4NKrdvq8QghTZJNyoPVVJmImWEQWm1lk+k0KXA1pzP24CTAETkZcB2VX1ApBQJR41QsX7NCAvTmhEmpjcjLGpMazZJNyoOBSx7jBEGeWitpJFCgfFm3yoijcExzszzOEaFY/2aERamNSNMTG9GWNSa1mySblQeCslkuRth1ARTa63UkUK3ActzPi8DdgBrgNVA+i36MuB+ETnxuOMOm7TBRoVS4n5NRM4HLgUOB05U1XsnKPcU0AukgORk+jaqFNOaESZ2z2aERY1pzSbpVUAl+CyNR6napUDVZfOYJZjWiko6UujlTBApFLgHWCsiq4HtuGihr1PVh4GMeXxws3u8qnYef/y6kjU4bCpRb1WqNYCHgFcCX8+j7Omq2lnS1lQY0/peQ/LZNK3NTmqpX3PHtnu2cjHt7zWEvs20Vjxskm5UHFpjT8qM8lFirV0O/FBE3o6Lzn4+uEihwDWqeo6qJkXkPcBvgAjwzWCCbswySt2vqeqjABa/wDCtGWFi92xGWNSa1mySblQeWls+J0YZKaHW8o0Uqqo3AZOm9whychrVTOX0awrcIiIKfD03xoIxSzCtGWFSOXozZjs1pjWbpBsVh1JbT8qM8mFaM8IiT63NOFChquabpu+5qrojyDZwq4g8pqp/zHNfowowrRlhYuOoERa1pjWbpBuVRwmflInID4C0U28b0KWqzxqn3FNYwJvZT409lTXKSH5am3Ggwryb4Sw5UNU9InIDcCJgE6fZhGnNCBMbR42wqDGt2STdqDhK6XOiqhekl0Xki0D3JMVrLuBNrVFr/k1G+agErYlIE+Cpam+wfCbwyfK2yig2pjUjTCpBb0ZtUGtaCyeEqWFME1Wd8K8YiIt48xrg+qIc0KhaSq01w0gzmdYK1ZuIvEJEtgHPAX4lIr8J1i8RkXTMg4XAnSLyAHA38CtVvbmgio2KxLRmhImNo0ZY1JLW7E26UXHk8aRsUl+6PHk+sFtVn5yoGVjAm1lPrT2VNcpHCBG3bwBuGGd9JlChqm4CjildK4xKwLRmhImNo0ZY1JrWbJJuVBx5BIaY1Jcuz4A3r2Xyt+gW8KYGqLUgJEb5MK0ZYWFaM8LE9GaERa1pzSbpRuVRYGCIqQLeiEgUeCVw3CTHsIA3tUCNBSExyohpzQgL05oRJqY3IyxqTGs2STcqjhDMWc4AHlPVbeNttIA3tUOtmU4Z5cO0ZoSFac0IE9ObERa1pjWbpBsViV/a+A8XMsbUXUSWANeo6jm4gDc3uNhyRIHvWcCb2UuJtWYYGUxrRliY1owwMb0ZYVFLWrNJulFxhBD05i3jrLOANzVIrT2VNcqHac0IC9OaESamNyMsak1rNkk3Kg6ltnxOjPJhWjPCwrRmhIVpzQgT05sRFrWmNZmNeeXSiMheYEu522GMy0pVnT/eBhG5GeiYZN9OVT2rNM2aGaa1imdcvZnWjBIwU61BhenNtFbxzBqtgemtwrF7NiMsZpXWCmFWT9INwzAMwzAMwzAMo5rwyt0AwzAMwzAMwzAMwzAcNkk3DMMwDMMwDMMwjArBJumGYRiGYRiGYRiGUSHYJN0wDMMwDMMwDMMwKgSbpBuGYRiGYRiGYRhGhWCTdMMwDMMwDMMwDMOoEGySbhiGYRiGYRiGYRgVgk3SDcMwDMMwDMMwDKNCsEm6YRiGYRiGYRiGYVQI/x8+fkAj8yql7AAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<Figure size 1080x504 with 24 Axes>"
+       "<Figure size 1368x504 with 24 Axes>"
       ]
      },
      "metadata": {
@@ -1085,46 +2861,117 @@
    "source": [
     "import time\n",
     "rel=0\n",
-    "\n",
+    "v=3\n",
     "if doanalysis ==1:\n",
-    "    conv=24*3600\n",
+    "    conv=1\n",
     "    fig = plt.figure()\n",
-    "    plt.rcParams['figure.figsize'] = [15,7]\n",
+    "    plt.rcParams['figure.figsize'] = [19,7]\n",
     "    fig.subplots_adjust(hspace=0.3, wspace=0.2)\n",
     "    vs=range(1,ncases+1)\n",
     "    ncol=7\n",
     "    nrow=2\n",
     "    count=1\n",
+    "    var_0=dsc.SABV.isel(ens=0)\n",
+    "    defm=np.multiply(np.mean(var_0,0),conv)\n",
     "    for i in vs:\n",
     "        index=((count+1) % 2)*ncol + ((count+1) // 2)\n",
-    "        print(i)\n",
+    "        print(index,count,(count+1) % 2,((count+1) // 2),(((count+1) // 2))-1)\n",
     "        ax = fig.add_subplot(nrow, ncol, index)\n",
-    "        count=count+1\n",
+    "\n",
     "        #ds0=dse1.isel(realization=i)\n",
-    "        #dsdef=dse1.isel(realization=0)\n",
-    "        mod=np.multiply(np.mean(ds0.QVEGT,0),conv)\n",
-    "        plt1=mod.plot(cmap='RdYlBu')\n",
-    "       \n",
-    "              \n",
+    "        var_i=dsc.SABV.isel(ens=i)\n",
+    "        mod=np.multiply(np.mean(var_i,0),conv)\n",
+    "        \n",
+    "        delt=mod-defm\n",
+    "        plt1=delt.plot(cmap='RdYlBu')\n",
+    "                    \n",
     "        ax.get_xaxis().set_visible(False)\n",
     "        ax.get_yaxis().set_visible(False)\n",
-    "        \n",
+    "        if((count+1) % 2==0):\n",
+    "            ex=' +'\n",
+    "        else:\n",
+    "            ex=' -'\n",
+    "        ax.set_title(str(parameter_list[(((count+1) // 2))-1]+ex))\n",
+    "        count=count+1\n",
     "        fig.canvas.draw()\n",
     "        time.sleep(1) \n",
-    "        \n",
-    "if(delta == 1):\n",
-    "    if(rel==1):\n",
-    "        fnmfig='figs/ensemble_GPP_delta_rel_'+caseroot +str(i)+'.png'\n",
-    "    else:\n",
-    "        fnmfig='figs/ensemble_GPP_delta_abs_'+caseroot +str(i)+'.png'       \n",
-    "else:\n",
-    "    if(rel==1):\n",
-    "        fnmfig='figs/ensemble_GPP_error_rel_'+caseroot +str(i)+'.png'\n",
-    "    else:\n",
-    "        fnmfig='figs/ensemble_GPP_error_abs_'+caseroot +str(i)+'.png'       \n",
+    "          "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 190,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 1 0 1 0\n",
+      "8 2 1 1 0\n",
+      "2 3 0 2 1\n",
+      "9 4 1 2 1\n",
+      "3 5 0 3 2\n",
+      "10 6 1 3 2\n",
+      "4 7 0 4 3\n",
+      "11 8 1 4 3\n",
+      "5 9 0 5 4\n",
+      "12 10 1 5 4\n",
+      "6 11 0 6 5\n",
+      "13 12 1 6 5\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+kAAAGeCAYAAADohUAvAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAEAAElEQVR4nOydd5wkR3m/n7dnZuPtXj5d0Ol0yiJJgBJBCUkgHSIjMohkE0z8gYk2lrGxhU0wGJtgWZbJYAOSLMtCQkggIQQKKCKE4ulyDpt3Zvr9/VHV0z17G2Z3Znpndt7n89m7DtVV1T3fru6qft96RVUxDMMwDMMwDMMwDGP2CWa7AoZhGIZhGIZhGIZhOKyTbhiGYRiGYRiGYRgNgnXSDcMwDMMwDMMwDKNBsE66YRiGYRiGYRiGYTQI1kk3DMMwDMMwDMMwjAbBOumGYRiGYRiGYRiG0SBM2UkXkaNF5Hci0ici70ujUvVGRB4XkbOnSHORiHy7RuW9S0S2iUi/iCyewfE1q8s0yz3E1zlTxzI+ISKXzPDYM0RkY63rZBiGYRiGYRiGMVtU8iX9I8CNqtqjql+eLKGIHCoiKiLZ2lSv+RGRHPAF4PmqOk9Vd812nSpFVZ/wdS7WsYy/U9W31yv/emADVzUpr6qBK5/HlHVuJEw3NSlvRrqp14CeiJwqIg/WOt+Z0Kr6agbqNdBezSB3jevRktprhLatnvi6HDbLdWhJbbUyjfRcnW0q6UyvAb5f74rMFBHJ1LMTWQMOAjqA+2e7Isb0EZE3A2eo6psTm6OBq6dXcPyhwGNATlUL9ahjs5EYuDpFVe+e7fqkiOmmChpRN6p6E3D0bNfDY/pK0ArnqKp/N9t18Jj2qmA6bZuIKHCkqj5c73qp6rx6l1EBpq0Es3WOInIG8G1VPbjeZTXYc3VWmfRLuoj8HDgT+IofUTtKRF7oR7X2i8gGEbkoccgv/f97ffpn+XzeKiIPiMgeEfmpiKzx20VEvigi20Vkn4jcIyJPmaJOl4nIV0XkahEZAM6cok6IyBtFZL2I7BKRT07rCsV5nCIit4jIXhG52ws22vcWf359IvKoiLzDbz8KiEaD9vrrOVkZTxaR60Rktx9R/cQ4aQ74IpQclfMju/8lIt/29bnX/24f99d5g4g8P3HsjSLy9yLyW/8bXCEii/y+MssIn/ZvRORXPu9rRWRJIq83Ja7zX053JDpR3oUi8oSI7Ez+XiLS6X//PSLye+DEMXmtFJEficgOEXlM/KiriCwSkY0i8iK/Pk9EHhaRN01Wt0lYQwMPukgd3RNqRKoDV/6euTGNsqbAdFMdM9KNNLhlVw31afpqQJpAfxeNfWeaAaa96pizH3PEDSpUg2nLmDYN9N5XFZN20lX1ecBNwHu82fMfgQHgTcAC4IXAu0Tkpf6Q0/z/C3z6X/t9nwBeDiz1+X3Pp3u+P+Yon9+rgUrMwV8HfAboAW6erE4i8iTgq8AbgZXAYmBaI0Eisgr4X+BvgUXAh4EfichSn2Q7cD7QC7wF+KKIPMNfryf7NAv89ZyojB7gZ8A1vp5HANdPp54JXgR8C1gI/A74Ke63XgV8Gvj6mPRvAt7qyy0Ak7k1vA53jsuANty1iK7zvwKvB1YA8315M+G5uFG0s4BPicixfvtfAYf7vxcAF0YHiEgA/A9wty/3LOADIvICVd3tz+/fRGQZ8EXgLlX95nQrJjZwlcyjrgNXIvJsP1Cz2q8f58s6Zib1nU1MN2V5pDHgqSLyZyLyEPBQYvuH/DXaIiJvSWyfLyLfFDfAt15E/kJEAhFp9/V8SiLtUhEZEpFlMmbQVEQ+KiKbfP0fFJGzZnKNpksr60tEThKR232e20TkCzM5R79PReTdIvKQ/w3/RkQOF5Ff+/x/KCJtU9TnDHGDwh8Vka3Af/hdbV5jfSJyv4ickDjmWHGD4Hv9vhf77aeIyFZJdARE5GUico9fTg5yd4gbnN/l87lNRA6q5BpWQytrb5xy6/1MjK7d3f7avVpEForIVeLarj1++eDEMWUfS8Zo5hoRec+YMu4WkZf7ZRWRI/zyOhH5va//JhH58Eyu0XRoZW1JA7VrItIN/B+w0pfZL+6j2Ek+j73inqlfifKRcdyfxbVxb5cmea42BKo66R9wI/D2Sfb/E/BFv3wooEA2sf//gLcl1gNgEDc69jzgj8ApQDBVXfzxlwHfnCJNsk6fAr6f2NcNjAJnT5HHRTjTDoCPAt8as/+nwIUTHHs58P6JrskEx7wW+F0FdTkD2Dhm/+PR+fi01yX2vQjoBzJ+vcfXZ0Hi9704kf5J/vpkxtbdp/2LRNp3A9ckrvP3Evu6ZnCdo/IOTuz/LfAav/wocG5i359G1wI4GXhiTN4fB/4jsf7PwL3AZmBxhXp7M3DZZPeE/02eitP204BtwEsnuSdeCjwMHItzOfkL4Ba/7wXAHbgBJ/FpVlRwT+wDnuPr0DFFnZ7kNXEa0I4zsytM87dahRtQW+fLOMevL/X7X4gbTBHgdNw9/4zp3BM+7WeAnwOdwD24AcMDdD9FHmfgzOWm/L3r+We6SVU3ClyHG1Tt9OdVwA1S5nz5g8BCn/6bwBW49vFQ3HPpbX7fpcBnEnn/GXG7dwZxG3Q0sAFYmajv4Wnps4X19WvgjX55Hs5keNrnmNDNlbgB9ycDI7jB8sNwA8+/Z4Ln/pjrXgA+68+jE3cPDHvdZYC/B2716XO+Tp/ADXw/D+gDjvb7HwHOSeT/X8DHxrm33oEbqO7yZTwT6K1ANxcBF5n2mqptOyKxvhh4hf/de7w+Lk/sfzx5HmPq/CbgV4l9TwL2Au1jywK2AKf65YVR3Supr2lrzrRrY/sez8T137K+Xg8AH5iknqXfkiZ5rs7237RDsInIySJygx+12we8E1gyySFrgC/5UZO9wG7czbBKVX8OfAX4F2CbiHxDRHorqMaGadRpZTK9qg5Q2df6sedwQXQO/jyei/tijIicJyK3ijNT34trpCe7JuOxGvcwrgXbEstDwE6N/faH/P9JX6Pk9VyPe2mYqP5bE8uDiXzGXudBpn+dp1WGr2vEGtwoX/I3+gTOjCziG8BTcB33CesmIv+ayONfgdcl8r1nbHpVvVFV71XVUFXvwVmKnD7J+b0D+HtVfUCdT9HfAcf7kc887kF7DCA+zZZJ8oq4QlV/5eswPEWdXglcpaq/VNUR4C+BsIIykrwBuFpVr/ZlXAfcjtM+qvq/qvqIOn4BXAucOs0ywL1QzMcN1mzGtRVzAtNNXXUD7lrtVtWozcsDn1bVvKpejXtxOlrcV8pXAx9X1T5VfRz4PM76CuC7uEHUiNf5bWMp4l7CniQiOVV9XFVr1aZPmxbSVx44QkSWqGq/qt46w3OM+Kyq7lfV+4H7gGtV9VFV3Yf76DClb6yv91+p6khCfzd73Rdxlm7H+e2n4J5xF6vqqH8vuopYc9+LlsVZ3K0jtkYcex0W4zpVRVW9Q1X3V1DXmtNC2kuSZttWQlV3qeqPVHVQVftwA9uTXeskP6Fc/68HfuyvwVjyuLatV1X3qOqd1dZ9JrSQthqxXSvDtzG3qmrBPze/TuXaa8rnatrMJE76d3EjMqtVdT7wNVynG9yoyVg2AO9Q1QWJv05VvQVAVb+sqs/Eje4cBfx5BXUYW85kddqC6wADICJduAfZdNiA+5KePIduVb1YRNqBHwGfAw5S1QXA1Ynyp1PG4RWkG8CNmAIlf5ilEyeviNWJ5UNwjcPOaeaxhYQbgYh0Mv3rXEkZY+sasQF4bMxv1KOq63x9MrgG5Js4d4gjJipEVd8d5YGzFvhuIs+njU1vA1d1G7hCVfO4keunAJ9X1fHamAMQkY8l6nUV8NwxdZ11TDf1041nw5j1XVo+0U40ALgE9wUzOei3nthd5+dAp782a4DjcS+3ZaibyOkDuIGl7SLyfRFZOV7F0tBnC+nrbbh3hz+IM/E+fybnmEgzdpB77Holk2ntUNXhMdvGDj53iDMFXQlsUNXki3tSf98FXu7fNV4O3KmqSa1GfAtn4fd9EdksIv8gbkKyAxBnEh1dg48BH0vo76oKzm9SWkh7Y88hrbathIh0icjXxZlT78eZQy+QCnylfaf+f4HX+E2vAb4zQfJX+DqvF5FfiDezHqc+B7RlyXURee70zvCA/FtFW43YrpUhzv3gKnEuOftxgwOVaropn6tpM5NOeg+wW1WHReQk3OhHxA7cCFEyZMPXgI+LyJOh5Pt3gV8+0f9AOVzncxg3alLLOv03cL5vONpw5o7TPe9vAy8SkReISEac79cZ4vx+2nCjPDuAgoich/O1ny5XActF5APi/DV6ROTkcdL9Efdwf6G/bn/hy6+GN4jIk8QNYHwa+G+d/oz5/427Rs/21/mvmf5AxVT8EKelhf7avzex77fAfnG+K53+d3qKiESTy0WT8L0VN6DyzUoeYhViA1f1GbhC3HwQf4Xz6/y8z3tKVPXixEDL+bivWAsS2xoB002ddOOpaEAHNyCZx73oRBwCbALwnacf4kb9X4f7KtI3boGq31XV5/q8FGfyPF66NPTZEvpS1YdU9bW4eVI+C/y3OB/KaZ9jDalUe+AshFaLm1clIqm/3+M67ecx8dcm1FmI/LWqPgl4Nk5X406OqqrnJ7R2Me4rfnQ9JusMVEpLaG+cc0irbUvyIZxJ8Mmq2ks8N1SUd9mHHWD5mOO/B7zWd7o7gRvGK0RVb1PVl+Dus8txbeJ46Q5oy8Zck5une4JjaAltNWC7Nl65XwX+gIs20It7z07qDibQXhM/V1NlJp30dwOfFpE+nB9y6UZVZ+L8GeBXfuTiFFX9Ce6Cft+PtNyHe9iA84/4N2AP7iG0C9eI1bJO9+N8Hb6Lu1n2ANOKl6uqG4CX4AS4A3dD/DnOj74PeJ8vcw9ObFdO9wR8PufgfMi34iY7OnOcdPtw53sJ7iE+MN3zGYdv4b5WbsX510w7FqW/zu/FhevbgvOp247zfakVf43TyWM4U7FvJcov4q7d8X7/Ttw1mi8izwT+H/Amn+6zuBv9YzWqlw1c1WHgSkQEp8t/x40qbwH+Zrr5NDCmm/oMeE4L3yb8EPiMHxxdg2svkvGPv4sziX89E3SSxMXzfZ5/IR/GfZ2YzfCgLaEvEXmDiCz1L317/ebidM9xFvkN7pp+RERy4iYbexHloW+/i3sun4bzOT4AETlTRJ7qB5/34waeZkt/LaG9MaTVtm2j/Nr14NqaveIi8/zVmPR3Aa/x2joBZ36d5Gpc5+fTwA+03KIDABFpE5HXi8h8ddZt+zFtVVqnudKubQMWi8j8xLYenBb6xU3o+65oh6ruwPVR3uDvh7dyoLVwMz5X00UbwDHe/mbvjykmBqwi33m4yTHWzvY51vua4R5663EDE1fhzKe+ndj/aVzDupd48o834iax248b9LnUbz8LN0FaP26g4TvAvCnqcxnwt2O2TVWnC4EncANjn6SCSdhITDjj108GfoEzrdqBM5s7xO/7M1yjvhc3mPL9qI5UPpni+/21aPPrK3050eQ1U9bZpzuDBphAxHSTjm58WqV8cqUzmHzCzYW4l+xoEPZTjJnMFDcxz+5Ij2PzxU0Y9Ft/7Xb767cyLX22sL6+jRsQ7seFanrpTM5xAt3cDLw5sf63wCUV/J5jtXbRmPMs0zLuK94vcBNS/R542ZjjD8G9mP/vRPnivkg9iOtsbMNFaankXrmI2k8c1yraG/u7ptG2vRM3YL0XeBXuuXijvz5/xPknJ7V1GG4gqN/X58vJOvs0/+6POXHMdsVFGmrDRR7a43+f24DnVqgNNW01f7vm013qz2Gv191puC/p/bjIXZ/Gfb2O0p+H+2i2FzfPyy8Y09+gwZ+rs/0n/mSMFkVcHMFvq+olNcjrRbgZIwV3Q56MmwHURGYYhmEYhmEYhlEBMzF3rzvi4oT2j/P3+hqX838TlPOJqY+eUXmnTlBefz3KmwVegvOv2wwciQudpmlfZ8MwDMMwDMMwjGbFvqQbRhMgIvdTPrFVxDtUdaLZWGdSzv8xfliYv1PVv6tVOYnyTsWF/zgAVZ32bKNGOaYbo57MVX1VUJ9PEE9GmuQmVT1vnO1GjZmr2rO2bfaZq9qqoD5zvl0TkUtxk8ptV9WnjLNfgC/hIhkM4twCZiXcIFgn3TAMwzAMwzAMw5jDiMhpOB/6b07QSV+HmwR7Hc5l90uqOl6krVRoSHN3wzAMwzAMwzAMw6gFqvpL3AR0E/ESXAdeVfVWYIGIrEindgeSna2C02DJkiV66KGHznY1jHG44447dqrq0vH2zV/wZC0UJnbTHxx44qeqem7dKjcDTGuNzUR6M60ZtWamWoPG05tprbGZS1oD01sjY+9sRlrMstZW4WbHj9jot22pIs8ZM6c76Yceeii33377bFfDGAcRWT/RvkKhn2OP//iEx97xq3ctqUulqsC01thMpDfTmlFrZqo1aDy9mdYam3pqrQLfzTOAK3AhlgB+rKqfnrrWE2N6a1zsnc1Iiyq1doyIJH/Yb6jqN6ZT/DjbZs0vfE530o0mRQTJZWa7FkYrYFoz0sK0ZqRFbbR2GS7e8zcnSXOTqp5fbUFGk2Ntm5EWU2ttp6qeUEUJG4HVifWDcRGrZgXrpBuNh4AE4w1mGUaNMa0ZaWFaM9KiBlpT1V+KyKG1qZAxp7G2zUiL+mvtSuA9IvJ93MRx+1R1VkzdwTrpRiMi2KiskQ5Vak1EVuO+NC0HQpxp1ZdqVDtjLmHtmpEWlWltSZVmoQDPEpG7cV+aPqyq90/zeGMuYG2bkRbVv7N9DzgD1/5tBP4KyAGo6teAq3Ezuz+MC8H2liprXBXWSTcaDkGQjI3KGvWnBlorAB9S1TtFpAe4Q0SuU9Xf16aGxlzB2jUjLSrUWrVmoXcCa1S134ctuhw4sor8jCbF2jYjLarVmqq+dor9CvzZjAuoMdZJNxoPgSBn0QGNFKhSa94Maotf7hORB3AzgVon3SinBu3abEzmZTQhKTxDVXV/YvlqEflXEVmiqjvrWrDReNg7m5EWLaa11uykh9eDhm45c05t8tQb3P9yZm3ymw2icwBUym8C8ddrou3j7VN16wGFsn3C6ZPXYy75N4XXQzHvlnM1ikAyx7RWttnrZKzeRMNxl0tpw4JLn2kryy9NrXn/zacDv6lJhtMleU1rqQ29YW5oTUNI6Kakp7BQ2q4SIBpSpB2AQPLjZikjA2h7d5lOU9LaZTTCZF7RNQ0LtXuGRvk2s9bAnYNvjwjcK1akNdWAoDjklrPtJf2EZA94TkbI0D7o6ImzT09rkxchshzYpqoqIicBAbCr5gVFWhsdgvZ1tc232bWWfJcN4tf5sc/RvHaTDZzupDh6gC5L7dijdyJrj3fLifwaQW9pofzCXY9aP0OhufUWXh8vj3mOJvsBIVlE3PrYd7UkMjIAOfecbVWtVUJrdtKNxqYGM4WKyALgEuApuPAJb1XVX1dfOWNOMbXWKvLbFJF5wI+ADyS/MBlGiRq0azaZl1ERtXmGTuW7+UrgXSJSAIaA13hTUaPVsNndjbRoMa1ZJ91oOKQ25ixfAq5R1VeKSBvQVX3NjLlGBVqb0m9TRHK4Dvp3VPXHtayfMXeoUbtWCTaZV4tTC61V4Lv5FZxVh9HipNi2GS1Oq2mtdc7UaB7ETQwx0d/Uh0svcBrw7wCqOqqqe+tbaaMpqV5rgtPZA6r6hbrX12heptCa19sSEbk98fen0ywlmszrOOCfcZN5Ga1GZVozjNpQ/XP0XBF5UEQeFpGPTZLuRBEpisgra1p/o3moUmvNRst8SS+Et5IJRtxKkC3zoagW3f0dRucfDUBb5hcMFRYB0DX4B+i9oGbl1AzvH6MSIHnnp1TM9qLaCUAmGHG+cxTiQybwK5loO1B2/JR+JmOQbFXmLIcBO4D/EJHjgDuA96vqQDWZVkyZb3AA2fbaZb3pq8jKYw4sp5iH7PNrVk5N0Rsm9gceM6fBRHMcTLRcOs77NM3El6xKrT0HeCNwr4jc5bd9QlWvribTipnAt78mWe/9HgAyf3m5DzLU1g+5loyZV6OsnR87n0Zx1C0E2QP0FTC+L3opTeSP7rVW6atBBVqrasbtuk7mVbzO/Z/wHyxbroYRf7vk2kG972NYjP1tazWfRy1J+p7nRxjMrgGgKwjj6+LbvUiHQogmngeldpAQneCbiXbOj3UsZ9ZSa43N2LatrbNmWV+z6GjO3fEVCBL+7hn/mzXic1RvIK/dACXfcnDtTjQPi4SJ963CCGTbS/rKSnzM2HlbIKHDw56RyDuddzYRyQD/ApwDbARuE5Erx0ZI8ek+C/x0RgVNRkJrte7m6f1/hxx7sl/zbUb0vAnOqnFpNcBfi5AswcAOt6174QHPzwl9zWXiearKjk/M6ZJy/6CpaJlOutFECFONiE3lJ5wFngG8V1V/IyJfAj4G/GXtK2s0NVNrbVJU9WZq/1w35iJVaq2iItKazMtobFLQmmGUqE5vJwEPq+qjACLyfeAlHBgh5b04t7ITZ1qQMQdosbbNOulGwyFTTwwx1demjcBGVY1m2f5vXCfdMMqoQGuGURNqoTWbzMuoBGvXjDSpUm+rgA2J9Y3AyckEIrIKeBnwPKyT3tK0WtvWMp30bHBK+YYKBmKGCnfTmdldWtfdG92h8xZDcRTtWujWu+bTPrjeF5SjS/rccq69ZManezYjXfMhiMWlBW9+XywgbX5es55XTPPMpkH+GvpYQ3fW/exBcRjNORMy0SJBEJt4ipSb35XMUcaYoE1mzhInCqf9rbGaEAuqulVENojI0ar6IHAWacatnkmYjbGmfZF54+A+hjvXApAPO8gvOY8g7/YFUkAoApALhhkefRSAvvxBLGl/GIDOYCfkRwjbXAifUHOlsFKBnDr9elbKyNWl8BpIMKGpsWbaYpOnZJg1TkfC6+PjNCwL03EA0fXSEKbZfjd1OI+ZaC0KpRJd21FvChkEkB/2aUIkMi8d7jswD73c/V8sxmaomcTvoyGEYTompPlr4nPJ5MYNrXYAGsZmopyOJF2AJgkbE1EylU9Za7M6mddMXBwiM/akqXLfTsjmID8Sb4uu98hAvBwW0KIz4ZXMD1ANkchUN5Nx+gJIjkG0ddY2TNdY+n8MWV+HXHts1t6epVP8u0KYNGN351FKJ2ci+Wvc8jhm7+ORDDE5Hb01dbsG02/bxtzDgHMDS7q8eD2du+1L8X5wbZ/46zV8Vfwbi5Q/vzR0bhgR9WzXhq70ZbRBJkdOnLeeEsTtD1AI3b2Vk4FSWx12LCSQU8vbNe/aGL3zjUdIlqB/u1vpmTDZuEyht8msH8c7cOzA4j8BH1XVokgddD3D56gmXWcncKGVJz2rfEOQjdMWryt3jRmDVuHGNy0K18Z1yORcmUHozNwrIaqb11vkejHZO5v074JOL7JWemebJi3TSTeaCJFazN74XuA7fmb3R4G3VF0vY+5RG60ZxtSY1oy0MK0ZaTK13iazftwIrE6sH4yLTJHkBOD7voO+BFgnIgXVaLTYaBlarG2zTrrReNTA50RV78I17IYxMS3m32TMIqY1Iy1Ma0aaVKe324AjRWQtsAl4DfC6ZAJVXVsqSuQy4CrroLcoLda2WSfdaDhEINNCszcas4dpzUgL05qRFqY1I02q0ZuqFkTkPbhZ2zPApap6v4i80+//Wu1qajQ7rda2tVQnPfzlhwGQI4+K/TCzbWX+crL0zSWfzc6BnbFPXFsnDProNp09UMjDricA0KSP0t4d0DXPLbd1xn6dgD54D/R6H4ye3tgnr7MH7XOhDiTr/JDC39zo1g9aBgtcSDe2b4UlS932Ve+Ky9QbYGAPuv4PbrWvD0a9r1U2Q3CK85vSPZvpWdrOSBg5G3WSVefbFEieUHOl5WQ4j1DaKOqtLrviSCkcTqg3IUwcyq7kZyfBNF3ShWAO+Jwov2C4sICCOv+2tmCAwIenyI1uh47zARgu/o5c0E5/fpk/LqDof4u29n5GC05PQpGOTB9hYq6AyB9NNCzNn9Ae9DFQWAJAPtNJkMkTFnKlPIra7utzLzkfzmXH8FG0BQN0ZPe6OmhAZ2YfUD6fw1Dh7pJP+0jYSyB5+kZXANCV3V0Kv9GVWxSHPPT1iy9MHKIoqTNXP59EfuGWS75O1090md3upO/WtJgjWtv0VejsdStR6KrILzbXDvNf7fbt+0FprgAdHUIkKPeJK7t+TjNkgpIvZ+SPqdHvFobg/SOlrRP17aok7n3Hfzk/5GS54MrOJUIU+nsCXAg4ifx2E37HWhxFJECjug71IUsPLZ3DARqYyFfQbx8q3k2nf+YLp0N4XSmk31hf4VLeMwo9Nke09ptPwiFrEhv8NdmyBd22jWCde6fWJ/45/m2HB6DdPwuja1rwz6jRYehd7Ha1daLRHAjFRAjQnduhrQ3tcmGo6FkE2/xcUx3tsQ9xJgd9/wh+3hUyWRjyz/qubuheUMpTFr2+tBz+/API6lV+RV1acL7g3vddt21H2tuRo4/3+7LxOQASzb8gUuYzjGpCgzfE89LImW4+BUAS4bLGkgwxWTlzQ2vR9QGcHpLXKPDLuXOdH3kmeqYkfPjbOqGYnK8k+o2i9slfIyX+LSXR3gWBi48QvatlsuXtSXJ+gYT/+3BwEB24qIdh0FE+/8vwVf6YNqeFKL9CPq5fYZTw1z93VThtXVmZMiacaU73RRcEOnr8UoFQbyq9KQinQ+b60vETtWtCCPMWMX2q05sPWXr1mG3jds5V9c0zLmgywsQ7hgTxNc+PlM+tEoWihPL7vJL5mSKSGoq0mpz7wG8rez8KfbmqpTYk6fNdmoMl6bseaS35jE3Or+DPT3e5tlRWHFXaXla2PyYZOlcS9Vb5hVvEa01uKKWbcL6NSv3dD2COtG0V0lKddKM5EIFMC/mcGLOHac1IC9OakRamNSNNTG9GWrSa1qyTbjQcIpDNts5NaMwepjUjLUxrRlqY1ow0Mb0ZadFqWmuZTnr4yw8TnHgaAPrwPbB0ud9RcKZ4APv3oXv/Ed3hzJSkvQOWOrNhHRmGefPd8vCAM5ePTEjyw7E5VP9AbO7evwf1i7R1ovlRgsOe5vLY/li5CcoeZ6qsEkBYRI4+xm3fvROZ78yg6V5YMhml70doZGrTtxvd8ATs92aCXV3gfTYk14Y+dIfbPq8H3beVtsKG+Ny9Of69xRfztIW3+jpky8x9gqFdBN6MKsx2l0yoguIQYcabW0u5SalwOvq7i9zKqkPQwgNu+8p3MjVCEDTvTVjUW/xSjvbMfjq9S4EzC3LnNZJbTk5vAiArOULN0pHZC4CSKZnIh5qj02/PBUPODF6zvpxsycQ9G4yWzNBVA7Le1Dyn+ygG3aVQbSIhI8VeX+5IKczeovbHGCn2kMGbWQVxCL5CeCv9BafBQDpp8791VkYQQnratpTOPSfOtLSg7WhY/hsOF52GOjP7Sm4SGRkpM6EKfZMkhITSVtLaRKE8SqFJolBPQQCBNwurKGRUc2tN7/87t3DQwbBnq1sezUNXZ2ym29YBe78UHxSZn+Xa0Uw2Xg8ysVn52PBlidCRqELBazppepk0E23vhmK+ZP6OhuBdLgiCkhsRGiKZTHx834/QIW++GYboyPa43CjkVmcPmm0rmapK13wY7nf7sm1x3QByHbFZbJApPycffqkz2AkJFxLyI9A+waPRmxLq7u8guQ7w7kl0vnj89OUHN7fWHvwHt7D2cBjyz5pCATq9afi8bqTrUPSBi+N9EV2dsG+vW85moL0DRny4v9E8DLvJnBXi36tQiM3Wh0fc7z/sjxkejPPP9UKfd0UbHHTm6pE55KKF8XIQxHkD+sjn3f87djq3sv6BuL5ROb09Jd3JypUuffS+sGN9HEKoWHA6BPdcb++O8xJxoeUA2rsTof+I3z26MhCFl4OykEv64D+gPd6VpWNzmZn+xDS31gDXpo81Cw4S5upRG1K4svy+Dgux+0N+ZMw9H4WyyzoNtXeV8tOBXQCMfv2/aP/AW9324SH33uXftcK2HoLRREjKpNsPlOrbUdjg2h7cexJ6TXk6cO1UwvULDeP6SUBwxov8MUXvMlGMj0uGiIvM9NvKQ6sFOsregptvbUEbcei4zDi6iEyko1BcAMH1EJx1YNpxaXK9hWPc6ZK6y7XH68mwsJWiYdw/SL7zA/rHO5CjnunzLgKx66xm2w90mwEQid37iqPlz18NoeC1FmQO0EQZifcAWXHUxHVPpJcx66VFvz0k656kfn3se1vpeDmz3IWxcE3JjXZqmlxr06RlOulG8yAC2RYyZzFmD9OakRamNSMtTGtGmpjejLRoNa1ZJ91oPASkhSaGMGYR05qRFqY1Iy1Ma0aamN6MtGgxrVkn3Wg4RKSlfE6M2cO0ZqSFac1IC9OakSamNyMtWk1rc76THv7sfQBITw96320ADP/v7+h423lxov6Ef10YOv83QIMA2eZ9IsMQ3bW7tCxrD4/9zPbthW7ngyZHPq08zIf3j9Qd65HFi9HH7/V5KPQucMtDfbE/3Ogoums3staHuFm6HB3Y67Kbt4id4vxXlnStgh2XuTR797jwL2sPLeXBoPMF1b4+ZEFvKZ1ueALxfvYUirDY+eY/lR9Bn/OXEQkozFtNdtT55hNkS/6bQQZKcbKyzwfvVy1hAQ2yLvyCR55+kavD/X/Hwwd/EIAjmRoBgkxzjpS5sHSOgAIF7SxdL5EQVde4ZIPRkh9/QP4An/6k51LSDygbxH5BOtZHKIpSJZBTr+kgS4aROORgfhjxPqSa8MPNBUO0Z/aX+atn8ZoMzmJ+mwuxUQg7S/7kQdBfOq+IYuhqngkGSucKIE/cSc8hbj4GBvZAh5usIcx0EoSxz36SgNinVTjdhRoce96RL137On8NboBCFC6HKWlmreljX4R5/rd8+IHSPS8r/Hwbvh1j9143pwa4tivn/RmzWXd81A4ltTQ0ELdJ87ohOmZk2M25Merzy8SPEM3HIfdU1dmlRSGOglzsE1kYcSGLwPlglsIb5aDnFUj4A5dH/+7Yhy/Ixv7E2Xbnfz/fhaPUretLc3DQuxi9yWk1OHtd3EaD9x/2dUiG2NHE7y+4MHDeR7FMGYnQNrLo9eiubyF0USlNrbV7/7akNUaG4nu1Z6H73SLyI7G/LMS/vwQw7J8nBSDp19uWgzZ/TKEQ67ark8K1vwUg+9ynwmgeHRp02YUhOuLSSVui/EUL3TN8r5vXQDdsRJY6nbB3Dwz6uQuGR5Cn/oVbHr0Y3bI1vm+CwNUJoKPbhT4FWNTh3hX6fN0XLiL/fTcXRu4165xewfmnL/Lh3Ir5cr/QYj5uuzJAzyv89uuQkYGE3mNfYDn6I/HcExVGLWpmrZXCmuWH0cII4ufDIUjMn5EMF5mY36JEctt4x0S+5PnhUt7ifcjb3//m8hCLhdHSfAFBcajkn06mLTGfh/eRj36/Qr68flFoyZGry+tTdq9k4/poGLdduXbIdZTm/yHT6eoBzk85KjM5j4g/797cJp/5Ye59DSC8HvHvc2RyZe0a2efHfunDfVTavDWt3iJfdA0n9O0HJvdDLz1HxoT6TPqKJ3zRB8NldIlrU+ToE+P0+aGydFIcjf3Qk23smPBn8bkUXF9i3st9ftdA6M9pjC98WX39PFhA2bwtGmTHhIBLzAmR1FrSNz16F/Ttl+gN0Ofb/Z4l5VoLzoqv/zT8/JtWazNkznfSjSZEhGy2gh6WYVSLac1IC9OakRamNSNNTG9GWrSY1lrHZsBoGgTnczLRn2HUCtOakRZTac30ZtSKWmhNRC4Vke0ict8E+0VEviwiD4vIPSLyjFqfh9Ec2HPUSItW05p9STcajxabvdGYRUxrRlqY1oy0qI3WLgO+Anxzgv3n4TzYjgROBr7q/zdaDWvbjLRoMa3N+U568fEdAARde5FlCwDIHtTtYmSC8+Mc9X4bHd4nO/LZbmtz/t0AXZ1Iws+bnYn4vYUCxd+6wWYdLpA5fFlpO13OqUe6u2HV6tjPaN4iGHSxXWXN+8G7oOuWb0BfP/tXvwSA3k3/A2ujAerTWZI4N1n6ZlfM/7yO4NBlFG75g6v2B38Ux6rdtBmNfEsXLXB+fetdnHRZuADm+X0i6KCPT5xrJ7PpEXSe9wVLxO+URStRH3NZ1ryfQE71x4/x30zW88mfKPmij375leSedewEKUtVIWjSETElU4pJHpJ1fuiRc7TG6YRimc+2alDy50lud4clfH4IS3HFywgLJb8iKdtfLPdnmvfy2N89EfNTJUDCAu0Zr8nE3ALl67+Nt0l4gK94FKs92l9izfGxy3z3wpI/lEhYdl2CKKZ86HzqVH4Rl+/9maT0zzjImeBPNx/+lkAKEySM6ti8WmN/X6ntklwbmvXXPgjcvigm76IFiPfRpasrji/t27NSrOb9fW6eCnBtoc9bd+yM/YQ72pH9/bBiRVyPYhR/NxFnPT+MrPjTUhLd8o04fbYN8b6Y2rsMxmiN+a92/w9dEvuh79iKPPkT7phd34K2Dje3AUChgEZzh2zYhBztWhvdtx2yudjfbbiv5Asv3QtL8zRocRTxPqda/B6y4LUVxQeWxW+Mz++hf4z9qidK38xaG83Hz8nu+bDNxTVnx04XAx3cb1UoQOB1lc3EemrLlcchz2bLY0aHXjdd3e63BchkyJ59Qlw+IPN9LPJCAen05e7ei5z8mTirG/9fSeOjv1lP23G+TTv/dQe0awBy7MfIX/8qstF90dFBcNrnANBNX4Wl/nleLMKCRfEcCgN95F7q8wvD+Hx27EQHBkrnLUsPQRNzgpRiq+/5IrL2g/5cz5l0Do1I+wDh1e9EFi+eODG10Zqq/lJEDp0kyUuAb6qqAreKyAIRWaGqW6oqOLqOuQ7nJz42VjqgnfOdDz/EscajdIW8u+/B3fvJWNMRHT2uPSjGcanJ+B8gmVfkBx+1Q8UCdL00PmboyrjO2baSNrSjJ9Za4vFL+zrnlx7VDeL40MXrSrHVyQ/7CYD8+Y0OEuDfWTNt5fVJ1jXypw6LEOYJiJ7HiTjUwVmT29BGvutZYPiq8rpOQFO3beDOL7p2GrrrF1RgUj3WD30cirSTkZFS+q7MToje8ZLHZ9sOvM6ZxHOoeF1crPfzlrZOtMtNVCGcDvMSx+bOjed3KObj98DIFzwx74Jmfdz1xLwNEhZKc1G5uQsS87hIcMD8B/Hx18fPTzkTeie5OFG6oPz8JqPptTZN5nwn3Wg+Wm32RmP2MK0ZaWFaM9KiQq0tEZHbE+vfUNVvTJj6QFYBGxLrG/226jrpRtNhbZuRFq2mNeukG42HQCbXOhNDGLOIac1IixpoTUQuBc4HtqvqU8bZL8CXgHXAIPBmVb2zqkKN5qMyre1U1ROqK+UAdJxtxlzHnqNGWrSY1uZ2J31kG9nnX+iWE+HQssc9Iw7RMW9+HJ6qs8eliUyg2jtLx9DeDQt8VmHRHT/gTUgHh9Bhl1+wqCM2mz/kSPTx9S5NILBre2kfm9fDqrUH1llD5JgnMb/tCLcemcNNQtg/SuagZbR98J9K2+TYj/n/oe9dz3On95xVBCsXI8e7sA+S60D3ezPRXIczAQNkwXK0swe2+LovWORC0YALVbLyaLfc/+M43EOF5M56RrmZ4zgIUhNzFhHJALcDm1T1/KoznJR+inpLydQ9Imn+HWqOTOhM9MKgIzaDh7LjQs2RCbzZnAZj0sXXriz8WpBFvcmuFEfjZW+yFLa537Zs/DEsxmZOnA7BxFbkyfKjcyqZ85WZof/iwGO03ERfJaCozrQs0DyhuOUMI3EoEBF3L5TO8YZSOZUylam7q3NttJYqhV3O5HvR4vi+zA8j7X65mHdml6U2bhEsdOGlJNsem94W80hnL1uCMwBYsfzmUhga7dsBbS7UlPQPwEIf+6l/AJYvj83aB/vLTZqjUG39fZCwiCeTjV1mvJsOTKE3DUG8PhPmvrL4jbAYwpv/3NdhKHZRmtcN3d6ceGgA3bQxDjm3oBei8IMjA3H4uEwuDh83uA9NmiFPh3TatctI0094YBP6m0+iIyNINKPuvl0QmZ1rCDtd6DHdtw855hjY40ORBTlKIe92702E0MtAR0ds/j44FId3A9jqQ5719qB7nEuDbtiCzJ8Xm9wHEodMy5a/xujmncghBwHQ8ckrKjvPfJH9P3QuawsuubG0WVa9K8536yXu3orCGSXDe0F8fsuWxcsbNzp3s2W+rpmsC5ME0NaB3vaXrpwT/6ayegJ0daH79k2aJKV2bSOwOrF+MLC5qhx1XxweLTI7j+7TyKQc4JHbYc1T3XIm654XpTBS2bLQkOCPSbjtldwOI7P4IBuXK0G83NbpXcl8VoV8eXzUqD7FgjMTj6LvTnaOkTYKo9D+4nh75px4uXh1HBIs9NcgMk8O4ndZ8iPQvcAtD/XFpv2ROXJ0HsUiDP2XW+69YLLalTNeqK9xaMrnKPvLzc2TyyIlU28d2IP0LGFcwmJ5ux/prlgoLWdkoNw0XMP4+VkslDSo2XYkCh+bCIUW109LdZMFr42rOtkpSkJrkbsDlLtz6Q3l75Kl7WG5q2S0DcrdAZLuIaXyfBi/yHWihjSn1mbO3O6kG82JUCtzlvcDDzC5V4zRytROa4YxOTXQ2qz5CRvNRTrt2pXAe0Tk+7iBoH2msxbFnqNGWrSY1qyTbjQcAgRS3UiZiBwMvBD4DPD/alAtYw5SC60ZRiVUqDXzEzaqpkbP0O8BZ+A0uRH4K/w0aKr6NeBqnFvFwzjXirdUVaDRtNhz1EiLVtOaddKNhkNEyE0+UlbJi+w/AR8BempcPWMOUYHWDKMmVKg18xM2qqYW7ZqqvnaK/Qr8WVWFGHMCe44aadFqWpvbnfQggKTvVuT3pmHsV1bMIwtXlpJofrgUHoggG/ssaehCXwCMDKCFUdiy0a13dZF97tNcsg0bSz5Hetc9FM//EwCyt11B+PDjiJ/wQFYsh02PueMXJeqcH2HvX3yPhZe+teLTbHvff1eULv/wHjI7Bks/enjmq8hE/kwjA+jD97h6jw4hXfPRxS70jCxcifbtcvvywzDqQ4EM7EWSIR8qQJ78iZIf3mRM4XMy6YusiEQTK90hImdMr4a1YzScR0ewt7QeSL7kK54vdpIN4tAwRW0v8wsaG4YtQsICBWL/zSg8mxCWwnwUpCfOS3JkgqHycGhRmZl57Bg6CoDlnZWdUzY4paJ0oiGhV1pIDg0D9o4698Ul7X8kK94vOiyUfO1UAiQ5Qpr0ydJwaof5MWTk2RT1linTNaV/k6qbMyMKn9beGYdLybZDW2fsow5xeJmRASTyY/fXd4X+0q0Xx2hk6cHu/8VxWBY696LrH0eO9GEUiwVo8/sS4Sx1x07k6EReEsQ+lhWSDOE2HsU/uPY3c8hidJfzg5Z53aX2fN+SJzH/oHvQh3y79shjpWeAZLLOhx5cWMq+yE+4DemZZqMGyJF/7sKwTUHz+QkLBIEL1xn50oYKI8Nued58N0cBIKtWuzSRj/jwSBzCtLcHht0x4f0PExx3TKmE8PENyFL3EJTRUUaudb9X5qAusse5uVnyT+xn4N5HaO91z+3swT1xZKtFC8uaBuntZOiHvwOg+7mVnWXbB38UeS5PTOSfG83pEGRhs7+0K5bH/s4QX6sli9xyKTzYaHwfDA1VVrkxBGd8gfBn75s6XTO2axD7Xkc+/5HPbyb2fdXDTkIKvu0LMs5HtvS8SLRXYWI5cXzJbz3vdRwWeKzg/GfXytWxr3lYKA89NZZwjC9uJUS+wblJ0iTfUf11+K/H3SvPBatuhvaueF+/nxOiMIp0+bkiRsu1pYVRpK2r8jpGROHmBi+fMmnT6m08JICMf7ca648e3b/RbxRpIAjK24BIM8V4XgXt34W0d7M/69q/3uHfxUV29JT7dmdz44dlLOQnDddYRjKcXiUk59kYHYrvg8g/PTr3XHv5cUn950fiftN0iOZkqCAU25zS2hTM7U660ZSIQDZT1UjZc4AXi8g6oAPoFZFvq+obalJBY85QA60ZRkWkpDXzEzasXTNSxfRmpEWrac066UZDUs1Imap+HPg4gP+S/mHroBsT0UqjssbsUq3WzE/YqBRr14w0Mb0ZaVGD5+i5uFClGeASVb14zP4zgCsAb+7Mj1X101UVOkPmdic9LKJbfDiXed0Ub3EhVrIvOiM2E523CN3nw5BpiKw4kuHAhW/JBUMMFZ35UIYCWR8WS3KLyOz8PXKst7jOtccmu0/Kkg+daamSQUM34pN72skEa3eit/zK7du1C0acWWWZqd6a97Pw0vfX9DL0fPXnAIz8w8sgI+R/8zgA7Sdsis1Usrk4rE5HtwvbNODD3/zxztg0tLsHhty1G/7WDXRe9N5p18eFm/nbifeLkMs0b4Mf4EyeOtgJRUWzsWlQZMbeHvSxL++sUudn1yPSVjoOKIUsGyosKpmxt2UG2DlyDEva/1hKI94EM5S2Ut6ZYITif/6by+iN74H8COJDv5Ewa8/Isys2c6+UUlg2biiFjiuEbbRlBpjftimud96b440Mlkz3JD8chz8Ed19FobE6e8bEj6uMjDx78vo2o9Y0dCGE9u+L78udO2D1YW55dAiZtyg2vQuLFDucyV6mTctNN8vCx1Ay/5SFK9kdOBee7uxO2vNRO7oYOejwkumvSlAyq9fs9jh8VqE8/F0y7FqtyL39e66oS19H5rgjXR127IQeFy6ut63Pmfkfcrirw5KlTkcA2zY6c2xANYS2tlK9dWRkup4VLv8jfUg4PjL+/hpobbb8hHXLVujyjcXO3bDcu0L1D8CSpW778D4YHnG/ARCcdBo6uB+AcPERBLsfcdtXHeo+h2x2IT6DpxyDHvMcn/cjtL/Kl9PRBcPOtSp39FKGbtzAY7/eAcCxLzmUzG7XpknfECS8cILzv053HQJuysp3og9c7Nw6AAJB896c//Y7Yclit1woINGz9JC1LqzfE+vjfHxIQN22rWQWP11VBGd/2S/98/h1bcZ2DZwbT2SCnm1zy5HJbWG0tByEw/ExIwPQ1uU0NZYgoOzB4Y//4q1H8sGTHnShZwFGB5mX2+OXi4kQbF2u3JLJ/Bg74/Z1MzzRKeg4H4audMs+fPAFq272ZSbM1otFFx4YnKl7FJqtrbPMXVMG9x9Y9+kQmb1PQFPrDZx2vNsA87z/6XguDqNDpeuNhmwYfjar2907PUEGgjDO1x//2OjzWNLh+no9HU5LvcU/+mOy6LB3tdq3nXD1MwHIFPsPdKGYrul6pciZoDfE68nzjvRUGHX3Unu5q1yUXn3/J9QcmezUoW8nJRmKcLzqVqk1H5r5X4BzcO5ht4nIlar6+zFJb6p/6OapmduddKMpkRqGWFDVG4Eba5KZMeeopdYMYzJMa0ZamNaMNDG9GWlRA62dBDysqo+6/OT7uNClYzvpDYF10o2Go9VCLBizh2nNSAvTmpEWpjUjTUxvRlrUQGvjhSk9eZx0zxKRu3ETr35YVe+vptCZYp10o/EQsVFZIx2q1JqIXApE0QSeUrN6GXMPa9eMtDCtGWliejPSYmqtTRWiuZIwpXcCa1S1309AfTlw5EyqWy1zu5OuUPij8zfPruwmc9xat/m++6Df++gumI9u9SEsQiXoupP2l78ZgGLYTqjOp6cj00dWne+I7tqAdC1gMLsGgC7ZXgo3lQ87yYjzychKHyOh84EMf3oFo/fvJLvC+XRk3/rv9TzzcRn4/U4WfvAcZK0Ln1SYt5rsoA8hU8gjy9z1Ce+8CXn6c+IDFy9jz8f+E4BFl91U2tx50YemXYfRr7yK3LOOnTSNAJmmm4REyTDidOB9esKgg0BH43Bo+7cj3c5fltFBuju876UEzh898oNTJcy4+QqKmi35pEthxPmjJ8J0hOJ87AYKS+gJXEiqXYVjWPz6N7k0A5ug5xV1PO/xUQkQdf7lbZkBpDjKzpGnArC8697SvA/ZrhEy0VwPhVF0yPuFZXJIzyvc3PwzJB/+lmwweZijGmjtMuArwDeryWRahCEMD6LrnyiFu5K1a2BX5Dfegz7wO1i0wK3v7yNY5f3elq6NdVbIQ3E0ngdApBQqBmBR7hFfXjEO4aYh/bqS7qF7SsfoXl/u7l3IM//aba71OU/C6B/30Hm287kPFq5EoxCRGroQm/O8r3D3wjiE04oM7HBzJPDINoJ1X6uqDoVvv5HMiU+dNE1TtmuBuHkPggD2Ov9yensIf+/9yY9aBY+tL20v3LuJ7Jpet97Rg3hfxcz+DfFb0PpH0KFBZLUP8Tc6SjDs/YE7eyEKeZQfiX/L0d8zf00vC45YAEA4mCf7hm/V55ynojcRom+fuyZy6unog+5DixxxOPqo80GV0SHnp7/BTbBf3NhH2wd/5PbNsPjw5x+I5weYgKbUWkTkJ5wfcX7UyXlJhvvdciYbz7nR3uXCQ0UhKEcGYt/Z4b54OZMtzcHx7mfvgXxYmi9GNCSnQ3E50VwdkU/uFD7ZdSE6vyDw/vn+OuSH0SHXnsv8g9gXurlI5vNw7L8/MuiOj3zme2ZYhz6n1XH9/RM0rd6S5xX5ohfyTivJfV6TOrDXhUrzrO64hdKdPLgvnuMgweruu8gW97qVtk40yDJadJpsH3kE6XXze7BgOZlo7qDI/zxtNIzvv7AQh53u7GGYJXQUfKCQjDoffH9MNDdSJji98vBwY6kg9BpUpLVJQzRTQZhSVd2fWL5aRP5VRJao6s6KKllD5nYn3WhKWi3EgjF7VKs1Vf2liBxauxoZcxVr14y0MK0ZaVKt3iqYbfv1wEf9aj/wLlW9e8YFGk1LDdq224AjRWQtsAl4DfC68jJkObBNVVVETsLNPrmrmkJninXSjYbEwnkYaTGF1qYynTKMirF2zUgL05qRJjPVW4WzbT8GnK6qe0TkPOAbjO9HbLQAVYZoLojIe4Cf4gaFLlXV+0XknX7/14BXAu8SkQIwBLzGR05JHeukGw2HiNhXACMVKtDaVKZThlER1q4ZaWFaM9KkSr1NOdu2qt6SSH8rzkTZaEFq0bap6tXA1WO2fS2x/BWcG+OsM7c76R3LaXvPDw/YXPyvNzNyxzYAOt9yLMFJp/kdeXRwX1nanDg/JSUo+V7K0rWEZGlT5z8SSlspJnTbpl/Hvt13/Yq2g7y/ydOfRmbbr8m+9bsADHzwHNqOcj4wuXf9oFZnPCnF4aLzZfN+mZm7r4HDn+x2ahj71OXaCH96BcO3OjeN7MruMl/0asi98Fkwf9mkaYRm/ArQA3Kmi8jqqx4ABb2VfNH5D7b3xrebds4rn6oiLMS+QIVR1MfP7cruIRP5ygU5KIyA96Mrhu0lf+7OzD5Ccf5Q83ObIO/92XpeAX0/KsXirEe86vFI1k0KI1AscFCn01ch7CQjzn8wO7ozjrm9Zwuy2LsKdVQfnjKQqeN1NqXW2g9CDv8Qcnj55vDqd7qFRQuRQ9YgC1e69ZXJRAXncxctF4tx/NyOHud/Ds7frBQLtRjHkG3vZt7wfSUNkmlD/T457lOEl7/NLa8+uOSfXm8y89thxMdNTvrUjQ5CWxe6f7s/jYKLcwuwbXspRnW1/uiA80dfvHzSNE2ptc4VyHGfOsB/Wn9woVvYvRc52s+ns3Q5uRWJa5AfKfn0arEQ+xOvXIWMDiFL3ZwuZNriuQJGh9Bbfg6AHP8M9D4394GsWknXqxYTPuGe29k3fIvwZheXXnJtyMmfqeFJT4xu2ows9POKrF5Tui76wH3IUudLr3fe5fz4gfAXv6awsY/MQc4HNfJHr4qO9rgOE9CUWgMIFhwwh4ru/R4AMtxfumfJtrk44ODu60wuPqCtM553o2t+qa0aDhfQETiX0rZNv4aVR8OuJ1y6+QexAB+7WgKIOgGRX3cyZnkNnk0VEbVjxaJrZ/t2uCr0LI3n2SgWmF+8zy1n2uIY80FQWz/6zORdhSr1Vuls2xFvA/5vpoXF9I4fk1uvLfNHz8t8cqF/xkXzZURIEM8R1N5V8tOO5iMCyA5scvMcAPTtROYtol39/ALdiftYJK6P3uDyDc6q7hQrRRPx3SNf8/bu+F1BlQ52xDoQKY+nXot6VvihumnbthkytzvpRlMiAjn7CmCkgGnNSAvTmpEWpjUjTSrQ22RuY5XMtu3LkTNxnfTnzqiiRtPTam2bddKNBkRaaqTMmE2q05qIfA84A/cSshH4K1VNP3SD0QRYu2akhWnNSJMp9TaZ29iUs20DiMjTgEuA81R1VibxMhqB1mrb5nQnvagj7Bt9GHDm6lEoq54LLqPrgjid7nKhXIbmH89wRw+L1IdPkZCO7F63nB9CvSmo3vUL9PjnI+LMPUbDeeRDZ2ocfO4KJOdGeXJHLCT7Mm+Tmh+h8MR+EkZZhIP5mp/zZCz9/i2M/MPLaP+gCxWk27YTHu9CPWT2b0B3OZOe4kNbKTyxn/anO7P0kTu20VajOsjaD5bM1yZMI5DNNNtNuN+FkJDyEb5scBZlIR3D6+PlkrlQ4Ez3ohAy2bbYVHxoXxxCBiDbznu+7UynPvmKw1jR6SY4zQ5uRiMTOMWFoQFoB0TiMB8pkQ1OgcHL3UroQmFFl2E0O48O8ebT+ZHSdZAlawjb3LnVYpw0I88uv97jUK3WVPW1Mz54xoXug+GrnOlZZJqWHznAbLtkJtq7LDbzLuQh503Vi/4qR6bGG3+PHPwkty0sAt70fXQQjfS0ZzMUCshBzqUHEXS9s1SUNaAj3sx0y9bUwrC1f/xy9N6/dedQGHWhcAC65qP5YfSRB1392ttLbRwAg+6ayDOrr4Mc/ZE4XNFEaZqxXQv3uPNq6yyZGmvfLjKv/s8Dkur6LyFHn4Dud2a5OrAH6V0KgGSyaNS+5Ydh63ZnbgyEv7me4LhTALi+/zyO/Ow/ArD640EcamzRAmQ0j94fW8VKjzchzab3GhOc/eWSW4msif1N5KBl6A533uHuIYKV7h7TfEju+FVQmNr1puI6PPuz6JbJ565sSq2Ba9vy17hlCaBYQBaM08QOXxW3Y/kR9+yM2sJsm3N1ifLwpu8dwV6+G7wHgNfu+hSabUeiZ2uxED+Ps4m3neLomPqFpEZk9j94ORRHY/el/Ehcr2Ix0Z6Pxu4Ata5D9JtMQJV6q2S27UOAHwNvVNU/zrSgcvqcWXlE5CIxJvxZrnhd7N4VJnQSveuN4yIW6GgpPG6gIc94juuH3PHThe65OEVIu7L80yAyV9dEGDQJYvN2Dd16IuxaWbpaEF33Or+zNRtzupNuNCcCZFtopMyYPUxrRlqY1oy0MK0ZaVKN3iqcbftTwGLgX8V1cAs2oWtr0mptm3XSjYYkqGSk0TBqgGnNSAvTmpEWpjUjTarRWwWzbb8dePuMCzDmFK3Utlkn3Wg4RCDXQiNlxuxhWjPSwrRmpEUttCYi5wJfwn3dvERVLx6z/wzgClwMa4Afq+qnqyrUaEqsbTPSotW0Nqc76RkZpTvrQm6Mht0ln3TlF6U0oeYIFzrfuIyOsKBtLyOh83XLBrE/UjHbS2aR98fo7EX+75sE570agODRX1H4kvPZefTGTTz5c89zxzy2C/2DD/W4dx+dn4kHCru/mPD9SJH2j/yk5INfeGAbuVPWA6D7dyLdzj+r8MR+dLhA33Vu34JLbqy63PDWjwMQnHQ2xd61U6ZvvntQ0EwbomGZz1JSaxL59ZQ2+OXCCAQZ1Ps9SVhAIp+zts44/NW8RQyGy/jKG5ym+wrbSr7GOrQf8eE8sqM7oTcx6cK8l9f4XCskCgGz7wfo1vWwdBUAmQVLUB8+Rzp7Yv/BICCQU6svt//H7v+OeeWheSag6bQmAdrRU661ts4DtFY2D0HkezncF/uiZ3Luz/vUybK16EbfXh3yNGRwDwC6axMMep/0jnYYHEJ3b3Lre/YQnPa5UjHj+SqngTz1LwDvhz/k/e87e6Bvj5sTAdANmyg87s9puEj7R35Sdbm69RJX/oLl0L1gyvRNp7Ugi/YsQRK+mDJ/WbnWvC+nrDrWzX8R+c7u3x7f221dyCJ3/zM6BL3L0D/e6Y474mjC+93Ez8/jdvRPj3PbVx8Mo74dHByCbLYsXKkc96m6nPJURHM/6M5vUrzpdwBkzjyxNMdBsKQ7Xl46DwqFmoT5A9BNX0UWriiFeZ20nlVoTUQywL8A5+Am9rpNRK5U1d+PSXqTqtYuJpkE5f6/ufYDn6Hg/LCj52d7t9NUqa0PoXN+nEfE6BCvy/+zXx6E/FDswx0EUPR5J/3To2dY54trdorTpuulzge/5DOdi0NjQSnMIWERje7F8fz4p0vSDz3yRZ6EpmvbxuLfSSK9lbQWZMvTJP2xNYyvTfLdTkNGir0AdGZ3ceevXR+DsOjSSfl8MC7vRBgzObPq05kRmXNiP/2wEJ9bdG+M9ceHGoVfS8wNUIGPe9NrbRq0zjz2RtMgCNkgmPBvyuNFVovIDSLygIjcLyLvT6HaRhNSrdYMo1Km0lqFbdu5IvKgiDwsIh8bZ/8ZIrJPRO7yf7PTkzVmlRpo7STgYVV9VFVHge8DL6l7xY2mxJ6jRlq0mtbm9Jd0ozkRqXqkrAB8SFXvFJEe4A4RuW6crwBGi1MDrRlGRVSrtVn7umk0HRVqbbLY1auADYl9G4GTx8njWSJyNy5k1odV9f4ZVtloYuw5aqRFq2ltznfSo1BWnf7/sQSSJxBnOiQaEpIlI85kaLTYXQrBlmGEIV3m8xogOPUcdMN9AOhj6ykMO5PRtjZh+DoXbiF31CJ0mwvnqMPFxjFb8OYk+Sf2k3vMhSfSkRFk6RIAOj9zNc/7s8u5bP1fA7CgFmWevM6VIyEZxv8tklQze6OqbgG2+OU+EXkA99JR9066Jk2ZxtuXoGROlW2fMLRLMegm6HWhPKR/F53Dmwhv/RUA844+Al3sTUs1dOalgGqIdFR7JjVEAli4BPa5+uWybQx3HwFAR/bpaL8LFbaV01gxtXX61Hiz/7HXeyKadabQqbQ27ll19MSh/qLwRJH2Mllk6Rp3/NaH0G0uVO3eL11P9zMOAiB3+tNgeATd9IA7ZngEOa5WZ1Q9kmlD+71p/v5HYF43suZQt+/ZnyV7y0fdvuGp26CKyjvIheFKSWulr5sAIhJ93ax/uxZM/KpQcl2Bcj32LHHhosCZTZZCsI2gw32w3IdGHtxfevbolq2lEKb60CPIiuUuTTZTs9+sVkiundH7netRe/ddyEIfEm7JIoJnfxbAhWur4dcdWXlMLbU2Wezq8Q7WMet3AmtUtV9E1gGXA0dWVLlJKJ1f5sDAr9E+GavHts5YX5lc3KaFxdhkN9ee0GMW3bu1FL5MkmbMhTFh1xqBTLZUd80PI1GYuCBTcmfTh/4RWVX15Y/JtlesNWjO5+hk51fS2th3s/FcFsHpJ2EO3hm4tqHkegGQCcrTNTKqoInwcqrOHB5cWMCOntoWN8e1NlMapt9oGBGCm71xor9p5SVyKPB04Dd1qKrR5NRSa4YxGVNpzettiYjcnvj700QW433dXDVOUc8SkbtF5P9E5Mn1OyOjUalQa5OxEVidWD8Y97W8hKruV9V+v3w1kBORJTU8DaNJsOeokRatprU5/yXdaD5EZKqRssnM9JL5zAN+BHxAVffXuJrGHKACrRlGTahQaw35ddNoLmrQrt0GHCkia4FNwGuA140pYzmwTVVVRE7CffTZVU2hRnNiz1EjLVpNa9ZJNxqSKUbEJnuRBUBEcrgO+ndU9ce1rJsxt5iLo69GY1Kl1ir6uplYvlpE/lVElqjqzmoKNpqPKuNWF0TkPcBPcSHYLlXV+0XknX7/14BXAu8SkQIwBLxGVccOGhktgj1HjbRoJa1ZJ30MImEpVFsm6ccuZ9Kx7asAaK4dNqyH3nluXzZLrstdyrb5bWje+ZtkVs0n3N7nkrz1uymdwdTIotcD0P3F17P9Vc8CYMkHTiO8/R4Atv2/k/j5Fb8lf4kLd7Ph3Gew9FT3btjxyStmVqZU7oMjVOdzIiIC/DvwgKp+YcYZ1YGSf5OG5X6eY0Na+JAUgeRLIY5o74LhfmS1s3AN77yP4CjnfytHH1/yWatJ+JVa0nsB0utCFgHoyAC5HheiKPzxWwhe/h8ArCheh+J87TYPPJ1V3b0zKm46vk3Vaq0pGKu1KNSfhs7HbCgew9LBvW4hLJR8abuevJhd17twjMsWdSCHrSrtC1767/Wv/3ToeQXyzFcAUPzum5BDV8AO1z99/A3HsfaGuwEIr/wTRj7vfDlzxx1McPaXZ1Rcylpr7K+bfo4DjXyJJYB2768eFiB3LgC66xLnP7zeh9fuaHd/QPjHTUiPn4NjXje6b59L09VJcMrfp3IaFTP/1XR93oVh3XDuM1jx2icBEKzOkr/EtcG5t3+P8MdvYfQrr3L7urJVvQtUqrdatGvehP3qMdu+llj+CvCVqgqpBv8sLbVtyXYtCguliVC3xXzsCxyFzvIhTAmyY+ZTeEU9az59cudCNF/Lzm+i3m9esm3oZveTyJF/7kJQAgx9y/mtz3/1jIu05+iBjDuvUBQuTa8fP7Racn3sfglqE8KslkTnkwVG/O0fBO5+Ca93610vhaK/t4rXOX91gOzzZ1SkaW1irJNuNBwikKvuJnwO8EbgXhG5y2/7hH/pMIwSNdCaYVREtVqzr5tGpVi7ZqSJ6c1Ii1bTmnXSjYakSlO9mxnff9MwDqCVTKeM2aVarTX8102jYbB2zUgT05uRFq2kNeukGw2H0FoTQxizh2nNSAvTmpEWpjUjTUxvRlq0mtbmdCc91Cx7Rlzc3/ltm0vx0CdCJaAQdpbWC2E7RX+J5mVBVr3LpXvin2HZMsKbXFSv4HVvI3PzIwAsffISMktcHoWHdtL2wR8BsPvNp3LNf27ndfpgDc+wegZ2DAIw70e/I3fUIgDae9u4vOtoXjro6rpk4/lVl/N438kAFEJlcce2yRMLNOM9KFH8S+9fM56fTSn2ZmEEGRtjM1oXSn5Bkr8mTjPUB0vWwMAet2/VMgi9JWshX/I/y1/yWnb+76MArPhJA0WeK9X7WDJ9mwAY3TxA2/BVbn/H+eB96lZ19AEz050UfZxbVWcbNWniJtVaFN/c+2NO6tM1OoS0+XZNgnK/zAxxnN1d34rjCG/eDCeeDUDmtt8z/zAX67W4c5AMm8i8zs0vsOVlJ/O7G/YCsG5vY7Vtow/sor0jA23OxzkIpDQHx7If/prwL18IQPGR7QRnz6wMyXufVgnieMwTJm5Cram6cwxDF4uaSbSmIYwMIB1j2jXw8ardoix/e8mPFkA3bUbOdW2X3HZv3Ka15dANWwHIvPqfCK9+J+FWNy9eI83xAqBFZcflDwFw0Nu6yRyyGIChT66j8zNXw5dfCYB0VPfKJfu2unu+rXOKhE2oNQAUKfg2KJObvF3zcdFLp1lq1zR+s82cA9EzND/sdAzovMXueRo9q/PDpWVZ9Hp06yX+mBFk9Z/V4LxqSDRHDbhz9jHTdeslyPK3l5ZVtSpzQhnaF7+TZA+MWV+euDn1VprvR4KK/KIPiJmuYSzA4KzYZzuZJMgm3kkS73njHdNo/ul+7hmKhfLnW/G6OGZ64dqp37OmoHTPw9x8jlbBnO6kG82JoGTE3CiN+mNaM9LCtGakhWnNSBPTm5EWraY166QbDcl0ZoM3jGowrRlpYVoz0sK0ZqSJ6c1Ii1bS2pzupI8U2+nPHwTAjqGD+M0Tztx2174hnr7WmaOtmd/Bmnv/CgBZezjZ9m72zXMmkQvaDhs/4z17YPXhJZNPgPWXvxOAw9//TPKP7QWguHu4tL9jWTenvqC7didXI6KQREm6nljH2W9tL613XnRV1eUc+kcXPif/y/vY+iffnjStGymb3DWh0VAC8tpNRkYIcCZUMtznzBK9iVQYdLB31IWyW5R7JDZbC7ITmjnpwB6KvWsByPaeiwC68+cu/8WLIetMg8KfX0Pw0gsAyCybx5Jz19blPKtB1rw/XvHR1XKnP4g+dp/bf+z5NQkft2nYuVZs6heetPiJyevUhFojLMLgPmeC6OsuYaE8nFAmgw4602Bp64xN7IKgFArrALZuQA4+3C2f+K7S5r3Xf4IFZzm3oXCwQN/Pn2CBD/zVvayLpz27WNvzqxGdf/O/ZetLbz6PoCs74f6ZoFsf8QshdC+YNG1Tam1gP+FvrkfWHgYZHwNq22aKd/wBgMxzjocu91zL//Rmsqc/A1l1ZHx810vd/2MtGPfshuXLAQhO/JvS5sL6L5I71R+/fSfSXv6KEiyfWVjGenPIdb8rWy98+40AtD/Ltfdt7/vvmpSz6z3/zB9+uZMTP/DkSdM1pdYAikUYdS54SICMDqFRu5ZrR3yYNbJtkPGuPkEWGRmA9nXj5zni82vvKrV9AujoJbHbgIaQNLnNNO6rsSx7a/mGHZe5/3O5OI03e6+K/EjsDjC4b/I6NaPewmLs3gWI15nmh5Gu+bEGwhCy/toG2ditIjhr8umJvTm4S+LDlUXuZtMIOTarRO8KkbSKifOImGHYtTJGB929DweGrxtDU2qtChq3JTJaGEVonZEyYzYxrRlpYVoz0sK0ZqSJ6c1Ii9bSmnXSjYaj1UbKjNnDtGakhWnNSAvTmpEmpjcjLVpNa9ZJNxoPaS2fE2MWMa0ZaWFaM9LCtGakienNSIsW09qc7qS3b3uEFd93/jvZc07hyL0bABi+4h42/nIjAAuPW8bmzf0ArPrH+Ww77OVkwslHafZ88ToWvL0PnnswAMLpHH3nA27fW0+n53TnhzZyx9bSMV3/cA39PvxPo9PxmY8y+L6/YfNLTgJg8WkHE3RFPjnCXZ+7C4ATH/pDxXkO/cCFAtt800YW3T2VD4sSSGGKNI3FcKGTP+59Mgvai6UGpG+0nZGBkP0j7lxGiyGrezsACCRkwehd7uDOngN9Nj3hdT+FV7j5DpRfIJyOPPOv3b5r34McczQAcvLJpWOCF/8bXPWOWp9ifXjqqXDbzwAIf/4BRk57CwCdbINMjv73/i0A875yYGiTiehtc+HdMr1L2dQ/wbwSJZpPa+SH0S2POP/y+UvdtpEBdIPzv5eeHuhoh917AdDVa0rzH0hHT+xfNoahS2+k893e53O+0xrAku/8ij1vdcvzX3ksXfnYB7336zcg73pejU+wPnRe/DGGPvQZAHa98bn0PnsVANKeobjN+a3e+pU/cPqmytu1KAwnGUFWL58idfNprbCjn91fvYXuIx8gd8RCAHZf+TA/+6/dAKw99E5GfXShtjY4sSNL5gVOk9I5sf+4btuOROGwVsdaa//45YS+7ZIVywkf2VA6Jlj3NcKfva+2J1gnMm9wPsHhDy6l+N03MXr/TgCCRR0M3LsDgN4z15C9cPL5WcYS5DKsPqqTnTdumCJl82kNcKGcwsjnl7LQhpJtd+HVwM2/kXNtlQz1TRqSTof7/fFtaO4XbpnTXSjA7Ze69Y4ekvNFy9I3u2N3fpOGZ6mff2bn+tL5lHyGI39+4hDClaIjA4kQbBM8NOLUzae3ZNgwDUvrkvF+58MDbl82B9Gp5Sr3JVdirZXClYXXl4dBhXg+onHCtzUamnGh+KQ4Gte3mI91Uhh19+J0Q8ll2uJ34Cl80ptSa1UwpzvpRnPSauYsxuxhWjPSwrRmpIVpzUgT05uRFq2mNeukGw1JK00MYcwupjUjLUxrRlqY1ow0Mb0ZadFKWpvTnfSgp71kZrbn2u/z22ucid7SpULgrTNu//ctvOwvjgAgvO9BdG3A0vzNbmfHBePmu+iymxj80PPpfO75pW2PPPepACx/xkElE7bshXD/044BoL07y8pnr6ztCdYJ4XS6v3w6O886HoD9t21l4fkuNNO9n7mNDm8R+5vDj+HkRyozDd37oLv2C49YwIIXHwH/efMk5StBg4+UichzVPVX0XouU+Sgrr0s0TvQzQ8BsKJ3sTPJy28H4KbshSzrdKbY80fvQTc9DEB41HMnsnYnc8Fl6N2fdivHOZPQoU+6UDNtT1tKcMh7S2kfPe1pAKw6/3DIONOt9vNpaITT4UR3Xnrln9CxwYWXY8WR7H773zC0y4UxvGPVMRWbIe8ZORSAg3/5QbLP+8spym8+rREqDA6hmzZTeNSZW4f7RhBvilfY0k/neUfHx2czsMyFoiQbh1YcS9fnr2X4My8BoP2TJ5S2bzj3GSw61oWsDNZ9jbZ18Ks1rl07aGWWhUcsqP4kU0A4na7PO62Nvv0MCt7NKbtyHg9/z2mrtxf+u/1oXjnyYEV5at69LAzdtJnuCydv35tBa2PJLuxg0QXHoIN5wn0uXFGQCzjtvB4AJCM8fGcfAMeetZz8g7vJPNW5XejqwyeMUBQ8758Ir3m3y+Op8fbwZ++DRQvc9pM/Q+bkxPb+AVi+rLYnWCci8/3Mq0+n+F9vJufvn3D3EAte7u4d2nKEl78NgOCl/15Rvm3z2zj4xc+ITcKvvG2C8ptPaw51obHAhV4LiyXzVx3ci7S7cH9aLCDR9tEhZJLwh7LkTS7drm9BR09c0o7LXEgtgN4LSlrVLd+o3emkQKQ1liTM80WcGXIQv1nohn9xu1b/WYUZB4nFybsKzak3KTfjzzpT7pK5dXT+yXBjGsaaGY+JTNf1hgPTRNvHltfAlLSWIT7HIFO6Z4nCvUbnK2dWlnEQxCE+KwjB1nxaO5AD3usmoPFVYbQgikg44V9aiEhGRF4rIh8Wkaf4beeLyC3AV1KriFFHTGtGWkyutUabDEdEJho7NBqe5tOaiLx2tuthzJTGeI5Wgmmt2Wk+rVXzXjenv6QbzUuGhpgY4t+B1cBvgS+LyHrgWcDHVPXy2ayYUTtMa0ZaNIjWKqWyz7tGQ9KEWls925UwZk4T6c201uQ0odZm/F5nnXSj4RDRRhkROwF4mqqGItIB7ASOUNWtUxxnNAmmNSMtGkhrlXLC1EmMRqRJtfY0oDhVQqPxaDK9mdaamGbUWjXvdXO7k957CN1fvA6AR59yDEuXOq+jed2UfNLPe8tyOt7t/DDJtrFCbkb7dwEgE0eQoevz15atF0fc/R7Mj30+Bz/0fAp+wKd/e4EtP3yCUz9f7Umlx/y1CwAY3DHIQ59zvm/Dw7BslfMd2bsvzx9PfBIAR932+0nzWnnFb8dsuWyS1NXP3igi5wJfwnnPXKKqF88gm1FV5yCjqsMi8seJbq6s5FjSsQpYxZ6/ORWAu67Zzuo1WQb7nDaee+lWdOWLANCtm5DVRwEwWFhIzyQRTuS4T5Wtj/hwUbnh+BmTv+S1bHrMxUKad/tWJHBaXzq9851V8g/tIofT0X0v+jrrn1COf67zIdy0Wdn9ZnddF11206T5HDLPh+NZ9zWWTFlq82mNzhXIcZ9CjoO9PqzjQ7/ZQ4eL7sfgIDyzPUvnhd5/rKMd9u9zywcdPmklOj55xYEV688TzGsrrQ9+6Plk/ZNjx9YCm55w836cXtl5NgTFkQJhv7tf7vrC3WzZ4gIwrVghjI7CvU9xfsNPvW/yeRCi+Ud6Lkxunejnr7/WRET8/nXAIPBmVb1zhsWNsuDQkr+0XPknACz6k5Mh6y3hg4AV293vT1sOHRhm9GpXXNs7JtdacO6/Hrgxm0W6u0uresdfuYV53W4ehg1b3PopMzyjWUAygix34euCIw6O/cn37oMu11YVf3AhmVf/55R5Re8zMZdNkLL5tKaq4QknnAC9fi6gnd90IZ0iNETzbl4Esjm0WChtD4OOKX03ZfEbyzdoWArjBqC7v+MTBqWQlaWQb81CVO9MzumsLNSXu0K65RvIij+dMqvIl78yqtPbrGktCo2W9BmPiHyki4nzGh0CPy/ChBNuAARnjb878jtPllfaFk6eZ6MiAaUXgrGE11cWji137jQKbKq2rfL3ugmY2510o2mpZvZG70v5L8A5wEbgNhG5UlUnH0k4kGNE5J5SleBwvy6AqurTZlxJo2EwrRlpkYLWzgOO9H8nA1/1/8+EY2ZcWWPWaTaticg9z3zmM2dcZ2N2maneTGvGdGmitq3q9zrrpBsNRw1mbzwJeFhVHwUQke8DLwGm23E6tppKGI2Pac1Ii5S09hLgm6qqwK0iskBEVqjqlhmUdyzweDUVNmaHJtUamN6akir1ZlozKqbJ2raq3+tsdnejAal69sZVwIbE+ka/bXq1UF2f/AP6gWcAS/y60fSY1oy0qHrG7Uq0VhM9gtPkTI4zGoHm05rprZmp6jlqWjOmQSrvbA3zXtcyX9KHR2DJCudjokVFQ+dr1H38Utjof4uVK3lo9ByOXNk57fwjn+wnznk6B/39SwHY/cBuVj3dxUddf/sugsDF4AVYtBDa250DShDAsx6rLAZ0mnSsnQ/A9ru3k+t0Ulk2T0rLKw5W2ua5azr4oeczsKmfpd+/pSZlSzjp7I1LROT2xPo3VDUZ3HQ8z55pO5eJyFW4WRjvE5EVwJ3A7TiTlW+o6j9NdvwZl5zBw399E53dbixMVixn65Dz4Z+3YglZcf51PdnpDbYtuORGAPrfcxZdR38cgMJj+zjhzc4HdNcd2yiOuOt3x9HHMDwMIyPu9E9501q6/uGaaZWXFm0vP5Vbn/d1wLk4rVghDO9xcdJPOiVHm/eL1i3fYPei8wBY3F79JK3NrLWCnwvjyecs55GbnKvTvHnQ/vRlEPn29vU5n16A7POnWzUOv/leNq5zc4gt+/Ir2f3AbtY+0/nYbvv9Hjbtc6d75byjmTcvPm7VyoCj73xg2uWlQe/pq7nnH38HuPZ31Sr3M3Z1wppDhK4Frl0b+ssXkj3YzYuQe8f3qy53Cq3B5HqrRGs10SM4TSZNQsM9Q25h/zDBocvdchDAkkVueedu8g/sQnLOX10WvX7aZQZnfIHw5j93K7/5JDow4Jbbcu6v37WZ4eVvgwXzS/t00zYAMhdcNu0y643mQ4L5vq5B4rvI4iy6Zw8A0tnG6FdexUPfcJaRT76n+veBZtMa8LEyE2QNIZOFyPdcglJca8m2o8P9bnthlEBOnX6Zy97qYqUDuvd7se9xJvFaPDqEbvpqWbzx0vEV+HWnTtKPOgggiOcSSV7H6LwpFpDlb69J0VU8RxtDa5H//nhx0KO5EfIj0PniGRTq44XrDc5Pe6KY6GN940t1qsCvO20mu15Jin4ejdGhmV27cUjhna0h+hDQQp10o4lQhXDSiTd3qupkMw9vpDzExsHA5hnUZK2q3ueX3wJcp6pvEpEe4FfAP80gT6ORMK0ZaTG11mByvVWitVrpEWDtDI8zZpsm1Jqq3nfCCRZQoCmp7jlqWjMqJ513toZ5rzNzd6MxiUY2x/ubmtuAI0VkrYi0Aa8BrpxBLZKOL2cBVwOoah9UMXOF0ViY1oy0mExrU+utEq1dCbxJHKcA+2botwnlmjSaDdOakSamNSMt6v/OViu9Vf1e1zJf0o9+3graVjlbzD2/214ydy9sHqB4pZtZX0du48h/eFdV5RRGioTe1HjZusPY8dPHADj0pCUs/tbNnOjT/Xz50XR1ueX+frjtSDeR7okPNY7Ze9ux3ozx8jjEHJQvz/PXdGj7IL0nLif/1VcDkHvXD6ooWWPTrJkcrVoQkfcAP8WFWLhUVe+fQVYbROS9uFG1ZwDXAIhIJzBh0LSF//RuAGT+co488nCY769jRzeqblxs2+Bqjpw/fbeKJB0nrkC82VTHm89EVjhz91W7NiBr3g/AGmDjuhPo2+xMAx+44nGyVzmtHff7xtEaALv3RhGJ6B9w1np7djodFApw2EufDIAsXEk+dAnX94+wZl77uNlVRpNr7enLAGg7ahHHLnIx2KQri+QC9OFHXKLR0fHDXU2D9l5vNllUVr79qRR3OzeE7uXdPPXLPyul+92xTlttOdi7T7lptVs/dUNjaS0yyQYYHY2jYkWuIYuOcvesdGTJrHDm7uEtHyV49merKLU+WhORd/r9X8O9BKwDHsaFjnlLFRXeABwXrey4/CEAeg/tJbuhD4Cwf7QUnm/ztY+x+KhF9H59nHBG02HnbgB02ZJSaJ/8bx6BotL+kZ+UkoWXv80tLFmELF7gtv3ywwSnfa668muMDhdjgYUhmnyR9C8B4batFJ7YX0q2+82nThlqcopSm05rIvLeMhPkYgGybeUuAv6ctJAHcRapsvKdMy818VtIm3umaLFQKkcOea/btsVby2aypd+y0lBmqZL8whhO0AcIgoSpcoDu/s6MXFPKmbneGkJro0Oxm8PYsHv5Ycj4519vleba0XWP/k/+XklXtMjsPRmyLTKZbxQqCU+oYXyOxQIMX+WWO86vpuBmattm9F6XpGU66UYToVrpiNgkWejV+FGrKngb8GngbODVqrrXbz8F+I8q8zYaAdOakRZ10pp/qYiWFfizqgqJeRuwrUZ5GWnSnFr7dI3yMtKmSr2Z1oyKaa62rer3OuukG41JFSNlNaRDVQ8YplfVG4AqPxcZDYNpzUiLxtBapXTMdgWMKmgyranqO0844YR3zHZFjBnSPHozrTU7Taa1sRun815nPulGA6J+tGyCv/S4PFoQkR+lWbCRFqY1Iy2m0Fq6equEy2e7AsZMMa0ZaWJaM9KiObU20/e6lvmS3vP1i7h5tRs4GxlRRn1EhacM5ll60goAsof0Vl3OYb+8p7Q8dNH5ZNqd72PSjxvgeVsf5KGTnY9tR3uRrQ1oVCinOR+Y3u8+QJ/3QZRAkIzzBQvzIV1HOt/NcN8IuaOXEu4drL5gBaYOH5MGyTAMh1V81IKVAOweWcPCJRtd2A6/fVXxNwDsKhxD+eSR0yd74bdLy3rHXzHyk28B0Pb2V5alO/jq2wl/7FxqRu7ZwZ7fba+q3HpRfPp5HPtuF7LrkUvuoXd1D52LvZ91ECDHuwk7B7Nr6NYdAIwUe6ortMm11nGRC1elP76MwIdDlFwGzYfIsPMbJ6z+wZUMrTj86Rex+WcuxOeK08s1/PQHnO/5Y2cex/DIyIRukbNNZt3ZHHOHC1l31xUb6fDfjDvaYXhEaF/mfIWza3qh12usf6C6QhtHa5VSFoZm+U/+AYDNL/owHTtdOLbhvSOl+QqWP/dgHv+fR6j2KRq89N9Ly4Vvv9Ftm9/O6P07aR8n3eiXX1nyW84eMr/K0mtP5vij4lByAKN+LqHR0dJyYf0++h/fx+HrDgVAh6vUSZNrDYDlR8LujeWmrdFLeJCJQ6ZVU+iyt8ZZR2HJ8sPOFz6Zzvue66avxr7emQPDss020unuPh0dcn7W4xGGsZ+/BJVEAZia5tLbAVrTjh4kP+Z6RbrLdThN1IIolFoUlkxk/OsvZ8ZpYOowZ41KWIy/eo+5p2ZM82qt8j5Egib95Y25jZZPrjN76ATLxpzBtGakRcNorVJMh02Lac1Ik6bSm2mtqWlarc1Id9ZJNxoPrW72xhpynIjsx42Gdfpl/LqqavWmF8bsYloz0qJxtFYpx02dxGhImlBrIrK/bMZto3loLr2Z1pqZJtQaVbzXtUwnff/oKk54k7M22PW77dz5S2e+nR8qkDnImTZKzpkArT/reADWXH9XVWV2XnQVySBbhf98A5mTngKAPvIYB5+9BoCwb5RjE2GMGoYlrn4H/eU6Mn9/DQDFQsjIHmf603PEAjTvTHXaT1wOo6Nk3/Ct2pRdCxOsKlHVGdmzRWZTbZkBJNfhzKWA4WJvKQTbYGERiyPbzRqE15Bn/jXtyeg16syTM4ygEhC87E0AdJ6zm86eV1RVVr3IBCNk33QBAEcfscSZ5XlTbXnmMxlY4E5wtNjNwnZnbt2TO7b6gptZa8OuHdOO9jisWEYgEFi00K0X4gfayOdfTvuHflxVXTs+9T8c9ql4Pbzm3X4hhGHn2rHy/MNZvnuYzs9UO+l9nVi6lq53PA+AZ8z/FXvv2wlAJhfQe9wycke5ayfdHYQbnWtFTdq2BtBapahq5oQTTiiN/kv/LgDaunN0rnChN0f2j7Lfu0J1reohCGLrvqGLzqfzoquqqkPymueAwY+c61aKIdLjzCdHNvbTNt8tt73nh1WVVxeOOx1u9tdheAT295V2jT7gws0V9wwjgZBd0Q1A2wdrMC1Fk2kNoExvw31oMR+/kGfi11XJZNHE+enObyJL3lRVHWTpmw+s1/ZLnbuaJKxWvZl7VaHf6oTOWwyA7N/uPtsVvKudBHE4LygzF672usV5NofextVaWDhQZ9G6BOXh7ArXuv+TIdOmS+acxLL/f+Tq+HeJzNsjt4Rk+gZBs+4FVgojzv0kSaSFMBG7PNsGuXNrU3iTaa0aWqaTbjQT1YdYMIzKMK0ZaWFaM9LCtGakienNSIvW0pp10o3Go7nMWYxmxrRmpIVpzUgL05qRJqY3Iy1aTGvWSTcakxYaKTNmGdOakRamNSMtTGtGmpjejLRoIa21TCddJKTj/S401arhAVb85g4AMue+iJGv+NBV7/tvhj65jp7VVYZ1GgflF4y+/qN0scVt6J1P5wte5vb17WLgg87npPuL102UReoIpwNQeGo7S791EgB73vH3bLl/LwBLnryEjred5xLv3oVu2FSbglWh2Bw+J+PifXW6n/gZ+1eex3DBhQXqCPcRqrvlVnd388h+59u/tidLMH5OM0J/dxGBjymlhQKsWgtdcWiifPhbAHLBSTUstXqE0wl7bgIgOP1c9I93lTQ1suxEsri4ibnsEKNF57vZXq3HT7NrzfvPyaqV5Lq6Spulpwfd5uI6Buu+Rnjj/3Pb22vb5OvvLkJWuZCDBEHJh67t8FEKtz3A6Fde5dYbzFdYOB2Odv6anX9+JMG/fAeAwvYBckctJDjKzV+iGzYRLOquTaHNrjX/2y44ew37bngCgMJgnl7/vNzzwC6OvvMBtr/qWS7ds1bWtPjwZ++j4/lHuZW2tpJvd+6QPvKP7AVg4H1n091g87sIpyPP2AOA7t9J8ac3uuXhAtLhGrC2oxYRzG8nmN8+UTbTo9m1BrFvcMlPNyh9QVMNSz7kuutb5T7jNUA3fy1eybVDxoW3JD8CA/tcmi3fKIVmaxSidza6r0NGh9D+RJi6yG84CGC0UL6tWuaC3iKf/SjcWnQ+uXaY93K3PHxV7UKJRUQ+7kEAGR8LVEOn9Wg+mfBqaF9X23KrpKS14Pp4o4blcx9A7F8/dvtMmQtamwYt00k3mowWGikzZhnTmpEWpjUjLUxrRpqY3oy0aCGtWSfdaDxazOfEmEVMa0ZamNaMtDCtGWliejPSosW01jKd9J7cFmTpWgB+8IcnsXXFCwF47+/+leLOwVK6jhc/Hf3hbTUrV7dfCsCe+c9jpNjLUGaB27HkWNrod3VbkCN7cO1N7GtFNjiFotxSWl9z8lIA2o9fBlu3AlC89xFoy9TObDts3pEyjcx6sm30/OGH9K45GoBixyr2jq4upVvZ9SAAw8UFdNXgTtQH/8EtLF7sTLTAmef170ajUB75EbIjf3DLSxrL3B0gkFMB0M5foPv2w6IFbl1jZbVl+ukvHATUwNwdmltrOR/kccXBiA9/RlsORvPlCb3ZnI7U5uGmm77qFg5aHpuzhYXYDK2jm+ypHYT3/L4m5dWFKIRO17Xknur0FP5mI7J4gTOnBnctgxo6ozSz1rpcWLrsqU8ncp7pXr+/FCYxs2XA7feNWThYuxcp3fw15Nhjod27HuSHoeA0ngkLBAc/BEDhD1trVmZN6XopAMLlJZP2Yr5IMM/pLLNqPsH8dnS4hi+fTaw1cG2btHWiWze6DdksLPUuFEnz9tGh2pog9/0I2rrKtxWd1qSzJ36WBg38+pw5B3LXxmb6o0NIm39WBFm0xhbbQFPrTYMskvX119BpKrpeSTPtWn/BDa9PuBwkX2YybnsUaqxWpuL1IDjLnQe4eyJ5jTJ1ukeaWGvTpYFbGaNlUYVC6/icGLOIac1IC9OakRamNSNNTG9GWrSY1qyTbjQmLTRSZswypjUjLUxrRlqY1ow0Mb0ZadFCWrNOutF4qMazWtYYEflH4EXAKPAI8BZV3VuXwozGp45aM4wy6qw1EVkE/AA4FHgceJWq7hkn3eNAH1AECqp6Qt0qZcwO1q4ZaWJ6M9KixbTWMp104XTy6kJPnbBqPiuO3A5A/kuP0vGip5TS6abNdH7+kzUrd8/85wGwiN9DYQDE+aM9MHw2y7zbk+7bRO7opTUrsx5kdAiAjb/dxprnrACgsGWA/ltcyKwNt27lqff9oTaF1fcmvA74uKoWROSzwMeBj9aygFJoikX70PZudMC9Jw90HkdGYl/hvDqfp57cltoUPH+R+1/Dch+9zh7Eh4XTHRth7363fUltiq0HoeaQ0VHkqKcB0BnsRB+5E4Dh7/yC3ouuqk1BTd7gl7TWtQtde7hb3rfLmYP19cUJvY9124feX5uCIz+6TDb2lwsCyPnlXDtkM0imtqGR6sY85+ucOagb3bWX0ZsfAeDebz3EiQ81RbsG8DHgelW9WEQ+5tcnatvOVNWd08k80poetJnseW4OleCW3zB6v8umY4UPi7jQhRFq/+T/m/YJTEi2zfnXRj6OItDp53EpFpC1awDI7NxfuzLrRLhvpPR/0OV9hsMQWTSPzLn/WptCmrxdA6+3tithxSFuQ3645FetIwNxwlwHLFlTs3J1ZCDhv50B1bi8IFsKsUphpGZl1oUgg3S4e1KLeTTyFc4Pgz+fmoWQa3K9CaeDeL/qts6J/dAlQP3vX/Mn29gyJYCM3xY2iXm3huXXK8jE5yVn1qiM5tbadGmZTrrRZPjJiGqNql6bWL0VeGVdCjKahzppzTAOoL5aewlwhl/+T+BGajwAaTQRddSaWW0YB2DPUSMtWkhr1kk3Go+pR8qWiMjtifVvqOo3ZlDSW3EvGkar0mKjssYsUn+tHaSqW1xRukVElk1UE+BaEVHg6zNsO41GpsmtNowmw56jRlq0mNask240JDp5qIudk43Ii8jPgOXj7Pqkql7h03wSKADfqaaeRvMzhdYMo2ZUoLVJByAna9umUY3nqOpm34m/TkT+oKq/nMbxRhNQ53bNrDaMMuw5aqRFK2mtpTrp+/POl/rwtp+hu51PerhiHre97WoATn7kCwQv/4+alrko7/xodc8W6OqFXvdxY3XuMfaPrgJg57xzWLLikZqWW2t0v7teK45bzLzzDgOgsLGPtiXOd6tm/uhQ9UiZqp492X4RuRA4HzhLVetrNyNS8g8fLsxnSccf/Y7D6M0d5ZePGvfQaRe1wL27696tsV9QrgNJ+jotPCiOAd3AZPZvgBOfw/6upwMgxSI9K/YB0HnRn9euoLkyKlvMxzFxO7qgMErx8R0ABEBw2udqW14Ur3o44fceZCGXi9ezWejqrG259WBgD7LC3Tu5nh60r49c3t0/NfNHh0q1NukA5GRtm4hsE5EV/iv6CmD7BHls9v9vF5GfACcBlXfSw7D0+weHriZ4eK/LN+ea0u4vXldxVhWzZyf0Lojn2ggSMYUzWad5QDoyBx7bQOjA3lIdJRCKOwbdcleO7IX/VsOC5ojVRiGPdMxzy22d8e+eay8lkSVvmmbVJ0e6F0DRX7uwiIaF2Ec9LMS+6I0cJx38M8HdL9LejYb+nIKgdr7oEXPlORqRzcV+4EHimdZxfm190cNi/NxuYvK4+UFyuq/cf17FxVGvJXNNa1PQ4K2M0bLUyedERM7FjfifrqqDdSnEaC5ayL/JmGXqq7UrgQuBi/3/V4xNICLdQKCqfX75+cCn61kpY5aYWmtmtWHUDnuOGmnRQlqzTrrReNR3pOwrQDvuhQHgVlV9Z70KMxqcFhuVNWaR+mvtYuCHIvI24AngAgARWQlcoqrrgIOAn/i2Lwt8V1WvqWeljFlgrlhtGM2BPUeNtGgxrbVUJ31x+2oAwl9+ifCJbQAU1u/n5EdqaNI4hs2vvxiAFV94NYNfuJzswc4spHvdScw74ngAdN92dP0TAMgz61aV6ti2AYDFHzsPBl04ttya1bQ9/aLal6U4k8o6oKpH1CXj8eh8MVL4Ucn0vDO7m0BOrVtxuuUhAOSgtehO93vRNT82TcaZ8jWDP48O7kMWLKczsxeA4WIPzHt5HQqiblpLlfmvhk1fdct79ziT7bd/r27Fhde5IAnBs06Abf79fEFvyeyY9k4XIsu3FY2M7t8JXf4eacshhQLB675Zh4Koq9ZUdRdwgG2h7yit88uPAsdVU44sej36yOfdShCUzLfbP/ijarKdFH3wIeSgZdDrw6615VCvO1m8GPZ7t4tGd+UZHUK6XYi6zEEKPkRh9sJv17ac+rdr6Vht9LwChn24zcJoyZRWFry2iqpPQX6kzKxegm4XtgxAA6RrgVscbfC2LdsOQ85FjCDjTPWp07WbC8/RyCw7vN6FDRP/tTZzTv3KFHFuCVDuwjM25Jo0dijTQujcT3Kou3bRO2Y9rt1c0No0aKlOutEstNZImTGbmNaMtDCtGWlhVhtGmljbZqRFa2nNOulG46HaUiNlxixiWjPSwrRmpEWdtZaW1YbRJNRRbyKyCBcq91DgceBVqrpnTJrVwDdxcyiEuPkVvlSXChmzS4s9R62TbjQeChSKUyYzjKoxrRlpYVoz0sK0ZqRJffX2MeB6Vb1YRD7m18eG+ysAH1LVO0WkB7hDRK5T1d/Xq1LGLNFibVtLdtKD0z5HFJSq3hdg5RW/LS13f/FDZfvCn3/ALQwP87M/vQWA54/jdtv3rucB0PPVn9eljlOx4dxncPDnX+lWRvPgwxXpXfcgT69HiXPInKXnFfFinYuStR+Mlw8Zs1NvcP8P7YPNbv4Dlh6Yh26/1B2/7K11qOHU6G1/6RYOXg2jQ26KPyAro/Uqcc5oTVa9yy2sorZhYsYh8+r/jFfGag3Q9V9CN2xk1w8fBGDpBNMJDH7kXLr+YXYsYHe98bkALPqLF0OnD7HU3gkd7ZMcVQ1zSGuHx8+ythTmUQlefGB4Mjnc/R9e9Y544yTXN7zqHQTnf73WVauI4g8uBCB42rHIsT7k5voNBPl6fRGaO1qj4/x0y+u94MBtUZMwdKXzWYcD/YYT6O7vIIteX/u6VYjuuAzp6IFM7OcsmXrO11BXvb0EOMMv/ydwI2M66T4cYBQSsE9EHgBWAdPvpEe+6cHkyWrCRD7bAVC4Nl6XSSoTXu+PqXGos0oJr6ezVL2Muy8mq2/VzKG2rQJaspNuNDgKWmydEAvGLFJHrYnIBcBFwLHASap6++RHGHMaa9eMtDCtGWlSX70d5Dvh+GgCyyZLLCKHAk8HflOvChmzSIu1bdZJNxoPVajbFwbDSFBfrd0HvByYnc93RmNh7ZqRFqY1I02m1tsSEUkOUn9DVb8RrYjIz3D+5GP55HSqISLzgB8BH1DV/dM51mgSWqxts076LBI8758AuGn1MeRy4xuo7nrjcymOOLOqeptLT0S2M4fu2g2APOlpyJI3ueVxzFxrgQIats5IWSrImQDogxfBgvnjpxm8HJk/3nMyRbqc2bF0zYeOHnLBSQDk6mQ9VU+tqeoDANLg4VPqgax5P31/dya5eeObWBYufR0A2UN606xWGZ2rfIvau6AUplAWvR5W1qc8a9fqQ3D+1wl/+WG3EoViSxDt0/2zFzJLVvt2tbsbepcAEBz+obpZ1JrW6kTni9Gh77jl8dr1Ph+GMEjDVnoSMjlo64xDYXXV12WgAr3tVNUTJjxe9eyJ9onINhFZ4b+irwC2T5Auh+ugf0dVf1xZzRuY7PNjN8WJwuaG10+8Ly3GmrZn62t232ptm3XSjcYjBEZbZ2IIYxYxrRlpYVoz0sK0ZqRJffV2JXAhLuzfhcAVYxOIGwn/d+ABVf1CvSpiNAAt1rZZJ91oQLSlRsqM2WRKrc3YTE9VD3iZMFoZa9eMtDCtGWlSV71dDPxQRN4GPAFcACAiK4FLVHUd8BzgjcC9InKXP+4Tqnp1vSplzBb101ol4f58useBPqAIFCazEqkW66QbjYfSUj4nxiwytdZmbKZnGGVYu2akhWnNSJM66k1VdwEH2FCr6mZgnV++mfoHNTEagfq2bZWE+4s4U1V31qsiEdZJbwBO3fCHA7ZtetGJACw7/3Cy73hX2lUqI9ueQQ738W42PApL6lxgi83emCby9IvG3a57v4fMX456/6JZe9otdR+lw96V5MNO6hUMq4RprW70fv2GcbePfvEVZE88DIDMc1MOr5Sg44y1bqGzB6lryBiPaa1uBKd9btztevenYXjYpXnd29KsUjmhf6nMj8JDPirUiXUsz7RWNyYMrdafcINeUKeJLSpEOrqdr3ImpVd801t98HMJHfBClvBVVx9ab1ZHKJJ+8fWuSH21NmW4v7SxTrrReKhCvnV8ToxZpI5aE5GXAf+Mi0j/vyJyl6q+oC6FGY2PtWtGWpjWjDQxvRlpMbXWJnVRnIJKw/0pcK2IKPD1aeQ/bayTbjQk5k9npEUdZ3f/CfCTumRuNCXWrhlpYVoz0sT0ZqRFNZEEahTu7zmqutl34q8TkT+o6i+ncXzFWCfdaDxUYdT86YwUMK0ZaWFaM9LCtGakienNSIsqtVaLcH9+PgRUdbuI/AQ4CbBOeiux6n9um+0qlFj81mdAYdStdHTUv0AFrbPplIh8GPhHYGkakz80OrLgte7/Wa5HuPQYAFQDilp3j/RUtGaU0/bBH812FQCQZ57k/s+0QSZT/wJNa6kjx31q1ts0AFl9sFsYHUWHXLz2utbLtJY+815eWpx1zbV1OT/hNObaANNb2kS+6pkG0BqkG6u9vlqrJNxfNxCoap9ffj7w6XpVKKU72DAqR9WZs0z0Vy0isho4BxfOw2hh6q01w4iYSmvV6k1ELhCR+0UkFJHJzP3OFZEHReRhP4OtMceot9YMI4k9R420qLPWLgbOEZGHcH2Ei8GF+xORKJzfQcDNInI38Fvgf1X1mmoLngj7km40Hqr1Dh/zReAjjDNKZrQY9deaYTjqr7X7gJcDX58ogYhkgH/BvYBsBG4TkStV9ff1rJiRMtauGWliejPSoo5aqzDc36PAcXWpwDhYJ92YmiCgeJObLLH/xg0suKT+H1/qFWJBRF4MbFLVu0UawlDISKDqjHs0RSMfCx3Togz1AaDFAvr4IwAEp7y0rkXWU2uq+gDAFO3aScDD/kUDEfk+LuyMddLryfCI/3+Ywj3OgKvttPoWae1aC6OhC/uXH3Tr81Io0vTWukRuFSmZvbeS1qyTbjQeVYZYmGL2xk/gfEgMw0LHGOnRGFpbBWxIrG8ETp6luhj1ojG0ZrQKpjcjLVpMa9ZJNxoPrS7EwkSzN4rIU4G1QPQV/WDgThE5SVW3VlFjo1mZWmuGURsq09qMByBVtRL3nfE+s9sNMNeoc7smIhcAFwHHAiep6u0TpDsX+BKQAS5R1YvrVilj9rDnqJEWLaY166QbjYeC1sHnRFXvBZZF6yLyOHCCze7ewtRJa4ZxAJVpbUYDkNNgI7A6sX4wsLnKPI1Go/7tms1/YMTYc9RIixbTmnXSjSkJzv5yyUN4wRvSKbOVfE6MmGxwSmk5l1b0GNNaSyKHvDdeHu/bdB1oAK3dBhwpImuBTcBrgNfNbpXmPnL0R0rLbSlNOWTzH7QwuXPd/ylEMY1ogLbNmA3kzNTjwLWS1qyTbjQcqkoxhZEyVT207oUYDU1aWjOMemtNRF4G/DOwFPhfEblLVV8gIitxpsbrVLUgIu8BfoozQb5UVe+vW6WMWaFB2jWb/6BFaBC9GS1Aq2nNOulGw6EKYaF1JoYwZg/TmpEW9daaqv4E+Mk420vhY/z61cDVY9MZc4cKtWbzHxg1wZ6jRlq0mtask25MG+UXpWXh9DoUoC1lzmJMgt4QL8uZdcjftGbEhHoTIqG1a0b9Ca9HA/cKVnO9VaY1m/+gVain1sDaNqOE8gskCsVm72xVY510o/FQCFvInMWYRUxrRlqY1oy0aAyt2fwHrUJj6M1oBVpMaylNzWQY00NDnfDPMGqJac1Ii8m0Znozakk9tSYiLxORjcCzcPMf/NRvXykiVwOoagGI5j94APihzX8wd7F2zUiLVtKafUk3Go5WmxjCmD1Ma0ZamNaMtKi31mz+AyOJtW1GWrSa1qyTPg5Jn+uI8fx4xks3E0TD+vhu1IGkv0lIlskjsMy4kDk5IjYRY3U0kc9YLfTWdFqLVkYGoKMuhZjWKkg3U+ri/1gHovMNCGGoDzrrUohprYJ0M6GuPpA1pnS+QRbp3+WW59W8ENNaBelmQjNqTSSAJ+5xGw+ph0966+gt7WfoZGU0GqX+Qd9Ot6G3LoW0jNbAOulGA6It5nNizB6mNSMtTGtGWpjWjDQxvRlp0Wpas0660YAoGrbOTWjMJqY1Iy1Ma0ZamNaMNDG9GWnRWlqzTrrReLTYSJkxi5jWjLQwrRlpYVoz0sT0ZqRFi2ltjnfS+2rmF1JL/5ID8pYAJsm/EfxRkufv6gsBp1aVz4RpFMKm8zkxrdWS6BpEWpOO82ecx6RpTGs1yWem+TeC3sa2bdL54qrymDCNaa0m+Yybt0SBahq7bTvgGsx7efV5jJemKbUGtdKbaW2cdu2Q91aVx6TpmlJvja+1SspoSK31XlBVHpOma0qtzZw53kk3mhLVlhopM2YR05qRFqY1Iy1Ma0aamN6MtGgxrVkn3Wg8WsycxZhFTGtGWpjWjLQwrRlpYnoz0qLFtGad9DlIGuY39ayD0lohFpoZ05qRFqY1Iy1Ma0ZaNLvW3PGmt2ah2fXWalqzTrrReKhSbKGRMmMWMa0ZaWFaM9LCtGakSR31JiKLgB8AhwKPA69S1T0TpM0AtwObVHX6E9kYjU+LtW3B1EkMI10UCMOJ/wyjVpjWjLSYSmumN6NWmNaMNKnzc/RjwPWqeiRwvV+fiPcDD1RdotGwtNo7m3XSjcZDoVCY+K9aROS9IvKgiNwvIv9QfY5G01JnrRlGiSm0ZnozaoZpzUiT+j5HXwL8p1/+T+Cl4yUSkYOBFwKXVF2i0bi02Dubmbs3AY3gQzIe9aqXAvVyORGRM3GN/tNUdUREltWnpObEtGakSSPqrVm1JiIXABcBxwInqertE6R7HOgDikBBVU+oX60aB9OakRatpDWX95R6WyIiyfboG6r6jQqzP0hVtwCo6pZJ3tn+CfgI0FNhvnMC09rcxjrpRsOhWtcRsXcBF6vqiCtLt9etJKPhqbPWDKNEClq7D3g58PUK0p6pqjvrWhtj1rB2zUiTCvS2c7LBQBH5GbB8nF2frKR8ETkf2K6qd4jIGZUcYzQnrda2WSfdaDx0St+SakZljwJOFZHPAMPAh1X1tplV1Gh6ptaaYdSGOmtNVR8AEJH6FWI0B9auGWlSpd5U9eyJ9onINhFZ4b+irwDG+7DyHODFIrIO6AB6ReTbqvqGmdfKaEharG2zTrrRcCh1HZXNAguBU4ATgR+KyGGq2kIGNEZEBVqbMSLyj8CLgFHgEeAtqrq3PqUZjU49tTZNFLhWRBT4+jQGOI0moYG0ZrQAddbblcCFwMX+/ysOKF/148DHAfyX9A9bB31u0mptm3XSjcajvqOy7wJ+7DvlvxWREFgC7Jh5iUbTUt9R2euAj6tqQUQ+i3uJ+GjdSjMam8q0NqmV0GQDkKp6wMvrBDxHVTd7387rROQPqvrLCo81moEW+9pkzDL11dvFuI8pbwOeAC4AEJGVwCWquq5uJRuNR4u1bdZJNxqOOvucXA48D7hRRI4C2gDzzWxR6qk1Vb02sXor8Mr6lGQ0AxVqbVIrockGICuvh272/28XkZ8AJwHWSZ9DtJrfpjG71Pk5ugs4a5ztm4EDOuiqeiNwY31qY8w2rda2WSfdaDgUKBbrZn1+KXCpiNyHM0O+0EzdW5cKtFbN/AdJ3gr8YAbHGXOEOrdrFSEi3UCgqn1++fnAp2e1UkbNqbfWLJKAkaQR2jajNWg1rVkn3Wg86mjOoqqjgPkqGY6ptTbj+Q8i82MR+SRQAL5TRU2NZqfOZnoi8jLgn4GlwP+KyF2q+oIxZqEHAT/xk8tlge+q6jX1q5UxK9TfJNQiCRgxLWaCbMwiLaY166QbDUerTQxhzB7Vam0q82MRuRA4HzjLLDZam3q3a6r6E+An42wvmYWq6qPAcfWrhdEIpKA1iyRglLB3NiMtWk1rwWxXwDAOwI+UTfRnGDWjjloTkXNxE8W9WFUHa1Fdo4mZQmvWthk1o3G0FkUSuENE/jS1Uo10sXc2Iy3q+852gYjcLyKhiExmQXmuiDwoIg+LyMeqK3Vy7Eu60XC02sQQxuxRZ619BWjHzaANcKuqvrNupRkNjbVrRlpUqDWLJGDUBGvbjLSos9amdOMRkQzwL8A5wEbgNhG5UlV/X48KWSfdaEhCMww2UqJeWlPVI+qTs9GsWLtmpEUFWrNIAkbNsLbNSIs6vrNV4sZzEvCwdx1DRL4PvASwTrrRGtiorJEWpjUjLUxrRlo0gtYskkDr0Ah6M1qDBtDaKmBDYn0jcHK9CrNOutFwKObHZKSDac1IC9OakRb11ppFEjCSWNtmpEUFWqu3G894n9nrZkcic3nCYRHZAayf7XoY47JGVZeOt0NErgGWTHLsTlU9tz7VmhmmtYZnXL2Z1ow6MFOtQYPpzbTW8MwZrYHprcGxdzYjLWZVayJyI/BhVb19nH3PAi5S1Rf49Y8DqOrfV1PmhHWZy510wzAMwzAMwzAMw5iKKTrpWeCPwFnAJuA24HWqen896mIh2AzDMAzDMAzDMIyWREReJiIbgWfh3Hh+6revFJGrAVS1ALwH+CnwAPDDenXQwb6kG4ZhGIZhGIZhGEbDYF/SDcMwDMMwDMMwDKNBsE66YRiGYRiGYRiGYTQI1kk3DMMwDMMwDMMwjAbBOumGYRiGYRiGYRiG0SBYJ90wDMMwDMMwDMMwGgTrpBuGYRiGYRiGYRhGg2CddMMwDMMwDMMwDMNoEKyTbhiGYRiGYRiGYRgNgnXSDcMwDMMwDMMwDKNBsE66YRiGYRiGYRiGYTQI1kk3DMMwDMMwDMMwjAbBOumGYRiGYRiGYRiG0SBYJ90wDMMwDMMwDMMwGgTrpBuGYRiGYRiGYRhGg2CddMMwDMMwDMMwDMNoEKyTbhiGYRiGYRiGYRgNgnXSDcMwDMMwDMMwDKNBsE66YRiGYRiGYRiGYTQI1kk3DMMwDMMwDMMwjAbBOumGYRiGYRiGYRiG0SBYJ90wDMMwDMMwDMMwGgTrpBuGYRiGYRiGYRhGg2CddMMwDMMwDMMwDMNoEKyTbhiGYRiGYRiGYRgNgnXSDcMwDMMwDMMwDKNBsE66YRiGYRiGYRiGYTQI1kk3DMMwDMMwDMMwjAbBOumGYRiGYRiGYRiG0SBYJ90wDMMwDMMwDMMwGgTrpBuGYRiGYRiGYRhGgzCtTrqIHC0ivxORPhF5X70qlSYi8riInD1FmotE5Ns1Ku9dIrJNRPpFZPEMjq9ZXaZZ7iG+zpk6lvEJEblkhseeISIba10nwzAMwzAMwzCMNJnul/SPADeqao+qfnmyhCJyqIioiGRnXr25hYjkgC8Az1fVeaq6a7brVCmq+oSvc7GOZfydqr69XvnXAxu4qkl5VQ1c+TymrHMjYbqpSXkz0k29BvRE5FQRebDW+c6EVtVXM1CvgfZqBrlrWIeW1F0jtGv1xNflsAaoR0vqq5VppOfqbDDdDvQa4Pv1qEgtEJFMPTuRNeAgoAO4f7YrYtSMaODq6VMlFJFDgceAnKoW6l2xZiAxcHWKqt492/VJEdNNFTSiblT1JuDo2a6Hx/SVoBXOUVX/brbrgOmuKqbTromIAkeq6sP1rpeqzqt3GRVi+kowW+coImcA31bVg+tdVoM9V1On4i/pIvJz4EzgK35U7SgReaEf1dovIhtE5KLEIb/0/+/16Z/l83mriDwgIntE5KcissZvFxH5oohsF5F9InKPiDxlijpdJiJfFZGrRWQAOHOKOiEibxSR9SKyS0Q+Wen5j8njFBG5RUT2isjdXrDRvrf48+sTkUdF5B1++1FANBq011/Pycp4sohcJyK7/ajqJ8ZJc8AXoeSonB/d/S8R+bavz73+d/u4v84bROT5iWNvFJG/F5Hf+t/gChFZ5PeVWUb4tH8jIr/yeV8rIksSeb0pcZ3/crqj0YnyLhSRJ0RkZ/L3EpFO//vvEZHfAyeOyWuliPxIRHaIyGPiR11FZJGIbBSRF/n1eSLysIi8abK6TcIaGnjQReronlAjWnXgynRTHTPSjbSOZZfpqwFpAf2Z7qqjVZ+HlWL6MloLVa34D7gReHti/QzgqbjO/tOAbcBL/b5DAQWyifQvBR4GjsV9xf8L4Ba/7wXAHcACQHyaFVPU5zJgH/AcX4eOKer0JKAfOA1ox41YFoCzpyjnItyoEcAqYBewzpdxjl9f6ve/EDjcn8PpwCDwjImuyQTl9QBbgA/5c+oBTh6nLmcAG8cc+3h0Pj7tsL+2WeCbuFG3TwI54E+Ax8b8vpuApwDdwI8SZZXV3ad9BDgK6PTrF4+5zs8F2oDPAflpXueovH/z+R8HjADH+v0XAzcBi4DVwH3RtfC/yx3Ap3z5hwGPAi/w+58PbAWW+fz/ezr3QaK+PweK/hr3+2vxQuB3wH5gA3BRIv0T/pz6/d+z/Pa3Ag8Ae4CfAmv8dgG+CGzH6fwe4CkV3BNfBa4GBoCzJ6uTP+aNwHqcjj+Z1FAlv5VfPwW4BdgL3A2ckdj3Fn9+ff53eIfffpSvY3RNfj5Jec8GdgKr/fpxvqxjxuq+0f9MN+npxqdX4M+Ah3Dt3xnARlz7uh3X1r4lkX4+rq3c4c/vL3BtSruv51MSaZcCQ7i25AwS7THwUVx72ocboD3L9FV3fZ0E3O7z3AZ8YSbnmNDNu71u+oC/wT3bf+3z/yHQNkV9Iq19FPfM+RbuHvih11gfrtNxQuKYY3HP071+34sT98pWIJNI+zLgnrH3Fu694dv+2u0FbgMOMt3NjXYN9xFMffp+4NXAQuAqXLu1xy8fnDim7DzG6OUa4D1jyrgbeHniXjjCL68Dfu/rvwn4cD11ZfpqrHYN1zcYAsJEuSt9HX+N0/wW4CtRPozfH7wReDtN8lydrb/p3iQ3kuikj7P/n4AvTvKj/B/wtsR6gOvErgGeB/wR17gFFdbnMuCbU6RJ1ulTwPfHiG20ghvkIuLG7KPAt8bs/ylw4QTHXg68f6JrMsExrwV+V0FdysTrtz1OeSf9usS+F/kbKuPXe3x9FiR+34sT6Z/kr09mbN192r9IpH03cE3iOn8vsa9rBtc5Ki/5kPkt8Bq//ChwbmLfnxJ30k8GnhiT98eB/0is/zNwL7AZWDzjG8gGriCFgSuf9jO4B3Un7gH6nsS+x6eqcyP9mW5S1Y0C1+EG9Dr9eRWAT+MGK9f5vBf69N8ErsC1j4finktv8/suBT6TyPvPiNu9M4jboKNxL2grE/U93PRVd339GnijX56HMxue9jkmdHMl0As8GTdIfD1u0Hc+rqNy4RT1ibT2WX8encSD5+twz9a/B2716XO+Tp/ADTA/D/cyerTf/whwTiL//wI+Ns699Q7gf3DP3gzwTKDXdDfn2rUjEuuLgVf437zHa+PyxP7HmbiT/ibgV4l9T8J1nNrHloXrgJ3qlxdGdU/jr4X11Yjt2ti+xzNx/besr9cDwAcmqWfpt6RJnquz8VdVCDYROVlEbvAmxfuAdwJLJjlkDfAlbya+F9iNuxlWqerPcSMv/wJsE5FviEhvBdXYMI06rUymV9UBXOM5HdYAF0Tn4M/jucAKX/55InKrN1Pfi2uoJ7sm47Ea9zCuBdsSy0PATo399of8/0l/o+T1XI97aZio/lsTy4OJfMZe50Gmf52nVYava8QaYOWY3+gTOFOyiG/gLAb+QyeYwE/chBX9/q8iEytVvVFV71XVUFXvAb6HexBPxDuAv1fVB9T5FP0dcLw4N5A87mF7DCA+zZYKqnGFqv7K12F4ijq9ErhKVX+pqiPAX+JGSKfDG4CrVfVqX8Z1uFHfdf6a/K+qPqKOXwDXAqdOswxwLxXzcYM1m3FtxZzAdFNX3YC7VrtVNWrz8sCnVTWvqlfjXpyO9uaKrwY+rqp9qvo48Hnc1w+A7+IGUSNe57eNpYh7CXuSiORU9XFVrVWbPm1aSF954AgRWaKq/ap66wzPMeKzqrpfVe/HWWtdq6qPquo+3EeHKX1jfb3/SlVHEvq72eu+iPu6fpzffgruGXexqo7696KriDX3vWhZRHpw98r3JrgOi3Edq6Kq3qGq+yuoa01pId0lSbNdK6Gqu1T1R6o6qKp9uEHtya51kp9Qrv3XAz/212AseVy71quqe1T1zmrrPlNaSF+N2K6V4duYW1W14J+bX6dy/TXlczUNqo2T/l3ciMxqVZ0PfA3X6QY3ajKWDTjTngWJv05VvQVAVb+sqs/Eje4cBfx5BXUYW85kddqC6wADICJduAfZdNiA+5KePIduVb1YRNpxJuKfw5mWLcCZwcgk+U1UxuEVpBvAjZoCJX+YpdMsayyrE8uH4BqHndPMYwtQmlBCRDqZ/nWupIyxdY3YgDPjT/5GPaq6ztcng2tAvgm8S0SOGK8AVb1J3Yz281T1yZVUygau6jZwharmcSPXTwE+r6rjtTFlSBw6sF9E+qdbZlqYbuqnG8+GMeu7tHyinWgAcAnuC2Zy0G897usYeEsOf23WAMf///bePM6Rs7z3/T5VWlq9THfP9OyLZzwe73jBZmwMxjaLYxscBxKCnZBAAodLLuSQ3Cxs9+Zw/Dkk5nJOEhJICMchCQFiuGEzYMBsNmPM4AXb2ON1PJ7x7Hvv3drqvX+8VSWpR91St6SS1Hq+n0/PaKmq963ST2/prXp+z4P9gVuCscmc/gh7YemIiNwhImtmLheVPjtIX+/A/nZ4WkQeFJE3LGQfi5aZeZF75vNqEmodNcZMz3ht5sXnLt+vvgbYa4wp/uFerL8vAm/yf2u8CfiFMaZYqwH/jo3wu0NEDojI/ys2KVkJIvLbRfr7ThX7Mi86SHcz9yGqcS1ERLpF5J/E5gIaxYbED0gVPml/Uv9t4Gb/pZuBL8yy+K/7fd4jIveKn2+qTH92FGmr5osQs7TRKfpqxXGtBLH5rr4lIod8/f0l1eu6Lc+rUVDrJL0POGGMmRaRrdirHwFHsVeIiss2fBr4oIicByAi/SLyZv/xy/wPKI6dfE5jr5rUs0//CbxBRF4pIglsuON8j8HngRtF5FdExBWRLrEJ3NZhf9wlsfueE5Hrsf7n+fItYJWI/JGIJEWkT0QuK7Pcs9iT++v94/Z/++3XwltF5FyxFzBuxfq15/s5/Cf2GF3hH+f/zvwvVFTiy1gtDfrH/g+L3nsAGBWR94tNMOeKyPkiEiSXC5Lw/T72gsrnqjmRVYleuGrMhStEZC3w34B/Af6Xv+05MYXSgb2mdTLUlkN10yDd+FS8oONzDHthsviuwwasBw5/8vRl7FX/38LeFRkr26AxXzTGvNLflsGGPM9cJip9doS+jDHPGWNuwXoZPwb8p4j0LGQf60i12gMbIbReRIp/lxTr70nspP16Zr/bhLERIv/dGHMuNp/HG7AhzTOX+0KR/q6fRz+rpSN0V2YfohrXivkTbDjwZcaYJdiQaoq2XXJTB1g1Y/3/AG7xJ90p4MflGjHGPGiMuQn7Hfs6djwst9x5RdratoD9qYaO0FcLjmvl2v1H4GlsxYEl2N/ZxdqDWfTXxufVhlPrJP3/BG4VkTGsDzn8shob4vxR4Kf+FZ3LjTFfwx7QO/wrLU9gTzZg/RH/G5voIEiq8D/r3KcdWK/DF7FflpPYpC5VY4zZC9yEFeBR7Bfiz7A++jHgv/ptnsSK7c757oC/nddhPeSHsAkerimz3Ah2f2/HnsQn5rs/Zfh37N3KQ1h/zbxrUfrH+Q+x5foOYj11R7Del3rx37E6eQEbLvbvRe3nscfuIv/9Y9hj1C8ilwD/F/C7/nIfw37RP1CnfumFqwZcuBIRweryn7FXlQ9iE54sFlQ3jbngOS/8MeHLwEf9i6OnYceL4hrIX8SGxP82s0ySxNbzfbX/o3wae3eimeVBO0JfIvJWEVnu/+gb9l/Oz3cfm8jPscf0z0UkLiJXY89lxaVvv4g9L78K6zs+BRG5RkRe4l98HsVeeGqG/jpCdzOIalw7TOmx68OOM8Niq/L8txnLPwrc7OvqUmzodTF3YSc+twJfMqXRHACISEJs9EW/sZFto+i4Np8+LZZx7TCwTET6i17rw+phXETOBv4geMMYcxQ7R3mr/534fU6NFm7H82rjMS1gjNe/1vijQmLAGrbbi02OsanZ+9joY4Y98e3BXpj4FjZ8qjjr663YgXWYQvKP38EmsQuygX7Wf/012ARp49gLDV8Aeiv051+B/zHjtUp9ehs2S2gt2WwvA+7FhlYdxYbObfDfew92UB/GXky5I+gj1SdTfJ9/LIJsoWv8doIENhX73Ep/qptodOMvayhNsHQ1cyfcHMT+0A4uwv4FM5KZYhPznKAoCy6lCW4uwEb0jPnLfQs/2Y3qq6H6+jz2gvA4NjP6ry1kH2fRzX3A24ue/w/g9gr9Kae1j8zYzxItY+/i3YtNSPUk8MYZ62/A/jD/9mzbxd6RegY72TgM/B1VfFdUd201rr0be7F6GPhN7DnxHv/4PIv1Jhfr6nTsRaBxvz9/V9xnf5l/9td52YzXDXAG9iLDd7E3oUaxVQNe2Whdqb5aa1zzl/ssheoRa7AXDZ/2+7jN79d9Rctfj71pNozN83IvM+YbtPh5tRl/4u+4oiAi92AHk9vrsK0bsRkjBfuFvAybBVQFpyiKoiiKoiiKMgu1hrs3HClNPlH899t1buc7s7TzocprL6i9K2dpr62THBRxE9ZfdwDYgi2dZqI+zoqiKIqiKIqiKO2E3klXlDZDbDm408q89X8YY2bLyLqQdr5D+dIwf2mM+ct6tVPU3pXY8h+nYNo8+UcroLpRGsli1VcV/fkQhWSkxWwzjUnGphSxWHWn41prsFj1VUV/dFxrAXSSriiKoiiKoiiKoigtQsuHuyuKoiiKoiiKoihKpxBrdgcaydDQkNm4cWOzu6GU4eGHHz5mjFle7r0lA+eaXHai3FsATE2++D1jzHUN69wCUK21NrPpTbWm1JuFag1aT2+qtdZmMWkNVG+tjP5mU6JisWmtFhb1JH3jxo089NBDze6GUgYR2TPbe/ncBOde/MFZ1334p38w1JBO1YBqrbWZTW+qNaXeLFRr0Hp6U621No3Umoh8FngDcMQYc36Z968GvoEtqwTwVWPMrZV7PTuqt9ZFf7MpUbHYtFYLi3qSrrQpIkjcbXYvlE5AtaZEhWpNiYr6aO1fsTWePzfHMtuMMW+otSGlzdGxTYmKDtOaTtKV1kNAHGl2L5ROQLWmRIVqTYmKOmjNGPMTEdlYnw4pixod25So6DCt6SRdaT2EjrpSpjQR1ZoSFao1JSqi09rLReQx4ADwp8aYHVE0qrQYOrYpUdFhWtNJutJyCIK4nXOlTGkeqjUlKlRrSlRUqbUhESk25X7GGPOZeTTzC+A0Y8y4iNwAfB3YMr+eKosBHduUqOg0rekkXWk9BJy4VgdUIkC1pkSFak2Jiuq0dswYc+lCmzDGjBY9vktE/kFEhowxxxa6TaVN0bFNiYoO01pHTtLz5n48Y3c97mytyzYN9wIgXFWX7TUF8+PKi+x7EtbbRK9ivNL3pPDFEeOVPC+m4jFaRJ6TQBdQP20sBq0VH5dG0klaC76/Rpy6asNwb1trrXhcmzlGlXt95ntl1/VyGCcWLlfVMa+D1pqRcbsc4Rjk5cB5TV2329Zaw98HL2cfO3P/xAp1ZjwQp7w+J05iepeVrtcC45qIrAIOG2OMiGwFHOB4vdsJtZbPgPu6Om74xyDX1G97TaDk98Ucv7mMcXCwmizW08x1ZPw49AzadYpfbwG9RYb3Q/KSwpUr6rpNoK5jZeSYH0Nmyj5OpMpqTdITZONDxBy7XM5LERdbLu2U+cGJfcjgGvte0TjZUVqrgo6cpCstTodlb1SaiGpNiQrNuK1ERR20JiL/AVyNDYvfB/w3IA5gjPk08BvAH4hIDpgCbjbGmJoaVdqTGvVWxcVHAT4B3ABMAm83xvxiwQ0q7UuH/WbTSbrScojQUZ4TpXmo1pSoqIfWNOO2Ug110totFd7/JPaCkdLh1EFv/8rcFx+vx+Y72AJcBvyj/7/SYXTabzadpCuth0hHeU6UJqJaU6KiOq3VmswLNOO2ouOaEiU16q2Ki483AZ/zIzW2i8iAiKw2xhxccKNKe9JhY1vnTNJzd4MbB8AFXEnXb9veD5Gsv73Ej2HiJADm5EFk/Xvq1069CDyaXg58L4gRB8ln7etuPPTI2Te9ghdlfSESaTb/U7i9Yl/nPL1fEmvfcJZG+q2Ltz2znVb1ckblPw+Y73FYNFrzv49iPKjDhebibXtmm922eHgmXl+/Xh0p8WimJ2b1ztmF/fGpzPtzjW3BOvY423Gt2sNdhdZqSuZFAzNu5839ADiSLbxY6ThVy8iX7P/9q8J2gLrnjqknM7Vmkj32deMUzqvGQcSzfmrAuInSbQTHbw4NSs+g3SbgyJVV96+dxzXwvf3Fv0Mq+Pvng3f3e3Fe9+sFv3sNv1WioERrUyOYVP+py5TzCIdjHBj894vyG8xcx/QuC9dpsfPoWmBv0fN9/mt1maR7Zlvo2TdODNfUcX4w/S0IxoZA08Hn0oIe9UBreS+J6xQdB3HC/QDCvBsAnthxTRIpYjIVvh5zpgq6K25DHFi2gbwJ5mTz+z3R7mPbfOicSbrSPnRYOIvSRFRrSlREoDXNuK0AOq4p0VJZb7VGCJXbuOY/6EQ6bGzTSbrSckiHJYZQmkc9tCYi12GT2rjA7caY22a8P2fSGxFxgYeA/Zrwa/ESxbgWVcZtpbXRc6gSJVXordYIoX3A+qLn67B2HqXD6LSxrXMm6bFr572KOfY5GDoNsGFDU/mlAKScY0ybpcT9MgMZb4iskwLAyWdxu+xysmYTmeyzAJxMn8Zgcg9CHoC8SZLzkgAMJZ5m2th1utyLF7qHVezQj0vKHiBOacin2KtTRhwbzllURka67NxBzI8LYXhzlPywKxaHkM2vq+1cYmEhYef1CAmf7zYaGR5f6/4IV0VXpq0GrfkT7E8Br8P+kHhQRO40xjxZtFilpDfvA54Clsy7/XKfYYXdKQ5dB8jkbQibIx6eH1abN0nAH8coU46Mx+22cIj74W2u5MLQNs84OOKF68acy+exV/Mj6z2AIzl/HwohnqYoNO8UjjyPWbEZ8LVWdEwqjmtgrUJgL8vMgzqUYGtaxu2yFocKu5PO25tnCXcifG08u4KYZMgae840xkG67XlPsvlwOYNLzkv4be/E4IQ2tZhkQq3lTQw3/PxzDT2HjmWfojd+JOx3GCKb7AlD0oPvVfj40HOYVdZxIFxFzttu98mpMqTWy+EY32Iwj19s7XwOBX9skyKJzXNcA8LPJHzuf2HldW+xI5MJXi9azmwr2cbM7YTbID8v+8F8mWkvCUPXu/pKSj8WM7MkpJFiy1K8ZHvlkFwaHH9Qa63fbHcC7xWRO7DnzpF6+tGLP0cJ/5mbnLe95DvsmXj5MSBZZE0w4BEP9eaYbaGebLOF+YHgEcOOm3UvCTeDYJx2JYfrSypmxsAr2HE8YqXfC98e68V6wuOXN/dbq0CgwzksKjI1ghtount+/W33sW0+dM4kXWkfOiwxhNJEatfaVmCnMWaX3ZzcgU1yUzxJnzXpjYisA14PfBT4v2rpiNLi1GFc04zbSlXoOVSJkhr1VsXFx7uwkWg7sdFov1djj5V2pcPGNp2kK61HjZ6TKmpuXg18A3jBf+mrxphbF9yg0r7U7qUrl9BmZmmYuZLe/C3w50Df/DqutB0d5qVTmohqTYmSGvVWxcVHA7RgFmYlcjpsbNNJutJyiIBbW/bGf2XumpsA29T/q1ShtUpeumoS2pRdRkSCC0kP+xeOlEVMHcY1RakK1ZoSJao3JSo6TWsdNUn/0V5bGu2MwS6G09YLES/yNgwkp1ndvZTJnPVbZpa8kqnJAQB64sc4Pr0BgGVd1ks3ll0Vrht4L9P5vrCsQE/8GK7v/+mJHePZk6vp8RMeLEnkyBnrSffM+aS9XgDWdN9POt/H9oPrABjqTjCUsts4OR1naZf1wKzuXhq2nTf3M5JZw9GplQCkYnBgPFgny6vX2xvGE7lNLF1KoZwagGslIL4PHayvySOG8csqOF6GKe8x+1j6SLr+nMX7PlJUwu0UFlyeR3Bq8JxUUXMzEip5qgM/cdQlygKqbbfY9xxVX8PSOA0/RrVpjeoS2sy2zG8Av+qXyuoClojI540xb51vJ/ZPjJKKnQCsNy5nksR8/27cmaI/cQYAI5mdxJ0BADJeD47kQh+cwQ09dQaHmJ9zw8UjZwqlo4q9wgA5seNhwplgOm8DAgoeYTsOmfyz4eOclwrHS0eyxJ1pu4xxSMUuDLc7nNkVepBFvLBv+XDctM+73BQJZyLsd+gvLePEDjx1ZvmWsA+Ge4N0HAhX4bENx/he49k8n34prfkpp2attQTbD41y2pKi8jt+mbSDE8LGJaMMda0FYO/EBDE5HYDpfDdJ137OwXEP1st4CXrj9tyccCZI+xrKm4J3cySdIOYIXTG7bl/8MEenVgOQdAnPs3FnisP5NJ5vw3fFMJG1j3sThm7/OwKwLFn4St6zb5jVvVZXMUdIuPY70RM7yvFpe17dP5bmrKUriYktpzbT2xtz/DJrxg2/UwDeivMLnnK5F5G4fxyq86cXl22rXj2LQ2veDM9uQPHxdeRK8ub+8NgE3utguXLrQ+mYUowdBwu+cxGvxIdePF4GPviZZL1UmLMo6GNA4DUPtl3sFQ/645k4jvjt+GX8iseioKQfbqKkfFxpvqCism1chcuPgx2cNeeGiSVLy9FVTfvrLfguzsxHkMn30LX3R/a9TX9M1nvAf8ch56XCfCjFBJ9ZQHjemeFZz3opHP+xK+nwdc9zcARy2Lwqgsd0/hF/uWx4Xixe35EcnomVlKscyz4FQNyZJuGMh+vEnSky/pxjIjdErz8TdCRb+P44pd8joCRPlRfrCY5CIR8EgFwD5of2+Rz5XYrLCHbiebRaOmqSrrQHIuDO7TmptZwHwMtF5DHsZOlPjTE75ttPpf2pQmuVeBDYIiKbgP3AzcBvzVhmtqQ3H/T/AgvGny5kgq60B3XQmqJUhWpNiRLVmxIVnaY1naQrrYdQ6UpZreU8fgGcZowZ9+9ifh2beVvpNCprbU6MMTkReS/wPWyu788aY3aIyLv99zXpjWKpUWuKUjWqNSVKVG9KVHSY1jpmkn73nhNcssqGRD5+VFjZY0PIvKLqNM+ddHhhZITjfhhdzBFW9/oh37KWVMwuO55dQTrfhePHSHrG4PmbOT6VpS9hnxhWsCplQ+ePZc8k5xnW9NhI2CNTa+mJ23CorJdiPGO3dYALSbnDnLPMbuPwZCFEr7cvF4awDmeGGc3YfqbzF/PC8BTp/ETYnyCsPuk67JuwudPGMjm83ngYUpP3EiRlDIB+dy95P2w1CG0Jwl4m8kP0xI4BMJ0fCI9XmkGSjJU93sJVbD88CsDG/gyeGQZgTfdA2eVL1xViDfScGGNGix7fJSL/ICJDxphjddl+laHZzQpzny+t3s+Z5dpmhsrPvW7tWjPG3IWdiBe/9umixxWT3hhj7gHumW/bO07Y7/yqnpEwLDfnGbrjLhN+OFvMEU6kp/011oXjVsKZwJVsOB44kgvD8XImiesVwtgDaw7Y8SEIlQPCMcmRXFFoaQ4Rj3S+UFUuCA92xCNvCqcezxTCBceyT4XrZL0BpvPdRcvZ/1OxaRLORNjvidxQeCbLeqkwdNgYh7gzzU/22TKar92woyS8NefvXxA6CPYqfXGoquCVljuSawA4md5NX/wIeWNDEKsp+9Xoca3RPDNsj8nmgQlGM4OALXkXc+z5YrDLZd94P0enJgHIeuD5Nom+hA1Zt+sIqRik/YjlTD7PZNZ+5gl3IPyc03mPVMx+XhPZHKmYQ86z2v30j6Z488vtBrpiwnTebvvwpINnMiT8OkL2PGg36JAPw+LzJs6ecfu5H5/KsjQVZyxjdZiKOYyk7TqT8ZXE/B+EmwZSZDyYytswzfHsSrrc8FRC0rXnwh/sWcKvnbEzfF3EC8+bXe5wQYMC054N7U+Jd0r4fDB+PXVykhXdttR9THaG1pW5aHetQRAWXlyGrzBOGArhxDlvOyKF3yvFYcaeiVO2JJtQYocxlFoUguUcJ1syZtgw9GzJ8+I2g20Uh7rb5baF7RT3wRi3xMZTGCOz4VhaHAYPfnix0+Vvonw4sUcMwePZYRv6fNZA0b4Wh8374ciB1mwJrSl/uXurLtPa7nrLm/tDy1NoL/CPecxJkzvtFQA45n6EgiWs+Jwp4pWEtRdbxxx825ev56AkpSOxgvWLXHhOcsQj5yVDHRnjFP0udxCb+J6YkymxXziSC8PihTxdbtG53deT6z8Otr0kfjC06Nrt+xZYPB49dh4AFw3tOMUGEIbmm0JpNvFyIIRziVPGtKB0qfMast4DxPN2bpOP3V91ibl219p86ZhJutI+iECsgeEsIrIKOGyMMSKyFXCA4w1rUGlZGq01RQlQrSlRoVpTokT1pkRFPbQmItcBn8BGP95ujLltluVeBmwH3mKM+c+aGl0gOklXWg8BqSGcpYqam78B/IGI5IAp4Gb/bqfSadSoNUWpGtWaEhWqNSVKVG9KVNQ+P3CBTwGvwyb1fVBE7jTGPFlmuY9hrYxNQyfpSsshIsRiC79SVkXNzU9iS7QpHU6tWlOUalGtKVGhWlOiRPWmREUdtLYV2GmM2eVv7w7gJuDJGcv9IfAV4GW1NFYri36S/p3dNor5yT0niTnLANix9yTLz14BQMJ1GElbn0TgPQv+d0U4NmlLXaTzBZ+3Zwwre/JM5awPY3g6G3rgzhiEpDsMwNLkLo5OnW3XweX0/nH2jK32e+bRl/D9GQJHJ+22jk8JY5kuzhi0no4NfYeZyA4B0Bs/QmrslwB0L/1tJrLWD3dw3CNvDKf123Ums3m6/b4+f3KS/WPWj9qbiPHgoS42+sttWvIMo5k1dv/cPuvt9Fkaf56M8T2tkgk9qIHvzj6+FDy/1EIujYmnSjxMl6+yPsOHjoxxSe4L9sXud5/yGc1EAMdtz6uyre7fXggzPd+t1IdAbwst1dbOWnthbJonDvtlVZYPcmzSeszW9nXhGUMmb8eUk9P58LFnise5OD3xLvqTdowTvNCPNp1PhB7dvsQgXa5dJm/ipGLDYZmsuDNF2veMTuUHcHx/3GByD4JH1vem2bat7y3nxcLybjmTxLfkEXem6Iufg2esnzfj9ZDwy1oVezwT7gQn02tCLzQQeqR74uNkMrY0zEByLxmvh8vXHPP7XuyrL/KpzvCjJt1LQw9psQe1eGxbmtzI8bQblrXpqsIi185a++XxCR7dPwLAdVtc4o4NPOpyR3H9z8iVPmJO6hQ/riXHdM5+/p4xTGSFrG8+T8WcUJNgz192e9YvDvY8nTeQ9ezn9sbLNjDtn39H0y5LknadoZRLOg9jGfv88ESalT32cx9Ou4xmVoV9OG9pMmxv7+g065dYn29XzKHbt2imYuMcmbQa7ku4uGI4OLHcfw4rcvcBcCh2FeNZ+5ti6xo39K3nvBRJZyzUm/UdF7zVvbHz/NfvR7JThbJGRSW7zhnsZscJe6yWdqXpL1Rkm5V21lqhrJlr/dFBRcWislbFnt/gefHjkvJXM3LsBK95Jh7mrxjLrA5/28SKS2GZeEnZNZE8Ttp+D/LJpWGJwOLPFzilLFfgt7Xe5/LeXtdMkacwXs4sOen85Mu2T1e9sey+Fj8O/j9zICgXdlWYTwPuJZO3Oku4EyXjmitX4OGPfV6caudC7aq3oBwegJu3Y7mJ2eMdlvIsQsQL64WF5fL8aZQxTvi5F5cycySLY/ySeUFJsuMv2u0Nbil8fuKEeRIEm6OiONdBcB7yTDzM6WKMG+aEyZsY47mVYWnJdP6hsD/F3w8RDzc/Ts4p5IsJxuy8SYalTUdueR8Xf+l/+W3GfH3ZwSfvJUv2Nczb4sQQCno33IuMHLKP+1eB85qiNreSw5a9y3lJ3Cpt5lVorVL1p7XA3qLn+7BVdwptiKwF3gi8Gp2kK8oMpLMSQyhNRLWmRIVqTYkK1ZoSJao3JSoqa61S9adyM/yZdte/Bd5vjMmLNPfik07SlZZDUH+TEg2qNSUqVGtKVNRDayLyWeANwBFjzPll3hds8qUbsKUl326M+UVNjSptiY5tSlTUQWv7gPVFz9cBB2Yscylwhz9BHwJuEJGcMebrtTS8EHSSrrQemilUiQrVmhIVqjUlKuqjtX/F5m753CzvXw9s8f8uA/6RGWGjSoegY5sSFbVr7UFgi4hsAvYDNwO/VbyAMWZT2JzIvwLfasYEHTpgkn54xPqxN65ZEvrG+3oS5P3gholsnhO+7239ki5G0jmWd1vfRSbvkfN9c0uSblhT/fhUll3DU/Ql7OHLeobjE9YXsvNIluX9QY3A80n63omEm2XLYJy4fwVoSSIX+jpP602yaq3tz/6JUV4YibG2x/oyd46czkuWWXuFcBUsLdRIXdtjPSXffvJFVi/r5oHdtubgOy9ZH9a0zeUNu47ZmoxrBlJM5zyePGa9N0cnN4V+vZPp88h5QU1F4dn00rCWfM4r+FtXdg9zMm23vaU/VfCYOOVjSAAuXdEHWC/6px/Yw/nrBmZZ0iICjl6VbQjF/rO5/Nsz66PO5vlutF+9uOZ5dXXPq9u/cPk21tpIOsempYU64jGncOKazOZJ+4PcslSck9PWP9YTd8Pv+UTWwxEhne8KtxfUqI45eUb9XB2T2Xzo/024hsGuJSztsmNKziRDT5xQqC07nl3BitRKUv4Z5uDkibBvCXci9MD1xo+c8rkGdaDT+cPhoHJ0qpfzllof5fH0XhyRsK0T03mGp+047xmXlT2B53M9cWcq9PVN5/pDL3xP7BhZY8fpTL4nrFubye9maXJjiSd4NgLvH8BzI1Ph+WU22llrmbzHZRus719kmOF0cIx7SRbtd87L4fi+xZgj4fkz4TqMZTLhcjFHQq15xoTb6E0YBnx/uYdLVywRLnNyOkd/0goqnffIeXa5kXSO85b2h9u+/+BImGfm508d4ZKzrIf8DafvKDuGnDPYzY+eORI+T7gOV/vnqP0TGQa7gnfyNm9CosfvA7zo3mCPiVfwGec8l71jm8JtDXXtI+vXP856KVKxYQBOpqfZ1Gc37soVEKeMC9YSaB96+OauY+FvlNmoh9aMMT8RkY1zLHIT8Dm/Msp2ERkQkdXGmIM1tUshlNWTwn4W1w4X8UrqQ5f22ympXV3sRQ98xsFrec/+/umJHQuXKa6RLeKdkrOCrjcAtnaTMdtL+lfwrntltebKFSU+aOs1tmONkXvDoFtjnFP87t6rfjPYiZK+el6hVnuwrF3fLTpG28J2hKtIzhEtHCznSKlney7aeWwL8Fw/H4A5NXdE8ec/M7dBMcU+9eK8J4GOHcnhShqWbbDrGy8cG2JS+MwdyeHgldQOz3nb/e45jOdW+uukSSZsbqoYl5d8rkn30nCdrJcKz3GuXIHnbgv76kjO5n4AHCcWvr70jr8hqHnkSA5n3yPk117i77dXekyCqaSBvNlOzLncX+4q6A+O1akEy8WK9q8StWrNGJMTkfdis7a7wGeNMTtE5N3++59e8MYbwKKfpCvth2YKVaJCtaZEhWpNiYqItFYuAdNaoKZJutJ+6NimREU9tGaMuQu4a8ZrZSfnxpi319RYjegkXWlJxNEBX4kG1ZoSFbVqTX3CSrVUobVKWZArNlHmtZkJmJQOQc+jSlR0ktYW9SR9uihErzgUcfNAHs/YUI2cSbKqx4ZKZj1Dwk2E5WUMThiy4ko2DNHcsMSGSB2ZtIfPmzIcOTkJ2FD6IMTvopW9YQmZZak4jx+dZKArCBGJkXBPPZ9N5xOs7oXu2EsAuGAZUCHMN5v36E/GuPGSQvjlWQOp8P9bv/s0ABNTWfq6E1y5aSkAXe4kR6fs/g2lsuH+9MQd1vTG2XnS7u/6JV1hSTfPxOiJ2/DWg5NTrO5eOmffZnLpxsrLi0gb+pvGml6mrBaqCSWfbZ35hpgvBMO9C+pjJdpRazmT4Xh6L8tSS+nyywZlvRTr++zjvJcg66XojdsQ3vHsCk7vt+GcMWcqLL+TN0lSsRM4/hi3KuWRMzYsbyy7mpRfimYsk2dZyr4+kc2zJOmXTsOG9o7nbMhuwnXCsXN4ymVFoZqQH3Zqx5fiMHE4Z9b9zJs4Mb9EUiHc166/LAk/2T8cvrbED4PuS7jh+DSV62Ii28WEX9IrFXMY7LL9zni9uH5JG0dyTOXsuDSZW8pIphCGPB8CO9Rs1Elr/0qEPuGJbJ7th0aZznlhmbTh9AADfjU7g8PhCRvG3pdwiTlOkW3KCUs4nZzOhuvnPFvONCiTNpnNh+Huk1mHkXSwvkfM19MzRydYvSTJCyfseXZJKkbKz/DbmyiN3d07PM3KPtvBj1xfrK/Zx49czuPb9+8B4BO3XBy+HljKAA5NBd+htL/vKRu6itVQEMY+ll3JRNbuw1TOYyyzipXdQZm6LFO5AQASToZfHLUhtS9d3jtr32bSE3c5OZ2dc5kqtVYpC3IlqknANE/GTwk1z3mBfaJgl3DTJ/CSNo52ZsgxUvqaSOFxEBpf3EbwfGZptGDbBjdcL+clZg0VF66imkTQxSXhXOeKotevIqgslef+Uy53FPc1wDOxsGSWSy4s11ZcQg5seS5XbDhxEGJcDcVtzblPbXgeNUyE5yQA8UPNg5DzoKRi/9TDpHs3h8u5QVkzHPImRdaz54q4Mx0u45lYGC4fo/B55EwcY5zwM7NlRm0Y+lS+n5Q7Eq6f85IUH9IgLD7uTM04h57BbASl2rImRUouDF935EqCiHHDveCV2iTCY1L0nfDWXRzqIeclQ3udS/qUdrPeA35ft87at5mUK3lXjnbUWi0s6km60qYIGjqlRINqTYmKOmitWT5hpc2IZly7E3iviNyBvRA0ojrrUPQ8qkRFh2lNJ+lKyyHY5HWK0mhUa0pUVKm1WkOQ1Ses1GVcE5H/AK7GanIf8N+AOIT+zbuwtoqdWGvF79XUoNK26HlUiYpO05pO0pWWQ0SId9CVMqV5qNaUqKhSa7WGIKtPWKnLuGaMuaXC+wZ4T02NKIsCPY8qUdFpWlvUk3RHhIPj1i8x0BWnx/dVG5zQX+6YHF2uLWEQd6bocguHxJV06IOKSbpQKsFM4Zk4mbz1qw11J3j5GUMA7BmZCtf/l5/s4s+utb+ZfvTiEMdH0xzyvXcbl3WHZWI2Lyn4H3Oe4a7HD/DHVxY8MJV4z+Ub53w/8EpOp3OcHE3zXL9t75Vr97MyNQzAeG4lu7Mrw3WOT3l0xYJyJYR9Hcv00ud7AEfSOVYXKkBVxaUr+kq8pLPR7uU8FiuN8IU3imrLw7Wf1mz5saQzzrQ/BiWdcfKhd3OKhDsRet2WdT0fjnfpfF/oY4cxWzbN94LlZ5wOlqcO+v9bDxpAKraU50+mOX/IbnvCDIX5KiazeTxjj2WQiyPAIR+WPKuWSvkunj1k92Ptsu6wRFzSTbKux3qLV6YmSOf7ePqkLYc1lfM4OWz750icrpgdB3OeYdj3+PYmpumKuWzqm1dX2dKf4rmisX82ItBanX3CEt61CMqHnpzOsSxlva6p2BRre31vojNZsuaRyVSYnyUVc8LtxBwh6cKEL5HjU9nw81uaivPTZ20uhUTcpcdv5+iJSX68/SR9/rlr1bJuzvbzzcz0pDuO8A9feASAq99/TVV7+b5Xnl5xGc/Y8kRBPgbBY8+o8Y+J4dyhNeGym/ptycHx7Aqmc4XvWM4kw+9SkBNhvrx6/SB37zlRcbn2G9csM73hwW+wYp+56eorKTdWsp4pLctWrlRbcQk3+55T4r8O/d8zyrs5M/oWLHeKL34OikuczUXBVx7z27DP905cxMa+nwO2hFwS62PO0h96nR288HFAtZ7fYgL/ejXlsdpVb+VwJEd3zH7Hcn2nERd/vjBxlPGuswCrO1dyRX7zRLhc3nSFn9eU1x/61Y9Pb0bEK8kXEywXc9Kh3lLucJj7IiD4/CZyQ/TPXYExJOle6v8/93LGTQSNhN+DqXw/3bGTdt+8BAaXpD9XijlTYfnC4pKF5Z5XS+BfD/zsc7GYtFaJRT1JV9oTEYhVqDk89/qaAVmpjlq1pijVEpHW1Ces6LimRIrqTYmKTtOaTtKVlqTGK2X/SoQZkJX2ppOuyirNpVatqU9YqRYd15QoUb0pUdFJWlvUk/S8ZxjL2DDtiWye42M2fOTaLT0cnbIlT1Z0jzKSWRuuszL1JF3eYfvEjZPFxj3Gs8cgbsM7jBNj7/hWzl22C4CR9HpSfmjMS5fvxfFsaMsb12fBD1F52erVfOnAKP29dhsHR9NlhXbWQIqz5hHqXg1BGZrPPPginpfmqz/aCcD5bzmTmNgyEzFnivVLrBxikqYvcZD94zYEsLh8zmQ2x5EJexy/vf1FLvrNi+bdn1etHZjzfREh7i78S6gZkKujISXN/G22Sjm6SvtYq9aagTEO6Xwfo5lYWFry6GQPG/ps2GPG66U3fjgMX8/nk2Q8W8Ks2z1xSthjoYQPZLEh6YOJPRydPhOAoa6d9MRs+an+xH5WpOJhqTYRj4E7/x8ADt3wdxycsMcyky8NC12RWkm9eadfcvKzj+zjgrW2HNNIOsdI1o7nifw4Xe4Yp/fb0MKx7EpSfrje0anBsDRbJu+FoaeT2erDVmeypX/ucP56aK1ZPuFM3gstDBPZfGiFGknHWN5t92k621uy3EtX7GLSL23nSDYMFc56KT/E01o1zhjsDkuK9cRd3nCBDRtPuE6oo6f7kjz66EHWrLbrHDk5xfJB67Uancpy6YqCP+HNZ63gze9fUe9DwJruAZ46OclE1oZfe8b+2ceGF4b9kFgRliRtKP6GvmPAELtHJNynyaw9fx6fyobHkXmUYAO49rS5rSDtOK4FzAyVLS4n5vgWgeJl8iaJK+nwNYNbPsTdL6cGsHvspazufo4udxgg3G7QThjy+54P0f0P/6MQUk/puObKFTQCV64IQ8wdyYVWC4AliaPkgnJcMkFe7NjukAvLiNlteAWLppM+pe/zoVLZtnbVW1AmLeuliPnlFO35sDA1yptYeM4cjr+Ufte6h4IQ8LivnayXCse4mGTC8+8XHunmhnM3Avb86Trp8POLSZrj03bs+u3r7uAHP7nBtunEw/4EBGWZ641wFZ7ZBvjaL9LQWHYVYO1unomxNBmUnMyG3xnPxEu+bwsJdS+mUtm2dtXaQlnUk3SlPREafqVMMyArQCRaUxRAtaZEh2pNiRLVmxIVnaY1naQrLUcVnpNayxRpBmQF6Dx/k9I8VGtKVKjWlChRvSlR0Wla00m60pJUuFJWa5miOmdAVtqZTroqqzQX1ZoSFao1JUpUb0pUdJLWFvUk3TOwc5/1aS4f7GbdoPWB/GjXFGv67Y3TJ4+6jIxbz2I6m2fL6tO4dsOw3UA+Szx7yD7u6iNrrPfnwPiFLE3uopf9AKS6R3BNUH7HIe/Y5dz4VOhp/8J9R3nhxWG2nG69ZL9/8bqG7fdsPLd3mKsvXsvvvdx6+ZLuQU6mNwKQwGUwuRuAXx5dx3nLkvQlAk9Mkk/f/QwAf1PkQX/thrl9ceX4m23P85LTBudcJoI6iB2VAbmdyqYVU2u/q/HFt2PNTc84TOcT7BqeCMtibR7s5vi0/T52xz2ePL4hLJM1ks6FfvW++EE8E/e3Ews9i2C9d0GpGGMc1vXYYJWZZYiOp08Py9Ok3GFevO7Ttp2pHJeumJ+3th7sPjDKa7csA2AwuZuMZ/tgcPFwSLm2rwlnIvQgingcm7JlMw+OT3Dj6UM19eHzTxzksvUDcy7TjloTgYQblF4r+MYfetGW5tk41MNzx6xHe7A7zo4XT7LR9413ucO4vq8y7S0JtbZn1HrX1y+xxyKTd7hg+T7Alo4KvLN5YuH5aXw6x9aXrWPfkXEAcjmP372gUPIsSvqThZ9NQYnXVMwh7fvnB7viYSnWld19TOc89py0z0+MTlcsmVqJH7x4Iix7OBvtqDUAg5R4YoVCOadib3Cxv9qVdEnZtuJ1cl4iLD9ZzOa+n4HxyPs5OBzJcmDiYsDmJQr8trG//xuMmaroyW4knomFvnSAJfGD5P0x3JUYrmfLYXpOFyKl3uBU7MKa2g7KYVXys7er3grl7fLk/ccGl7SXIumXMHUlF77XHTsZaiPppNkzcQUbem3ugOAzCXD8Y/a2lw6TdF8ErG896YzxyxHru17Xe5SNfXaO8dOfvgJHbO6XoHRa1BiccJzOeikSrj0GmXwPffFDHJi0elrd/Xghl43kwthUV64oH6daBUEOhkqlAttVawtlUU/SlfakDiXYNAOyUhWdFjqlNA/VmhIVqjUlSurwm+06bFlcF7jdGHPbjPevBr4BvOC/9FVjzK0LblBpWzptbNNJutKS1BLO0qwMyEp70kmhU0pzUa0pUaFaU6JkoXoTERf4FPA6rBXxQRG50xjz5IxFtxlj3lBbL5XFQCeNbTpJV1oOEemoK2VK86iH1qq4CyD++zdgIzfeboz5hYisBz4HrAI8bALET9TUGaVl0XFNiQrVmhIlNeptK7DTGLPL39Yd2DK5MyfpitJxY9uinqT3xB3+5KozTnn97+9/gYeftLXQ3/Kq07n6tKA2boy8KfLeOC7EuwAw4nBk8mwATot9H2I9+KUBcaePQdL60J8avoxNS6x/++69Z7HRr517w4WGe1Lx0I9263efZt1K652Myp8+cmKKvoRLztha7btOrGNtr/XXuJLlF4eDevGGbzzdza791qbd1x0v8aLXwlVnr2R1T2bOZdqzxEJfWQ91s+uFC1eV9KFd/OlR9bNWrVV5F+B6YIv/dxnwj/7/OeBP/Al7H/CwiHy/zB2EEpKusHlJF5uXdJW8/s1d1s+2vDvBhiUefXHr813TXfi+eSZOzkuEj/MmRkzs+yl3JPTeJdxxHM/60/NOT1ENYoeUOxz68vImhiP2+F001MtXnrP5PU7rT5XUrm4kfd1xpqzVnP5EwReYzveRcMYZyRZyRE7nrV/60EQu9KfX6kcHeNm6AZZ2HZtzmXYc17pjDhcN9cKMQ/Qf41YzI+kc5/vnsZjjsPa8ZLhM1kuRNfb8l/MSTOdsLfs9I1O85rTx0K+ecCZC7+N4dgUPH14NwNnLcjxz3C6zaWk3q5d0Mehr/ncvWMNP9g/77QpXrO6v966XZe/oNANdVmMbl0zSNWD3/bkTGTb22749cWScrrj9vvz4hQmOD0/R32ePS61+dICumMuyVGLOZdpRawBCzyl1ktN5mxvD9b+vANNeHynX5tmwddG9kjrpweO4MxXm1DDGwXX8PDvTE5iuPoxXGNdWdz92Sn8S7kRJzXKoXDO8XgTeXM84CA5xbxiArDMQ+uw9E8c4hf0rpp79LPb8l32finqbqyJPuZK4l5XZxstF5DFskt8/NcbsqNTvuSinNYDp/CMknYnQc308fSaDiT2A/UyKz4Vrux8h7yX97eVLcryk/LwtHNtDfumZAORNkrQHW/p3ArZ+fdCOI17YH89sw+Baj3cEBHlqsl6KhO/F7848z7i7BYD+hP14Vnc/Dti66TH/u2RwiEntWgt+e1SiXce2hbKoJ+lKeyIC8Q66UqY0jzporZq7ADcBn/NtFttFZEBEVvvJCg8CGGPGROQp7A8WvYOwCNFxTYkK1ZoSJVXoba6KPNWUxP0FcJoxZlxEbgC+jr3orXQYnTa26SRdaUGko66UKc2kotbmugMA1d0FKLfMWvwJOoCIbAQuBn5eddeVNkPHNSUqVGtKlNSkt4olcY0xo0WP7xKRfxCRIWPM3OFLyiKks8a2xT1J907C6P9nHxsPHLu7f3jFr5csdmjKhu6t4n7ITJHvsuOFaybwXL8cQT6F54dN/eDIFbx2zUOQteGgiMOR9PkA/P2dO+jxQ9s2rhnj/OU2BC6TdzlwdCJsM5V0yeXmDiGqN59552V8+Js7uPg6exXq2aMDXLLCJssczqxn/4jdn4mpLIeOT7JhlQ1X3Xd4vG59eOnyXo5Oz13tzGZvbLcv4VjZ0PaZYdvNDn+Piplh9q3ahyq0NtcdANvMqcy8CzDnMiLSC3wF+KPiHyOzYZhkOv8IrmTDkO2sl+LG0y8uWW4k45dziR0Ly5IVlyTKGw/HZMn79peR7FqWxZ6279HD3mkbaveh23/B377bjomjmeV4BlZ2P+/33eOFYbu903qTZLJ2TNs/Nh1ZuPufXbOFXx6f8PcpxmTOlqJLucNkvRQ7h+0Y3BVzOTZZKMc0kbV+pXr086yBFGPZucfJdhzXPDPNWPYpv3yd/WzHsiu45dyNpyy7ZzzN2u7HGM2uAmAiN8SSuC0v5FIIVX752gESzgSeH86bePpu0mdfD8CDh1bxmTseBeD3f/OCsNTYslScTN7j6QPZcDtB2HmUh/Ta05by7ReOA3B6f45M3vZvbV8Xhyds+OfYZIbuAT/MP+9x5rp+ct7MIWHhvHJNPwcnT8y5TDtqzTKOZ7aFzwwuSffUkN+U3B9abjwTxzPx8DkGHMc+NsZBfF9i1qQIKom9kN7KW676Fx742UvDdgKC5YP1i0fvSmHf9SQIfQ5C7fOuX97SUBJyXak8Wj36UPyZlKNGvT0IbBGRTcB+4Gbgt0q3L6uAw8YYIyJbAQc4vtAGLaVaC86DXW5pCPzyrgdCa45n4jwzfAkAZw8+iEMWJxzbUqElI8YEWc+eV2IinMycBtjPbTC5h5gfUm6Mw2zzzWIdNpqCNWJ7qPF8agVxL/itkMSRHOLva7myhrUSlJ0rtpaUox5jWxV5hH4beL//dBz4A2PMqX6YCFjck3SlbemgC2VKk6lRaxXvAsy1jIjEsRP0LxhjvlpTT5SWR8c1JSpUa0qULFRvxpiciLwX+B520vRZY8wOEXm3//6ngd8A/kBEcsAUcLNvH1M6kFrGtirzCL0AXGWMOSki1wOfoXyehIajk3Sl5RBsEiJFaTR10FrFuwDAncB7fb/6ZcCIMeagn/X9n4GnjDF/XUsnlNZHxzUlKlRrSpTUqjdjzF3AXTNe+3TR408Cn1xwA8qioQ5jW8U8QsaY+4uW3469sdIUdJKutBwiENfbAEoE1Kq1Ku8C3IUtv7YTW4Lt9/zVXwH8DvC4iDzqv/Yh/weLssjQcU2JinporYqQ0KuBb2DvOgF81Rhza02NKm2Jjm1KVNRBa9VWEwh4B/CdWhqshcU9SXdi0O2XZslOh570kpJU+QyrYoH3IwHJHty87y1046HfJMlJVqds+YGB1f18bffFXLTSek6mcx6f+pa9CPPYt57lz2+7FoDDJ6Z46pj1soxM5/jojeeF7f7ZNc1JTPnRG88L/WxPvXCQ45s3A3Bospfu5CQAz704zMR0lkeftMfh7377kprb/cGLts1r1j/N8lhlj/tiGe+b5csu9sI3q+xa0O58jkE9+jrfY16r1qq4C2CA95RZ7z7K+9XnRMiTdEf9bfi+Xmf8lP3u88tAiXjh8tO5AXzbOAl3wnri/LKTjuR4ceqVAKxIPc3yrmcB+Mt3vpRjU3ZbXTFhLJPjxPTpAJyYznP1ut6wzVvOXTXf3akLFyyzJTCHM4eZzPp9dR3GsqvxjM21sWdkin1H7NiTyebLluecL4emrO9/ILGXnkU4rjmSpTd+BGOc0LfbnziAYU+4TKDBtd3WFzyYtO+NZtaS8eznknTHwjJrXfkxAPaMbgRg5ea3sfOoPZd2xQzXvtZ+Lqf1p8h5VpsT2TxxR3j31tPCdoPPPGpev2kZAMem93Pv8/bzv+aMoTDHwWBfksmMfbysL0nOM3Up8wewf2KUweQeVqTGKi4bQUgowDZjzBsW3tJMTInvW/DKjufF++ZINvSlA7ikw/JlUPCRx50pXOzvsTP6H+CBn700fE/IF0q1FfnTA69uVGXXyhFzLidv7g+/Z/aYFPYveL24hFXg762FvLk/9EVX48Vvt7FtptYCbczUmytOuJwrac4ceNQuZxwccnj+NMqRbMHPbVLh3GGq/yIGncJ4WbycRzzMKVBcbs2RK+u2l/Mh5lwe+vQ9Eyfm2HxdXj4+q0e+Ht+N4twArlOz1iol+60mj5BdUOQa7CT9lRU71SAW9yRdaUsE0VA9JRJUa0pU1ENrendTqYY6aK2a0pKKAuh5VImOKrRWKdlvNXmEEJELgNuB640xNSYpXDg6SVdaDpF2vCqrtCOqNSUqatVa8+5uKu1GHca1akNCXy4ij2F/5P6pMWZHTa0qbYmeR5WoqIPWqqkmsAH4KvA7xphna2qtRhb9JN3EbFkFgv9nvu8mED+8woiDeIVSMaQnMF02DM84XcQyNmTbdXt49YYRjkzZMM/dI1MsXdoNwOA5Q9z/uC07s2X9AIf8smaZbHTlFCrh+qVKDh8c42cHVgAQc6ZZ2WOP0V9cdzaTf34d/2X1h+rW5mvXPQKAkVjhM5mDmI74HUErlGprZ63NFYZY7r2u2DB5r/D9Kw7tdCUbhrgPZ9ZzaMKWLrv9O09xzhYbrnvlluVM5zx2jNlxbTKb56KhQrh7s3ElzVjGjuEj6V76Enk29dvP95VrlnNfdwKA6Vx9xuOVqfnNSWrUWtPubop4s5Z6CnTmkC3RXF/8IFnPliIT8mGJo5xJMp3rZ1WPPZ9O5payvNvqcP/YNP299jN6+vg4a/usBmOOMBVxydJKxJ0pnt9nQ2RTyRgD3Tbcenl3gleusTa7b+46hiP1G1/W9DxS9bJVaG2usNBqQkJ/AZxmjBkXkRuArwNN8fE5ki2UJZPyd9kcKZSbxNiylUHZtpiTCde3b9vHrVLFTsiHYdWeccJyiIIXhhtPZp+l2527NN98CEvaVUk7n0dh9nPpzNeD42KMY+cM/rjomXh4bg1KowJ0ucPh47BcIPM7ts0gZ5KIsefJwvfEau1EendYXrMezLe0YS1aqzKP0F8Ay4B/sPl9yVW4O98wFv0kXWk/BGr+YaNhoUo11ENrilINVWptromT3t1UqqJKrc0VFloxJNQYM1r0+C4R+QcRGTLGHFtAl5U2Rs+jSlTUQ2tV5BF6J/DOmhqpEzpJV1oOEanpSpmGhSrVUqvWFKVaqtTaXBOntrq7qTSPOoxr1YSErgIOG2OMiGwFHKBp3k2leeh5VImKTtOaTtKVlqTGK2Wa9EapGr0DoERFjVrTu5tK1dSitSpDQn8D+AMRyQFTwM1+JQulA9HzqBIVnaQ1naQXYYxjy7T5pdqKfeyOXMmL2Sn7cj7N7hGhN2F9FEnXIev75Zav6qWny3rT+roTjE3aEgbvvKT4t1VzWZFaCcDt71rJr936fQB+55YLefqw9Zn+01cf51/+3+9y6bbnAbjlf93LxjNs2Zm/uun8BbVpnOqlJtTsb2rrsNBafdrNKrk2G3OVYjPcW/J+SXnECPajDlpreYxxSjxfrpMuPJYrmMoXZD+Ztd5zz8TCE+HmjYM88NA+APp7k5y+rDtc/te3rGho3+dLX/wcLvW79PknDrJxaTeHJ+y84Q//5gd89f9+LQBf23mUv/HHt/M2DHLtaUsb3rc6aK2l726KeNZv6fsXRbyw7JoxDnFnKwDH08fIewl2j1od9cQh4drPaOeR8fD8OdgbZ3jabqs77nLF6v4odqNq+hNn8NEb7eObP34P111rAxbigyluf9ieft55yXr+v2eO8KntuwHrXf/9i9c1vG/1GNeqCAn9JPDJmhqpI6Wl2/xzh9xb4jUPCMbEoGybZ0o9sYFWWwVHrgyTZU3nHyFvbA4HV7JM5mxp4CXxl5DOW6dMLv+IX6ozGhttJ5xHZ1Io3xf8Trk/9KfbkpVBXoNCPo7Aqx48L84p0CoE5d+6XBjLPgVATDLEnDQ5bzsAS5OXk87b6775/ENhbpsu9+KG96/TtKaTdKUlqZCwpR51EDUsVAFaJzmQsvipRWt6d1OZDzquKVGielOiopO0ppN0peUQoeF1EDUsVIGqtKYodaEeWmu3u5tKc9BxTYkS1ZsSFZ2mNZ2kKy2HoElvlGiog9YUpSpUa0pUqNaUKFG9KVHRaVpb3JN0Lw/D9gaq9A1h3MScixtcnNwUBP6kfA6CuundsKHX1nx9flRYljJse97edH3HJbvY/sxq2+SaJfT1WJ/TCwdH+MCrzwTgff/xCL/45tNs++Itdd3FWsmmbR3E79+3m5ecY82cA0M9vPItX+S+L9l57Z8dnSCZcGfdRlXsedT+n8nA0lVzLytQy3dwMYSFzuXjns86reZPL0fQ36bUTK9Ra81BfM+bW1Ut24zXS8IZt2uKV6gnjIsr0Bs7D4Dj6b1hXev948LLVlpHyUO9m1l32iAAJ0en2QW89Xw73r3tk/fxzHd2ArD922+v2x7Wg137RkjGXRIx+wE7jsM7Pv0zAP753S/n1p32mtzuI+OwQE96LqwD7lX+LNpQawaHnJfCM07oL591WeOQzveV1AUOvIo2x4F9bVVqiIOTJwB7ntw9Ms0Nm54A4OfxM/H8YTjhOuwdtnlgbjl3Fd/cdYyjIzZvShS+7vngeYYfb7PVPN90/Vms9fM2fOQ7T/GR68/h7++37yXitZ1HRzNrcSRLwpn7s2hHrQUE41Ol2smzLWf95vaxPadsA2yN6sAnHHOmyOULOYfyvjcdrK828Hl7OOH42CoU5xjxTKFO92Tucbpjl4aPa/38vaJjIuTnXrgt9SbhPlYau8tprfCafe7KFeS5H4CclyjUshcvNFsWciHYdZPuVvLm/nCbrlxR4z7VF9f30GdNihjpcP/T+YfCfAfp/EO4VfwOmYtMvueUNmelLbW2cBb3JF1pSwSDK7XNlzUsVKmGemhNUapBtaZEhWpNiRLVmxIVnaY1naQrLUmlq+iKUi9Ua0pUqNaUqFCtKVGielOiopO0trgn6dlpmBgGwBzei/dLWybbG0njnr8RAFmzhm/mbAj6RStTpNxhhjJ++MmSN5fd7MHxNGctnSwqq7ae7ffdDcCv3ngOh45PApDJFkKEensTnPmqjfXbtzrx7Y9ed8prHzz8BFe99cLw+cffdEHN7Xw9a0Pnf/LIfv76NY/Puay9UlZb+Ey7UU1Y+kJC4FuJcvs4c1+iDs9vR615xmUyv5SYZBAS/mtxMp4NGXMkiys5JnM2hDvhToThio54s5YXOjSxlHW9BwHYuvIM8D+L7Q//nMsvWQvAVDrHA48dCMPdB5b1sOnVmxqzozXyF9edXfL84QtX0ZWMzfr+Qjg0ZUNhjXHoic+dc7IdtTaR7eJnB89k84CD69hyoocmuvjF3mEAXrFpGd1x+4Ppe0+f4KozhljbszNcvzv2EuDUbLwnppOs7rWPt65cRqC1g0ef47IzlwNweCJNIl6aIGh5f1c9d69ufPn915Q8/9wvrc3u4jNtScM/vKI+35H3f+EET93zAm/6Ly+bc7l21BpYe0UYZm0gb2IlIclBCLEjuXBME+ORJxmGCs8soVy6/pVFrz8elsQCSkq1BSHkrZieKhW7sOT5VO4xgJJ9Cb53teCZWNHjua2i7ai3nEkylS+UdQzKj07k+lnW9SIxsaVKPRySvr0kJlOhnsqFpgcaOvU8+0D4yDOxkpDuau0dzWCmjrKe3Y/i/tejzN94biV5z2qs2HpSjnbUWi0s7km60qaY8CSpKI1FtaZEhWpNiQrVmhIlqjclKjpLazpJV1qOTrtSpjQP1ZoSFao1JSpUa0qUqN6UqOg0rekkXWk9pDVDf5RFiGpNiQrVmhIVqjUlSlRvSlR0mNYW9SR978QS/uezrwXgNeev5slzxgD49vee5dBnrX9w+ealTE48DMCH/uByXp68J6iWwGxZ/r+xfQ/Xv2w916wvlI668yPXAvDHX36UC8+ynrqnXjgRrvPRG8/jv37h4XruXsP4y5uO8+dfHeSdn9kOwMrVfaR8L+fJ0WmefNj67b7zV9dXvc0f/mwPAM88cpBb9qyvsLQp8VcpFsO9CFdV9KY3pZRZHZirz43zqref1rJekoMTp+OI0J+wZcTS+T72jNqRqz8ZoyvmcnzKXm3esCSJ59rvb5c7wmyOr89ve4F3XnMGAEsS94bH/DPvvIz3/rstx/Yrr9hILlc4QX7ilov54y8/Wu9dbAj//fVH+dA3lgHw7n95gIvOWwnYsljH/VJfd/7vh+ZVJvPeF0YBcB1h/cCSCku3n9aOj0zz+e88w4YNA2xY1QfAvfc/xyP/8ggA/3bucry03Scn7pD4kyu53vdhp2Inym8Um9clb2wJrHU9Ba392TVb+MbzRwFY29fFzmOFUmM3nj7E3Xtm32Yr8TsXPAfAHU+exeefOMhO38Pf35vguV12H7ZetIa3X7h2XtuNxRxWnruChx7eX2HJ9tNaORzxMIE/vOiHuWdiiO8Yz5Occ19zvs7i4pWU++yOvST0c8ecNPmikTHwfU/nH6nj3jSGrtgwANO5gXB/AvJFP/HnW0ou5yXDyVDFEmxtqLfiffJMPNzXhJPBMzHGc9avHnOmitbxijdw6jYDjZrS0rKBPz1v7kfwSvz+Mefy8L1WJzgWeS9JzrPzg6yXCvc763XRHTs571JySXcU4xRKw85N+2mtFhb1JF1pXyqfFBSlPqjWlKhQrSlRoVpTokT1pkRFJ2lNJ+lKy2E9J51zpUxpHqo1JSpUa0pUqNaUKFG9KVHRaVpb1JP03u44J0ZtGYVPf2MHO75nS8MkBrsQx8aq7PzqU1zxXhuK8rNnj3LFRTGmemxpntQs2/34my7gI995imuKorbfdfvPAVi3rr8QwnbhWm7++D3hMudfuLpOe9ZYhKv4+JvgbZ+8D4CTJybpW29Df154+ij9S+2Ref2Hv1u2hFs5jh0aB+CCKzZw6bkr+dKfz9W+wemgxBBzUS50vfh5cRh4O4a4V9v/INS//u23n9byBiayefaOTvPiEdv3sclDxF0bLnbk5BRXX7QmXD7mdLGyO+E/njp1gz5/ddP53PajZwF4/6sLr9/88Xs4bYsNE7/x9CE4fYir3vYlAPpOG2DdpsH67VwDEa7ir26yj//rFx7myAl7LFYsTXH3N58GID6Y4tJXfYaHfvKuqraZy9swv4efPMppV85dZqsdtbakL8mvXLWJqXSe8Ulbgs2NOZz1mzZ01nGEFx+0odcXXnsGuw+Msn/NOgA29KVn/YXx2g1L+fYL1qrxkmWF1+/ec4JlKavVy1ct4fJVS8LXxzI5Vvcm676PjSAYq245F7701GFOX2vPnyPjaV73io0AJFyHrzx3BIBf37Kiqu329CV5y5s24PlRtZ+ftf3201qACcLY/VJMQYmqnEmG+2Rww7tpnonTFZt9XOtyLwZs6HrSLRyTqdxjYZhu3NkaBrtP5opLxLb+T+RAa6lYoRybiIcxDk5RePZ4bgdQfdh7sA0A15lbS+2oN0e8sLQaQFyshkwsKKPm23gkGx5Hg4Prl2YrRxDmnTPbS173zDbARsg7cmVYktIz28Lw7na4OxxoLeYQhrvHnDQ5z47L3bGTCPmSUP9qcMmRiNnPIudVLvfXblorh4i8whjz00rLtWIZSKXjMYh4s/61GiJSyUSjtCztpTWlnZlba62mNx3X2pn205qIVJ8MQmkx2uc8qlprd9pPayLypyJyvv/aG0TkfuCT1Wyj9S8TKh2JS1uFs/xzszugLJw205rSxrSZ1nRca2PaUGuVMsoqLUwb6U211ua0odYeAP5ORPYALwc+YIz5ejUb0Em60nKImJa7IlaBS5vdAWVhtKHWlDalDbWm41qb0qZauwDaIOZXOYU205tqrY1pR60ZYzwR6QKOAWcYYw5Vu4FFPUkf7IrzVzedD8DvfGIb67dar3gyVdjti1+7mbf5ZYdSMYe9sdUMsrvitj9y/TnAOeHzvF+WaHBJwTP38R8/F7Z18tgk2374PFx7Vk37FCU9fX7pkkSM5561/kHHcUI/PxB67u/4s6vn3NbM939rzqUNbo2eExG5DvgE4AK3G2Num/G++O/fAEwCbzfG/GKBzWWgr2JptIVSja+nHf3o86Van9P8vOvN1VqldcvRHXO4aKiXi4Z6ecfdttTTzp+9iJuyrsrceIZk3OWWKzba5eMuoxn7e2RlamzObX/g1Wf6j84MX5ucyNDTVShP9MFvPIHEbCT02N5Rduz0y2L93tZKXW8ZMpk8E9P2c//yZ59kYtdJALo3DuClc7z2j+4E4Ad/+6tzbqc4/0hl2m9cG0zGQr/013ba0mg3/8qZxPxzgCPC4TfYHC4J12Eynef7jx8E4B1XzFbsz/L6TYEZvfB9jTlCb6IQZf/QEavX3oRr8zAMT9s3VvcvcJeix3GEVf1dAJyxvAfPr/F6cjpLd9zu6388eYhbzl1VcVsf+7WXVNlq+2nNGONdeumlhXJV+UdKSlUBJf7d4lJNYrzZa+b6BN70kn0omqcVyq3F8BaBE9TghPtR7E2fzD1Od6yyjsodr7laq0VvzdaaZ7YRm5HXIO/7rLNeKsyTMJlbSk/Mlm925tBbUFZtNkKPuniENZ/bFEdyJTkhgjwGYMvKVVOOLSh5COBWNFm11diWMcZ4AMaYaRF5dj4TdFBPutKiCN6sfxXXtV7KTwHXA+cCt4jIuTMWux7Y4v+9C/jHGrp7dg3rKk2mWVqrcl1lETGX1irpTcc1ZT60m9ZE5Jc1rK80GdWaEhVtND84W0R+6f89XvT88Wo1uKjvpCvtSR2yN24FdhpjdgGIyB3ATcCTRcvcBHzOGGOA7SIyICKrjTEHF9DeOVBF+IXScjRTa8DGKtZVFgk6rilR0aZaA9VbW1Kj3lRrStW02dh2TuVF5kbvpCstSM3ZG9cCe4ue7/Nfm+8y1fXWmD0LWU9pBZqqtbppUGkHas64reOaUiXtpzXVWztT03lUtabMg/aZHwRaK9LcOPBSYKhaDXbMnfSRk1P0+b4wxxFc31O5cc0SDo3buodLkjEuc7+K9Lx93tv/53e/HID3/vtDfMo3q+zZN8KqddY7l57KMTWa5pp3fQWAvjV9dPke0rHhab7zV9cvfOcaxIoVvQAc2D9KPGmP19DqXmJBHUlHSPXYmobv//rjPPXoQe78yLV1aVu8ObM3DonIQ0XPP2OM+Uzx6mXWmen8qWaZqhCRb11yySULWdXvyPzqfxd73yt50cu934h641EyW534hdJErdWswUza9v3Ca8/giW12zI/1d3HOpqX0xO3mJ7L50PtayStXjjs/ci23/C97zP9+SZLdO4+z+WX2fLXn6aNMPD8JwGXX/jMxf4wF6D19kO997IZ5txcFl16wmi/+7wfD5z2n21rvsb4EfWcvo3vA7set332aVcu6AXjXyzbU3G4FrcHcemvquDYyYeukj01m2egfE0dgebc9BxydzPD8/hHifhHgpcmN827z1esHuWffMADbD40ynrHHK+E6JFyHiWn7/CvPHWHQz5OQcB32j1iv+lvOWTnvNhtNLu8x4Pe12Me6vDvB8Sl7R6gr4fKp7bv5+pdtje7v//WNNbfbbloDPlCsN2McBC/0A9sGrYfclRw54/oNOiDXzLvNVOzCsK54Ov8Qxq/LLkWO9LyJMZ7bUeLpDqjG1x01wSQlOHZuUb+L78gF+w2lfuCa2l74ebT5WsPF8+zn7zqn1kHPeikApvID9CfOmHebjlwJWC963twf7kyxf9vglnrVAc/XZDW+7qgJvpcz68aLeCX7lc7bj30qv5SBxOl1abtd5geB1owxT/jRk78AHgI2i8hnjDF/W2kbHTNJV9oJA2bOK2LHjDFzZR7eR2mJjXXAgQUsUy2bFrie0nSaqrVEFesqi4aKWoO59abjmlIl7ac1Y8wTl16qBQXak5rOo6o1ZR601fxgkzHmCf/x7wHfN8b8roj0AT8F/rbSBjTcXWk9DODlZ/+rzIPAFhHZJCIJ4GbgzhnL3An8rlguB0YW6G8CqC3VpNI8mqu1atZVFguVtFZZbzquKdWhWlOipLbzqGpNqZ72mh8Ua+01wF0AxpgxqCLLHR10J71/MMWq9Tb0/MCeYfIT9tjt2jfCY08cBiCRdLn8bW+vqZ3jRyaY3jAAwPlnLeeee18AbDmz4jJkv/L+u+gftCE0Xl+y6lJmUbLMD109sH+UXNYPo/IM2bT9IjiO0OWXmDu0b4QNm5fyF9+2uRdufX0tSaoN5CuG6s2+tjE5EXkv8D1siYXPGmN2iMi7/fc/jf2y3ADsxJZY+L0aOrwXmHfMWCPDzou3PTPkvdpSZu2A4d4a96N5Wptt3fm0f9Y5tjzWxjVL6Ftiv6+pZIyY6/DsCVsWJZ03ReWuFkZQjtHzDG96wzmM+BahpSt6+HhRmbJXv+frALhJl/SxSV711jsA+Mnnb66p/XoTWHYA8uk8eHZ8y09lyU3m2LB5KQCJhMNyf5y+78AIr1xTS+mv9h7XfnjPLgDWnDbA4eMTAExM5+jpsueAn/10D+s3L+MTt8yndNOpHJ+yYfUre5LEHPs5PbzrOJ5n+JOrCqGmX3nuCGDDxpf12LDQe/YNc/W6gZrarzfpbB7P2EhJzxA+BujxbSiHh6c4cHQC49dn+z//7UH+4W0vq6HV9tOaiPxhaQiygyO5kiDToOxaEOoO9Qs7D5JRGdwwXLcvbvM+TeasDaE4/L7aUmZREvTbzHH/bWYG7On8I/Mst1a25QXrrRW0NpkbxBXbf9fESsr7TeX7Sbh2vFuVGKqh2YJ+gzD2fFGJwaRbuPnrmW2IeEWarPV3Tv3J+/sQY+qU98JwfS8e7mvOSzKS2QmwIMtAgbYa2/aKyB9i78y/FPgugIikgLlrlPp0zCRdaSNMVaF6FTZh7sK/alX02qeLHhvgPTU1UuAdwOE6bUuJkiZrrdy6yiJFxzUlKtpTa7fWaVtK1NSoN9WaUjXtNbYFWnst8BZjzLD/+uXAv1SzAQ13V1qTfG72v9ajq/IiSsvSXlpT2pm5tNZ6etNxrZ1pM60ZY97d7E4oNaBaU6KizbRmjLnJGHN38KIx5sfGmP9ZzQZ0kq60IMa/WjbLX+vx9WZ3QFkobac1pW2poLXW09vXm90BZaGo1pQoUa0pUdGeWhORryxkAx0T7v6593lc+RabZM9k89aHCJw8fwXnXrIGsB7rWvmPPyn4Rt7/9cdJ+p7t6anSXBXf+9gNXP/B7wCQz+URp/Wul9x0wSoAdh8YZfjYZNllkn4ZuamJLJs3DjKVripxw9wYoHL5mFaiduEsqNHZfeczl6tUqq1jaT+tlfDhaw8B8J/PDNLjfxfjrpDLe0zlgjIutZ+4bn9XoXTbbT96lu332XJvL926vmS5H33q1wB40//4AcOTWYzn0oq8/iyHHddaX9wD33gK1z92bnccN5Vl6VJbYmzNUC/9STuGj2Vq1En7aa1kXPvc+6ye3vo3JxnxS9SNnCiUNr3o0nXc98OdUKMn/de3rCi0+UubULevO8Fze4fLLvf3978QnrvXDPXU1HYjuGhtP+OZwnkxk7fHMZ33wseHjk9yaP8ol71ms10mW+N5tM21BpCKnSCT75nVX11c5mmhFJcfC8qS5YnhUnrsAu/5eK6QMqRcWbZmE3esPzhnknim/M97g3OKL71m2ktvp2itN36EqZzNQ1Lwjdvj1+WOMZUfsMvVOGMKSqllzQMAOOKR85KnLOfIlWS9B8LPyZEs0pRfmbMTlEM0ximpT178vcx6KbLG5nRJuqP1abh9tbag+nMdM0lX2gmDqdFzEjEtd/lOqZa205rStrSd1nRca1tUa0qUtJXeVGttTdtqbUG600m60nqY2rI3NoF5Z3ZXWoT205rSrrSf1nRca1faUGsiMlqccVtpI9pLb6q1dqYNtYa9o57yH+M/N8aYJZU20DGTdBk/ztmvsdEGe58/wfGfvghAdjxDv19eKO2HpNWrHNrHfq20PMeHv7mDl569HIDn9g4ztKoXsGWNvvDHr6qprUawvteG5Lzxiov4yn22lNzURCYswdY30BWWZtt8hi3x9KHXnlmfxlvPWzIrxhj30ksvXXCH61FeY+b6lcLfFwt12Zc20tpM0nk7xnfFHeKujaxyHMERYVkqKH1S2L+/2fY8f3zl5pra/MCrz4RXF77n337hePh40h9Dr7r6dE6OpfnI9efU1FajGOp6lrdfbUve9HUneH7nMQBiMZctZy5j02pbaq076XJgZBqAt56/uvaG20hrM8e1iZwtP5TqGWOZH1Y+MZrmyAH7u2P5yt4S29at332av7ju7Jr68LsXrCk8uWQ9H/6mDTf2PBPaO44cHaen157D33P5xpraawQXDj3Mtv32esd0zmNkuvAD8/n9wwCMjKcRR1jhl/t73ysXFBlZSptpDaBYb54plG+aiZAvCSStRxmx4tD3gKncY+SJFYW2F/TdauXXAFzHlsY0nl+KrYwlQMQreb328ms+baK32bSWM3YMifufdVAebebxms4/AtR23OLO1qLH9v+x7FOh3m3ptb6wLFwrai0oS5fJ9xBzbNnMIPQ969lxLE8stA0knamy37EF0WZaq4WOmaQr7YRpJ8+J0tao1pSoUK0pUaFaU6JE9aZERWdpTSfpSuthAK9tPCdKO6NaU6JCtaZEhWpNiRLVmxIVHaY1naQrLUhnXSlTmolqTYkK1ZoSFao1JUpUb0pUdJbWOmeS7jj88W9YX8fukWkevsZ6vt582QY+/d1nAPjELRfzrtt/zsBQd92bP5Hezf9zQ4aJnPUMbR5cw9tfbks+7DwZ522fvA+Af3vvK+ve9kIJ/L6vXPVDLnqTLcf2p/+eYd8LJwHYcv4KbrnG+lv3jkwzNpmpT8PGQL4OpdxamEaWRau03eD9VvOmN6VUXJtrzRVb2nH9ki5Sm21eCEeEJckYB8ftWHPj6UP8aK/9zibi9S2J9ouj46xf0uX3xbYNsGVZNw/tOcmntu8GWs8rLFzFWQPbAfij1yzlf6fs+Hbk5BSbVvdz1nLrud4zMkV/d3lf7Lxpc60FvtzLL1nLA4/Y0mjp6Rwr1ti8CLt3Hud7H7uBd3z6ZwBccP7KurZ/954TXHWBzQuQcB1G0lb7x5f38OKhMQD+7Ku/5ONvuqCu7daKcBWXrnwcgNHsar77rO13JpMn6X8fN6zqo687QV9Poj6NtrnWiglKsAle6G8VnNDfGniE68lk7nH/kYNLrlBiysRC7/Jk7vGW8woH53RXtuFIjky+UJIw2AchXzimUqc7km2uN2Mc3wduc2+IeOQ9+11MumMMda0FYCSzky63vvsZ6DcmDo5jfd6eiZM1KbKePfeM53bQGzuvru3WSqC1mHN/6NkvV97PFfs7RLW2MDpnkq60F+1TYkFpd1RrSlSo1pSoUK0pUaJ6U6Kig7Smk3Sl9WivEgtKO6NaU6JCtaZEhWpNiRLVmxIVHaY1naQrrUmDEkOIyFLgS8BGYDfwm8aYk2WW2w2MAXkgZ4y5tCEdUppPByUhUZqMak2JCtWaEiWqNyUqOkhrHTNJN92DbErsAuDcPV/h+l7r/fjsrv/KxFg6XO6Kl63jsWeO1q3dF8Zsjd1N7qOYsVG6umxt9GXdDog9/Kmhs0NfX0vivIZe+TEAsVgf/UttDcTNGwcZz9grWgeOjuM4Musm5oUxkGuY5+QDwA+NMbeJyAf85++fZdlrjDHHGtWRehO5n7sBBD6nyPalsVprODFnCoA1PRNk8t3+a0ImX3oSC2qlZ7L12df9E7Y29qoeD8ev5eqZGHm/zuuQO0Zq8xCPHhytS3uNIOZcDkA32zljnc2tMTGVY3lvgqRrPXYJ18GVthjXGk4qdgKAKzefEb6278h4+PjYMXtOTabseW1iun53Ow5MDnPeUIyka73nWS9Fzli9eyuX8KRfX3zngdbUW8G7/Dh93darfzLn0dNlvy8rl6bo703W7fvZ7loDWyvakSxpz/42MsYJP/9iPBM7xQdbC1nvARwpzUMReG5dSde1rUbhyJV4ZlvoA/ZMDIes/54H/uO60eZ6c500XcHjWI6TmdPojR8BCL3qYD3XhvrldfHMNuJOue1liJk0Oc/mP6ibn7sBuHIFee4HbN6I4pryMckgYnVRt+PW5lqbLx0zSVfajMZdKbsJuNp//G/APcw+SVc6gQ66Kqs0GdWaEhWqNSVKVG9KVHSQ1nSSrrQexkCuYZ6TlcaYg7YZc1BEVszWC+BuETHAPxljPtOoDilNpLFaU5QCDdaaWnmUEB3XlChRvSlR0WFa65hJunAV3a4N2Tar1uCttGVaXvzOGK+6fEO43MnRaf76N0fq1u4m97sATCdPIxPvCUNnevbejSxdA8CIu5Z1Kw7Wrc1GkDM2nPDZXx5iuR+aP5XO8+PHbL+ff/ood/zZ1fVrcO4rZUMi8lDR888UT6JF5AfAqjLrfXgePXiFMeaAP4n/vog8bYz5STUrRh6y3YHUtXxcG1+VDY5Dd3wHG5cMATCW7SeT90IrCtiwbYA/unIfsLnmdoMQd1eyYSieQ564H36fcCaIOYP1s8A0EBGPvoQ9FS4b6OLoeIbtvuXp+19+nB9/5tfr11hjtdZQK0+gtZXdu7j+bKu1n6TivOCHmA8N2XJPff02cPSDrz0InDnffShLTNLE3Ck/VNd+ZikZBiBv4pwxaPtzfLxOZUAbyNhk1v8/QyppdecZGOxJ8PpNy+rXUBuPa2D15sp2EmFZqlhYcjIIAwY7FiXd+tkc8iYetiN4GDuy+W0VQsU9U6fSjA0k5pe/yhaFIOdNPCxlV9cScm2sN+EqRGzIdtyZYkliPy72HJczhbKI9daawUU4NXTb4OJIjoTr98GrU2nGBlG8DzmTCJ+7kgvnPI5cWb8G21hr86VjJulKG1HZc3Jsrrs/xpjXzvaeiBwWkdX+XfTVwJFZtnHA//+IiHwN2ApUNUlX2ogO8zcpTaTxWlMrj2JpsNY0akMpQc+jSlR0mNacyosoSsQE4Syz/dXGncDb/MdvA74xcwER6RGRvuAxcC3wRK0NKy1IY7WmKAUqaa12vZVYeYBKVp6HReRdtTaqtCCN11oQtbEF+KH/fDauMcZcpBP0RYyeR5Wo6DCt6Z10pSUxpmHhLLcBXxaRdwAvAm8GEJE1wO3GmBuAlcDXxGZ1jgFfNMZ8t1EdUppLA7WmKCVUobWWtvIo7UODxzWN2lBK0POoEhWdpLXOmqSP2xIyY0NXc3zC+tCXDx7kXz75MwB+9zO/zh9fuZl6eDYDjruXAHBifIiB5DBLky8AIKu3YE4eAGBDz7dYt7KOHtsGMJxZD8DKdVle8XJ77I4NTxOP2WCMuvrRG5gYwhhzHHhNmdcPADf4j3cBFzakA0XU1VfdQdT1uC2SJCR5L4nrWD9uws3jiMvuo9bLyYalXL1uwF+yPscu8OVN5wfsfVmsXy8utg8Gh5gjdCfqV66mUYxnV7C2z/qol5weYzSdI7uqD6C+fvTqtNbyVh7POHTFbN6WzcsG2HfYlsWKu/bnxMd+rY4+V5+RzBJ643FijvXYBjkRwOZF6IrZH23JeGvrLWeSYR8dEU6M2v3pSsZ4+4Vr69dQ48e1SBKwGpzQH+5KNix/VlwWq8u9eP69n4PAxx2075lCHzzjhF70Vi6LBeCQw4jVWsxJ4/m+dCFPd6y+x2yxnEfBaivpTIR5D4KcCABL4mdSrzwbYL3mQR6XYoR8XUu9NRon9O+nSnI1OOLV14sODdVaNTYeEVkPfA57sdzDXkj/REM6hIa7K62KZ2b/U5R6olpTomIurdWuN7XyKAUqa21IRB4q+iuxPojID0TkiTJ/N82jF68wxrwUuB54j4i8qo57qLQSeh5VoqJxWqvGxpMD/sQYcw5wOXZcO7fWhmejs+6kK+3BIroqq7Q4qjUlKhqvNbXyKJZFErWhtAl6HlWiorFaq2jj8SOIgiiiMRF5ClgLPNmIDnXWJL3Phi7eu+sYLx45BMDJ0XR9Qxpn8OEv2hJl73z9AJ+4cz8rli8F4LqLX8K5y1+0fUhv5OToiYb1oR68ONYPwH/5jZcwkbWZFdcO9XDj6UP1b8ywKEosCFedUoZNQ9wXTkOO3SLRWn/iDPZP2BD0k9Mwmk7zzkvWN6y97z1vw8NfsSHJoQl7whzsStIVs6Uak844KXeY8emGdaFuTOSG6I5bDSTcODnP8NbzV9e/oQZrLSorz9LkRp4ftR+sI1kSfvj2+155ei2bnZMnjo6zujdJf9LqLuE6HBy3YcnLuxOMpK0GY25rl/ybzvXTnbQBjMsGUjj+caxrqDtEMa4FURu3MUfUBuD4P2SDqI1b59NI3NlK3tjSWMY4GD/4M+k2LgedwQnD6gWPmJPD+KHijoArNjw5Z5KzbqNVMGGIuweNPHaL4DzqyhUA5M39OJJDxIZtN1JrruTIevacWRz2HrwW0Oqh72bXLwDIbXw1Il6ou7iztQGNUVOJ5gpUa+MBQEQ2AhcDP69y+/OmsybpSpugV2WVqGiuv8lf7jrgE4CLveN5m//6x4EbgQzwPPB7xpjhhnRWiQAd15So0KgNJUp0bFOioqLW5owQqlPyVUSkF/gK8EfGmNH5rDsfdJKutB7GtP1VWaVNaKzWAn/TbSLyAf95SeiUiLjAp4DXAfuAB0XkTmPMk8D3gQ8aY3Ii8jHggzPXV9oIHdeUqGiw1lopAavSAujYpkRFjVqrh41HbJjFV4AvGGO+uuDOVIFO0pXWwwC5fLN7oXQCjdVaNWWKtgI7/R+0iMgd/npPGmPuLlpuO/AbjeqoEgE6rilRoVpToqSBeptHRNpuYAzIA7m57qYqbUxjx7ZqbDwC/DPwlDHmrxvVkYCOnKTfePoQNMJLXYZP/17Bk3Hp75SOGd/ZbSMupnOTfOU/bYLdcj7Sj3znKfv/9ec0qptz8q7bf87bX382ADnPsLrXerEe3T/SoBYXz1XZKD3oc7U10xtfablmeeer7Wc9W2yg1qrxN60F9hY93wdcVma538f+UJmVtT1L/P8X1Nd5ccu5hWixDb2nvr9nPMaekSm+v+1pAN5yzsqy2/nwN3fw0RvPa0gfK/Huf3kAgD9+40tI+WfCpDtNV6xRp8XFM65tXmK94Szp4tIVfQ1v741nLJ+1D994/mj4mmdmz+77jeePctPmU7cTBf/xpM2Bc8GqPs5fbv2lLwxPkss3Sg+LR2uBV5iI0g2U9dH6bee87aEvfi6m84/UvTTcfJjKPUbM6Qm99WDLYTWO5kakFXGNMeZYLY0FenMjsIHHnMvLTsKSrtWQYCej5cq0BeS87eG2mkHe3I/Z9AoA4jJFzks0+LvaUK1VY+N5BfA7wOMi8qi/3oeMMXc1okMdOUlXWhwDJqt3AZQIqKy1OZOQ1MHfVO50VjLTEJEPY8t+fKHKbSqtiI5rSlSo1pQoaazeqolIUzqFBmqtShvPfUR2yVAn6UorYgxkF8ddAKXFqay1Rpcp2gcUh8+sAw4UbeNtwBuA1xgzx21CpfXRcU2JCtWaEiWN1Vu1GbcNcLeIGOCf5pHRW2knOmxs00m60nIYwHg6H1EaT4O1VtHfBDwIbBGRTcB+4GbgtyDM+v5+4CpjzGSjOqlEg45rSlSo1pQoqUJvjY5IA3iFMeaAP4n/vog8bYz5yTzWV9qAThvbdJLeRK7fuAyA3/jLH826zIe/uYPpdHNLWwwOdTOeseElL1kOq7utCfWioTJm1HrgARkN1asngcd8Ls939H7wyjTcG99YrVX0N/mZ298LfA9bgu2zxpgd/vqfBJLYHxwA240x725UZ+vJab1J/vqbT9LdEy/7/mcf2QfAmuURGOhnYcUKO371JdJ0ucOArQG+prtBDeq41hBu2ryce/YNAzCSzp7yfvDe2FTzzqPrB2zd476Ew5KEDZTZvOF02NCgBlVrDSHmXM50/pFZ3896Ns+FVOFbbySOZBE8xPehh77+RlFZb42OSAtCkjHGHBGRr2GTsrbtJL3LvRjPbANmr5OeN/dDC2gtyNMg4pF0m661RYVO0pUWxHTUlTKlmTROa9X4m/zndwGnJB0xxpzRkI4pTULHNSUqVGtKlDRUb9Vk3O4BHGPMmP/4WuDWRnVIaSadNbY19xKMopTDYD0ns/3VgIi8WUR2iIgnIrNe2RWR60TkGRHZ6WcUVRYjDdSaopRQSWuqN6VeqNaUKGnsefQ24HUi8hzwOv85IrJGRIKL2yuB+0TkMeAB4NvGmO/W2rDSgnTYbza9k94C/OeHXn3Ka+//+uMAbFk/wDsu2RV1l0rwPMPmQRsD+syJaVY3Khw0wIDJN+xK2RPAm4B/mm0BEXGBT2FPCPuAB0XkTmPMk43qVFTMFj7eiqHukdBYrXU0n7ilfAmiT9y3i4s3LQXgyrWPYcvfRs9l59qycN2xEyWlihqGaq1hXL1uoOzrjx4bJ+OXOfvt858FVkfXqSKC0nB5Izx70paB21q+KmF9UK01jNlKq9lSWPa+V8KdiLBHp+JKDhEvLOHVcBqotyozbu8CLmxIB5qII1eWfT34veaZFLE5yrNFRRCOb4yL2+i85x02tukkXWk9jIHGlVh4CsD3+M7GVmCnP/AjIndgy4C0/SRdmUEDtaYoJajWlKhQrSlRonpToqLDtKaTdKUlabLnZC2wt+j5PuCyJvVFaTCd5G9SmotqTYkK1ZoSJao3JSo6SWs6SVdaD2MgM2f46YLLeRhjypXBmkm52+ydMyp0EpW1pij1QbWmRIVqTYkS1ZsSFR2mNZ2ktygf+7WXFD1b37R+AFx98Vpy/pWr7nj5UhB1xVS8Urbgch5Vso/Sg74OOFDjNluahpc6a1Uqa02pM+975elFz5qnu8tWTwPgShpXIijPpVqLnIuGemEoeNY8rZ3Wb0uwZfIek1GEaqrWIifmXN7sLoTYslgR/FYLUL1FSvB7Ld4Cqb+NcTCmqCNReNI7SGs6SVdaDmPANNdz8iCwRUQ2AfuBm4HfamaHlMbQAlpTOoRGa01E3gx8BDgH2GqMeWiW5a4DPgG4wO3GmNsa1imlKei4pkSJ6k2Jik7Tmk7SldbDmIaVUhCRNwJ/DywHvi0ijxpjfkVE1mB/sN5gjMmJyHuB72F/yH7WGLOjIR1SmksDtaYoJTReax1duUIpQsc1JUpUb0pUdJjWdJKuVMQzhp++cByAp144wdY3XdDwNhtYzuNrwNfKvB6W8/Cf3wXcNXM5ZfHRSeU8lAKTOVsGLmeS7BqOA3BFgyt0NVJrWrmidZnO2R+VU7k8O/YNA7OXjasXOq51uSTAmAAAC1hJREFULkGou2fsuOY0OgQZ1VsnI2LHt6hK/nWS1nSSrrQeHVZiQWkiqjUlKlpDa1q5ohNoDa0pnYLqTYmKDtNaC6QdUJQZ+IkhZvtTlLqhWlOiooLWfL0NichDRX/vKt6EiPxARJ4o83dTlb3QyhWdQHVaWzAi8mYR2SEinojMmsRVRK4TkWdEZKeIfKCmRpXWRc+jSlR0mNb0TrrSehgwHeQ5UZqIak2Jiuq0ppUrlNpp/Lim+Q+UAnoeVaKiw7Smk3SlIjeePlR4cvG6SNrsJM+JUqAZpeBUa53Jht6U/yjFqtSci9aNFtCaVq5oAmcNFAR20VBvJG1q/oPOxZUr7IMIvOgBLTC2KU3AkSsjb7OTtKaTdKXlMMaQ76ArZUrzUK0pUdForWnlCiWgRcY1zX/QIbSI3pQOoNO0ppN0pfXwPSeK0nBUa0pUNFhrWrlCCalOa0Mi8lDR888YYz4TPBGRHwCryqz3YWPMN6roheY/6BT0PKpERYdpTSfpSsthjMHroOyNSvNQrSlRoVpToqJKrWn+A6Uu6NimREUjtSYiS4EvARuB3cBvGmNOzrKsCzwE7DfGvKEhHUIn6coC8Mw2ABxyINc0pI1OulKmzI7h3vBxo/zqqjUlxPzY/q/jmtJgPLPNnkOhIXprAa1p/oNWwfshiF/MScc2pYFM5R4j5Z6wT9pPax8AfmiMuc2vRvEB4P2zLPs+4ClgSaM6A1qCTWlFDHhZb9Y/RakbqjUlKipoTfWm1I0Ga01E3igi+4CXY/MffM9/fY2I3AVgjMkBQf6Dp4Ava/6DRYqeR5WoaKzWbgL+zX/8b8CvlVtIRNYBrwdur7XBSuiddKXl6LTEEErzUK0pUaFaU6Ki0VrT/AdKMTq2KVHRYK2tNMYc9Ns5KCIrZlnub4E/B/oa1ZEAnaSXoTjENqBcqG255RZKM0pPLQTDvYRVV6bGoBGlizosMcRMHc2mhXrprZ20FkEjqrUqllsIYryGhbvVnSDMHTDiNKZykWqtquVqoR3GtmB/HTw8/ydY3UMaVWtVLVcL7aQ1EQfjh7vr2FYbqrXZMdxLyvWarbUFJ8SspnkReQNwxBjzsIhcXc06taCTdKXlMH44i6I0GtWaEhWqNSUqVGtKlKjelKioQmsLTogpIodFZLV/F301cKTMYq8AflVEbgC6gCUi8nljzFur3IV5oZ50pQUxGM+b9a8WROTNIrJDRDwRmfWLLCK7ReRxEXl0xlU5ZVHROK0pSilza031ptQP1ZoSJXoeVaKioVq7E3ib//htwCmlJo0xHzTGrDPGbMQmw/xRoybooHfSlVaksVdlnwDeBPxTFcteY4w51qiOKC2A3gFQokK1pkSFak2JEtWbEhWN1dptwJdF5B3Ai8CbwSbEBG43xtww18qNYJFP0sfq5gtptD92ru23gh+lbP9Sv1qf7cxcxoDXIH+TMeYpAJF6u2VUa/WkWt/XfLZRdpkGaq1xtIfWrC9t7u23gt4M9xbKE6FaK6U9tFZNGy2jteCxODhcWdM2Zl2mLbUG9dKbau1UrTVqXIN21ZtqrV4sFq0ZY44DrynzeklCzKLX7wHuaUhnfDTcXWk9jGmFch4GuFtEHhaRd0XVqBIxDdSaiCwVke+LyHP+/4OzLHediDwjIjv92pwz3/9TETEiMlRTh5TmUkFreidKqRuqNSVKWuM3m9IJdJjWFvmddKVdMfnGZG80xpziMZmFVxhjDvglGL4vIk8bY35S5bpKG1FBa7XwAeCHxpjb/Mn3B4D3Fy8gIi7wKeB1wD7gQRG50xjzpP/+ev+9FxvVSSU6Gqg1RSlBtaZEiepNiYpO0ppO0hchkZSuamAfjAEv15jsjdX3wRzw/z8iIl8DtgI6SZ9BB2itFm4CrvYf/xs2LOr9M5bZCuw0xuwCEJE7/PWe9N//G2w9zmovLi1e/DJpRpoXANbCWlPqiI5rykIQ4x/zebjpwjJpxmva2Far3lVv7YOObe2FTtKV1sMY8k0MWxGRHsAxxoz5j68Fbm1ah5TG0VitrTTGHLTNmIN+VMZM1gJ7i57vAy4DEJFfBfYbYx6rfw4FJXKaPK4pHYRqTYkS1ZsSFR2mNZ2kKy2HARpVtUNE3gj8PbAc+LaIPGqM+ZUZ2RtXAl/zJ0Yx4IvGmO82pkdKM6lCawu2VlTZhXKzbyMi3f42rq1yO0qL08hxTVGKUa0pUaJ6U6Ki07Smk3Sl9TCQyzVo08Z8DfhamdfD7I1+6PGFjemB0lJU1tqCrRUiclhEVvt30VcDR8ostg9YX/R8HXAA2AxsAoK76OuAX4jI1ksuOXPODistSgPHNUUpQbWmREkD9SYibwY+ApwDbDXGPDTLctcBnwBc7A2X2xrTI6WpdNjYppP0NqAVPCTlaFS/DNB21TwWCaq1unIn8DZs7c23Ud5X/iCwRUQ2AfuBm4HfMsbsAMLweBHZDVxqjDl26aVnNazDUTOvzzUiv2abam0+P2Z3A2NAHsjNdRFqMdGKY1u7ak0pT8FTPv/PtdF+9IaW26ShensCeBPwT7MtUCkB62Kmk8Y1u+3OGtt0kq60HKbDrpQpzaPBWrsN+LKIvAObnf3NAMXWCmNMTkTeC3wPewfgs/4EXVlkRDCuVfwxW8Q1xphjDe2N0jT0HKpESSP1Zox5CqBCXpZKCViVRUKnjW06SVdaD9NZnhOliTRQa8aY48BryrweWiv853cBd1XY1sZ690+JmAaPa1X+mFU6AT2HKlFSWW9z5napA7MmYFUWGR02tukkXWk5DJ11pUxpHqo1JSpaSGsGuFtEDPBPdf6xrLQALaQ1pQOoQm9z5naZKwGrMaaa8qNlE7BWsZ7SZnTa2KaTdKX16LArZUoTUa0pUVGd1hZcTaDKH7MArzDGHPBLAn5fRJ42xvykynWVdkDHNSVKatTbXAlYq2S2BKzKYqPDxjadpCstR6d5TpTmoVpToqJKrS24mkD1/TAH/P+PiMjXsH5OnaQvInRcU6KkBfRWNgFrU3ukNIQW0FqkRJMuV1HmiTFm1j9FqSeqNSUq5tJaFHoTkR4R6QseA9diE84pi4xGak1E3iwiO0TEE5G5wph3i8jjIvLojAgRZZHRQK29UUT2AS8Hvi0i3/NfXyMid/lt54AgAetTwJc1AevipZN+s+mddKXl6LQrZUrzUK0pUdForYnIG4G/B5Zjf8w+aoz5leJqAsBK4Gt+crkY8EVjzHcb1yulGWglASVKGpzd/WvA18q8Pu8ErEr702m/2XSSrrQcnZYYQmkeqjUlKhqttWp+zPolii5sXC+UViACrWklASVEz6NKVHSa1nSSrrQeHZYYQmkiqjUlKlRrSlS0jta0kkAn0Dp6UxY7HaY1naQrLUenhbMozUO1pkSFak2Jiiq1ppUElLqgY5sSFZ2mNZ2kKy2Jt/jyPygtimpNiQrVmhIVVWhNKwkodUPHNiUqOklrOklXWo5Ou1KmNA/VmhIVqjUlKlpBa371AMcYM1ZUSeDW5vZKaQStoDelM+g0rekkXWk5DJ3lOVGah2pNiQrVmhIVjdaaVhJQitGxTYmKTtOaLMa6cgEichTY0+x+KGU5zRizvNwbIvJdYGiOdY8ZY65rTLcWhmqt5SmrN9Wa0gAWqjVoMb2p1lqeRaM1UL21OPqbTYmKRaW1WljUk3RFURRFURRFURRFaSecZndAURRFURRFURRFURSLTtIVRVEURVEURVEUpUXQSbqiKIqiKIqiKIqitAg6SVcURVEURVEURVGUFkEn6YqiKIqiKIqiKIrSIugkXVEURVEURVEURVFaBJ2kK4qiKIqiKIqiKEqLoJN0RVEURVEURVEURWkRdJKuKIqiKIqiKIqiKC3C/w8coJnJXi/1IwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 1368x504 with 24 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import time\n",
+    "rel=0\n",
+    "v=2\n",
+    "if doanalysis ==1:\n",
+    "    conv=1\n",
+    "    fig = plt.figure()\n",
+    "    plt.rcParams['figure.figsize'] = [19,7]\n",
+    "    fig.subplots_adjust(hspace=0.3, wspace=0.2)\n",
+    "    vs=range(1,ncases+1)\n",
+    "    ncol=7\n",
+    "    nrow=2\n",
+    "    count=1\n",
+    "    var_0=dsc.FSR.isel(ens=0)\n",
+    "    defm=np.multiply(np.mean(var_0,0),conv)\n",
+    "    for i in vs:\n",
+    "        index=((count+1) % 2)*ncol + ((count+1) // 2)\n",
+    "        print(index,count,(count+1) % 2,((count+1) // 2),(((count+1) // 2))-1)\n",
+    "        ax = fig.add_subplot(nrow, ncol, index)\n",
     "\n",
-    "print(fnmfig)\n",
-    "plt.savefig(fnmfig)"
+    "        #ds0=dse1.isel(realization=i)\n",
+    "        var_i=dsc.FSR.isel(ens=i)\n",
+    "        mod=np.multiply(np.mean(var_i,0),conv)\n",
+    "        \n",
+    "        delt=mod-defm\n",
+    "        plt1=delt.plot(cmap='RdYlBu')\n",
+    "                    \n",
+    "        ax.get_xaxis().set_visible(False)\n",
+    "        ax.get_yaxis().set_visible(False)\n",
+    "        if((count+1) % 2==0):\n",
+    "            ex=' +'\n",
+    "        else:\n",
+    "            ex=' -'\n",
+    "        ax.set_title(str(parameter_list[(((count+1) // 2))-1]+ex))\n",
+    "        count=count+1\n",
+    "        fig.canvas.draw()\n",
+    "        time.sleep(1) \n",
+    "          "
    ]
   },
   {
@@ -1137,9 +2984,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Pangeo (2019.09.12 - py3.7)",
+   "display_name": "NPL 2022b",
    "language": "python",
-   "name": "pangeo-2019.09.12"
+   "name": "npl-2022b"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1151,7 +2998,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR is a Jupyter notebook that : 
#### - Makes parameter file ensembles
#### - Creates, configures and submits CLM/FATES ensembles with these parameter files.
#### - Analyses the output 

I realize that this capability duplicates some of the scripting that @adrifoster and Daniel have been working on from/for the PPE. I'm adding it here for the sake of completeness (so people can use it if they want). My personal motivation for making/using it (other than the Joy of Jupyter) is to collect all of the filename architecture under one umbrella, the organization of which, for me, is always the biggest timesink in all of this.  

Currently, it works on cheyenne but I think is pretty configurable.  Both the scope of the ensemble (it's currently just one at a time) and the analysis (just one plotting script) are slimmed down to make this script more palatable...  I have others that are bigger and uglier and do more stuff ;) 

The script has the capacity to track multiple sets of ensembles via iterated the ensemble name and number. 

At present, it is a mixture of BASH and python cells (yeah, I know). I'm gradually working to erase the BASH files where I can. 

#### n.b. that this is the FIRST CODE I have written since February. 🎈 🥳  💃 

 